### PR TITLE
Github action replaces dart sdk version constraints

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,7 +97,7 @@ jobs:
         rm flutter/CHANGELOG.md.bk
 
     # Needs to be "-E" instead of "-r" on macOS
-    # If changed, caution to not replace dart sdk version constraints  
+    # If changed, caution not to replace dart sdk version constraints  
     - name: Replace version number in flutter/pubspec.yaml
       run: |
         sed -i.bk -r "s/version: [0-9]+\.[0-9]+\.[0-9]+/version: $NEW_VERSION/g" flutter/pubspec.yaml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,9 +97,10 @@ jobs:
         rm flutter/CHANGELOG.md.bk
 
     # Needs to be "-E" instead of "-r" on macOS
+    # If changed, caution to not replace dart sdk version constraints  
     - name: Replace version number in flutter/pubspec.yaml
       run: |
-        sed -i.bk -r "s/[0-9]+\.[0-9]+\.[0-9]+/$NEW_VERSION/g" flutter/pubspec.yaml
+        sed -i.bk -r "s/version: [0-9]+\.[0-9]+\.[0-9]+/version: $NEW_VERSION/g" flutter/pubspec.yaml
         rm flutter/pubspec.yaml.bk
 
     # Needs to be "-E" instead of "-r" on macOS

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.1.77
 homepage: https://github.com/microsoft/fluentui-system-icons/tree/master
 
 environment:
-  sdk: ">=1.1.77 <1.1.77"
+  sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Current github publish action automatically overrides dart sdk version constraints, this should only replace the package version.

Related issue  https://github.com/microsoft/fluentui-system-icons/issues/117#issuecomment-723195724
