### PR TITLE
Use placeholder strings for build Flutter action tokens

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -100,13 +100,13 @@ jobs:
       run: npm run deploy:flutter
       working-directory: importer
 
-      # Build Flutter library
-      # The name should be same as the package name on pub.dev.
+    # Build Flutter library
+    # The name should be same as the package name on pub.dev.
     - name: 'fluentui_system_icons'
       uses: k-paxian/dart-package-publisher@master
       with:
         relativePath: 'flutter'
         skipTests: true
         dryRunOnly: true
-        accessToken: ${{ secrets.FLUTTER_OAUTH_ACCESS_TOKEN }}
-        refreshToken: ${{ secrets.FLUTTER_OAUTH_REFRESH_TOKEN }}
+        accessToken: "random"
+        refreshToken: "random"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,7 +101,7 @@ jobs:
       working-directory: importer
 
       # Build Flutter library
-      # The name should be same as the package name on pub.dev
+      # The name should be same as the package name on pub.dev.
     - name: 'fluentui_system_icons'
       uses: k-paxian/dart-package-publisher@master
       with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,12 +101,13 @@ jobs:
       working-directory: importer
 
     # Build Flutter library
-    # The name should be same as the package name on pub.dev.
+    # The name should be same as the package name on pub.dev
+    # Tokens are placeholder strings in order for the action to run on forked repos.
     - name: 'fluentui_system_icons'
       uses: k-paxian/dart-package-publisher@master
       with:
         relativePath: 'flutter'
         skipTests: true
         dryRunOnly: true
-        accessToken: "random"
-        refreshToken: "random"
+        accessToken: "placeholder"
+        refreshToken: "placeholder"


### PR DESCRIPTION
Since Github secrets on forked repo are not setup the same as our repo, therefore Flutter access and refresh tokens are not available when the pr build script is run on a forked repo. 

This change replaces the tokens required by the build Flutter command to placeholder strings, which will let the dry run pass.