### PR TITLE
Flutter SDK should refer to dart version

### DIFF
--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.1.76
 homepage: https://github.com/microsoft/fluentui-system-icons/tree/master
 
 environment:
-  sdk: ">=1.1.76 <1.1.76"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Fixes https://github.com/microsoft/fluentui-system-icons/issues/117
The environment version is wrong:

This should reflect the versions of dart that are allowed to use this package. Now 1.1.76 could not be used in any version of flutter. (Notice this version has not been published in pub.dev yet). 

This `sdk: ">=2.7.0 <3.0.0"` value is used now by default when creating any project with `flutter create .`


Versions used from popular packages: 
Bloc:
```yaml
environment:
  sdk: ">=2.6.0 <3.0.0"
```
Provider:
```yaml
environment:
  sdk: '>=2.7.0 <3.0.0'
  flutter: '>= 1.16.0'
```