### PR TITLE
Show all weights in icon sheet

### DIFF
--- a/generate_icons_md.py
+++ b/generate_icons_md.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 import os
+from collections import defaultdict
 
 
 def to_camel_case(snake_str):
@@ -20,24 +21,30 @@ with open("icons.md", "w") as icons_md:
         if asset_dir == ".DS_Store":
             continue
 
-        largest_svg_icon_path = None
+        largest_svg_icon_path_by_weight = {}
 
-        ios_references = []
-        android_references = []
+        ios_references_by_weight = defaultdict(list)
+        android_references_by_weight = defaultdict(list)
+        weights = set()
 
         pdf_dir = os.path.join("assets", asset_dir, "PDF")
         for filename in sorted(os.listdir(pdf_dir)):
-            components = "_".join(filename.replace(".pdf", "").split("_")[2:])
-            ios_references.append(f'`{to_camel_case(components)}`')
+            components = filename.replace(".pdf", "").split("_")[2:]
+            weight = components[-1]
+            weights.add(weight)
+            ios_references_by_weight[weight].append(f'`{to_camel_case("_".join(components))}`')
 
         svg_dir = os.path.join("assets", asset_dir, "SVG")
         for filename in sorted(os.listdir(svg_dir)):
-            android_references.append(f'`{filename.replace(".svg", "")}`')
-            largest_svg_icon_path = filename
+            weight = filename.split("_")[-1].replace(".svg", "")
+            weights.add(weight)
+            android_references_by_weight[weight].append(f'`{filename.replace(".svg", "")}`')
+            largest_svg_icon_path_by_weight[weight] = filename
 
-        icons_md.write(
-            f"|{asset_dir}"
-            f'|<img src="{svg_dir}/{largest_svg_icon_path}?raw=true" width="24" height="24">'
-            f'|{"<br />".join(ios_references)}'
-            f'|{"<br />".join(android_references)}|\n'
-        )
+        for weight in sorted(weights, reverse=True):
+            icons_md.write(
+                f"|{asset_dir} ({weight})"
+                f'|<img src="{svg_dir}/{largest_svg_icon_path_by_weight[weight]}?raw=true" width="24" height="24">'
+                f'|{"<br />".join(ios_references_by_weight[weight])}'
+                f'|{"<br />".join(android_references_by_weight[weight])}|\n'
+            )

--- a/generate_icons_md.py
+++ b/generate_icons_md.py
@@ -43,7 +43,7 @@ with open("icons.md", "w") as icons_md:
 
         for weight in sorted(weights, reverse=True):
             icons_md.write(
-                f"|{asset_dir} ({weight})"
+                f"|{asset_dir} ({weight.title()})"
                 f'|<img src="{svg_dir}/{largest_svg_icon_path_by_weight[weight]}?raw=true" width="24" height="24">'
                 f'|{"<br />".join(ios_references_by_weight[weight])}'
                 f'|{"<br />".join(android_references_by_weight[weight])}|\n'


### PR DESCRIPTION
Currently, we group all icons by their name, this change now groups them by weight so you can visualize all of the icons.

**Before**
<img width="1055" alt="Screen Shot 2020-07-29 at 5 58 59 PM" src="https://user-images.githubusercontent.com/70799/88868598-77639980-d1c5-11ea-8e6d-3b5af4e37925.png">

**After**
<img width="1078" alt="Screen Shot 2020-07-29 at 5 59 43 PM" src="https://user-images.githubusercontent.com/70799/88868600-7af72080-d1c5-11ea-9b75-2452c64757b1.png">
