### PR TITLE
Fix link to example in flutter/README.md

### DIFF
--- a/flutter/README.md
+++ b/flutter/README.md
@@ -21,7 +21,7 @@ class MyFlutterWidget extends StatelessWidget {
 ```
 ## Example
 
-View the Flutter app in the [example](example) directory to see all the available `FluentUISystemIcons`.
+View the Flutter app in the [example](https://github.com/microsoft/fluentui-system-icons/tree/master/flutter/example) directory to see all the available `FluentUISystemIcons`.
 
 ## FAQs
 


### PR DESCRIPTION
The relative link to `example` on https://pub.dev/packages/fluentui_system_icons leads on Github to 404, because on pub.dev the link leads to `.../example` though it should link to `.../flutter/example`

I solved it in my PR by replacing it with the absolute link `https://github.com/microsoft/fluentui-system-icons/tree/master/flutter/example` - alternatively linking to `/flutter/example` instead of `example` might work too (untested)