### PR TITLE
Change publish script to use Environment Files

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,40 +26,6 @@ jobs:
           exit(1)
         """
 
-  test-env-file:
-    name: Test environment file
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Update/Set the version variable
-      run: |
-        grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec | python3 -c """
-        import sys
-        import os
-        current_version = sys.stdin.read().strip().split(\"'\")[1]
-        major, minor, patch = current_version.split('.')
-        os.system(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> \$GITHUB_ENV')
-        """
-
-        echo "TEST_VERSION=HELLO" >> $GITHUB_ENV
-        echo "environment=development" >> $GITHUB_ENV
-
-    - name: Echo the variable
-      run: |
-        echo $NEW_VERSION
-        echo "${Env:NEW_VERSION}"
-        echo "$GITHUB_ACTOR"
-        echo "$environment"
-        echo "${Env:environment}"
-
-    - name: Replace version number in Podspec
-      run: |
-        sed -i.bk -r "s/[0-9]+\.[0-9]+\.[0-9]+/$NEW_VERSION/g" ios/FluentIcons.podspec
-        rm ios/FluentIcons.podspec.bk
-        cat ios/FluentIcons.podspec
-
   build-ios:
     name: Build iOS library
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,9 +40,7 @@ jobs:
         import os
         current_version = sys.stdin.read().strip().split(\"'\")[1]
         major, minor, patch = current_version.split('.')
-        new_version = f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> \$GITHUB_ENV'
-        print(new_version)
-        os.system(new_version)
+        os.system(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> \$GITHUB_ENV')
         """
 
         echo "TEST_VERSION=HELLO" >> $GITHUB_ENV

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,22 @@ jobs:
           exit(1)
         """
 
+  test-env-file:
+    name: Test environment file
+    runs-on: ubuntu-latest
+
+    - run: |
+      grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec |
+          python3 -c """
+      import sys
+      current_version = sys.stdin.read().strip().split(\"'\")[1]
+      major, minor, patch = current_version.split('.')
+      print(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> $GITHUB_ENV')
+      """
+
+    - run: |
+      echo $NEW_VERSION
+
   build-ios:
     name: Build iOS library
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,6 +45,7 @@ jobs:
     - name: Echo the variable
       run: |
         echo $NEW_VERSION
+        echo $GITHUB_ACTOR
 
   build-ios:
     name: Build iOS library

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,8 +26,8 @@ jobs:
           exit(1)
         """
 
-  update-env-file:
-    name: Update environment file
+  test-env-file:
+    name: Test environment file
     runs-on: ubuntu-latest
 
     steps:
@@ -42,15 +42,16 @@ jobs:
         print(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> $GITHUB_ENV')
         """
 
-  echo-env-value:
-    name: Test environment file
-    runs-on: ubuntu-latest
-
-    steps:
     - name: Echo the variable
       run: |
-        echo "$NEW_VERSION"
+        echo "${Env:NEW_VERSION}"
         echo "$GITHUB_ACTOR"
+
+    - name: Replace version number in Podspec
+      run: |
+        sed -i.bk -r "s/[0-9]+\.[0-9]+\.[0-9]+/$NEW_VERSION/g" ios/FluentIcons.podspec
+        rm ios/FluentIcons.podspec.bk
+        cat ios/FluentIcons.podspec
 
   build-ios:
     name: Build iOS library

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    name: Update/Set the version variable
+    - name: Update/Set the version variable
     - run: |
       grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec |
           python3 -c """
@@ -40,7 +40,7 @@ jobs:
       print(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> $GITHUB_ENV')
       """
 
-    name: Echo the variable
+    - name: Echo the variable
     - run: |
       echo $NEW_VERSION
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,10 +37,9 @@ jobs:
       run: |
         grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec | python3 -c """
         import sys
-        import os
         current_version = sys.stdin.read().strip().split(\"'\")[1]
         major, minor, patch = current_version.split('.')
-        os.environ("NEW_VERSION") = "{major}.{minor}.{int(patch) + 1}"
+        print(f'\"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> \$GITHUB_ENV')
         """
         echo "TEST_VERSION=HELLO" >> $GITHUB_ENV
         echo "environment=development" >> $GITHUB_ENV

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,12 +35,13 @@ jobs:
 
     - name: Update/Set the version variable
       run: |
-        grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec | echo $(python3 -c """
+        grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec | python3 -c """
         import sys
+        import os
         current_version = sys.stdin.read().strip().split(\"'\")[1]
         major, minor, patch = current_version.split('.')
-        print(f'\"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> \$GITHUB_ENV')
-        """)
+        os.system('echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> \$GITHUB_ENV')
+        """
         echo "TEST_VERSION=HELLO" >> $GITHUB_ENV
         echo "environment=development" >> $GITHUB_ENV
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,8 +26,8 @@ jobs:
           exit(1)
         """
 
-  test-env-file:
-    name: Test environment file
+  update-env-file:
+    name: Update environment file
     runs-on: ubuntu-latest
 
     steps:
@@ -42,6 +42,11 @@ jobs:
         print(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> $GITHUB_ENV')
         """
 
+  echo-env-value:
+    name: Test environment file
+    runs-on: ubuntu-latest
+
+    steps:
     - name: Echo the variable
       run: |
         echo "$NEW_VERSION"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,8 +44,8 @@ jobs:
 
     - name: Echo the variable
       run: |
-        echo $NEW_VERSION
-        echo $GITHUB_ACTOR
+        echo "$NEW_VERSION"
+        echo "$GITHUB_ACTOR"
 
   build-ios:
     name: Build iOS library

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,8 +40,11 @@ jobs:
         import os
         current_version = sys.stdin.read().strip().split(\"'\")[1]
         major, minor, patch = current_version.split('.')
-        os.system('echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> \$GITHUB_ENV')
+        new_version = f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> \$GITHUB_ENV'
+        print(new_version)
+        os.system(new_version)
         """
+
         echo "TEST_VERSION=HELLO" >> $GITHUB_ENV
         echo "environment=development" >> $GITHUB_ENV
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,12 +35,12 @@ jobs:
 
     - name: Update/Set the version variable
       run: |
-        grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec | python3 -c """
+        grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec | echo $(python3 -c """
         import sys
         current_version = sys.stdin.read().strip().split(\"'\")[1]
         major, minor, patch = current_version.split('.')
         print(f'\"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> \$GITHUB_ENV')
-        """
+        """)
         echo "TEST_VERSION=HELLO" >> $GITHUB_ENV
         echo "environment=development" >> $GITHUB_ENV
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,14 +39,14 @@ jobs:
         import sys
         current_version = sys.stdin.read().strip().split(\"'\")[1]
         major, minor, patch = current_version.split('.')
-        print(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> $GITHUB_ENV')
+        print(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> \$GITHUB_ENV')
         """
         echo "TEST_VERSION=HELLO" >> $GITHUB_ENV
         echo "environment=development" >> $GITHUB_ENV
-        echo "NEW_TEST_VERSION=1.1.85" >> /home/runner/work/_temp/_runner_file_commands/set_env_ee549562-0ef6-4215-a454-01b56d6608a3
 
     - name: Echo the variable
       run: |
+        echo $NEW_VERSION
         echo "${Env:NEW_VERSION}"
         echo "$GITHUB_ACTOR"
         echo "$environment"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,6 +30,7 @@ jobs:
     name: Test environment file
     runs-on: ubuntu-latest
 
+    steps:
     - run: |
       grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec |
           python3 -c """

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v2
+
     - name: Update/Set the version variable
       run: |
         grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec | python3 -c """

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,11 +41,16 @@ jobs:
         major, minor, patch = current_version.split('.')
         print(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> $GITHUB_ENV')
         """
+        echo "TEST_VERSION=HELLO" >> $GITHUB_ENV
+        echo "environment=development" >> $GITHUB_ENV
+        echo "NEW_TEST_VERSION=1.1.85" >> /home/runner/work/_temp/_runner_file_commands/set_env_ee549562-0ef6-4215-a454-01b56d6608a3
 
     - name: Echo the variable
       run: |
         echo "${Env:NEW_VERSION}"
         echo "$GITHUB_ACTOR"
+        echo "$environment"
+        echo "${Env:environment}"
 
     - name: Replace version number in Podspec
       run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,9 +37,10 @@ jobs:
       run: |
         grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec | python3 -c """
         import sys
+        import os
         current_version = sys.stdin.read().strip().split(\"'\")[1]
         major, minor, patch = current_version.split('.')
-        print(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> \$GITHUB_ENV')
+        os.environ("NEW_VERSION") = "{major}.{minor}.{int(patch) + 1}"
         """
         echo "TEST_VERSION=HELLO" >> $GITHUB_ENV
         echo "environment=development" >> $GITHUB_ENV

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,6 +25,7 @@ jobs:
           print(invalid_asset_dirs)
           exit(1)
         """
+
   test-env-file:
     name: Test environment file
     runs-on: ubuntu-latest
@@ -32,8 +33,7 @@ jobs:
     steps:
     - name: Update/Set the version variable
     - run: |
-      grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec |
-          python3 -c """
+      grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec | python3 -c """
       import sys
       current_version = sys.stdin.read().strip().split(\"'\")[1]
       major, minor, patch = current_version.split('.')

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,17 +32,17 @@ jobs:
 
     steps:
     - name: Update/Set the version variable
-    - run: |
-      grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec | python3 -c """
-      import sys
-      current_version = sys.stdin.read().strip().split(\"'\")[1]
-      major, minor, patch = current_version.split('.')
-      print(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> $GITHUB_ENV')
-      """
+      run: |
+        grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec | python3 -c """
+        import sys
+        current_version = sys.stdin.read().strip().split(\"'\")[1]
+        major, minor, patch = current_version.split('.')
+        print(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> $GITHUB_ENV')
+        """
 
     - name: Echo the variable
-    - run: |
-      echo $NEW_VERSION
+      run: |
+        echo $NEW_VERSION
 
   build-ios:
     name: Build iOS library

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,12 +25,12 @@ jobs:
           print(invalid_asset_dirs)
           exit(1)
         """
-
   test-env-file:
     name: Test environment file
     runs-on: ubuntu-latest
 
     steps:
+    name: Update/Set the version variable
     - run: |
       grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec |
           python3 -c """
@@ -40,6 +40,7 @@ jobs:
       print(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> $GITHUB_ENV')
       """
 
+    name: Echo the variable
     - run: |
       echo $NEW_VERSION
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
         import sys
         current_version = sys.stdin.read().strip().split(\"'\")[1]
         major, minor, patch = current_version.split('.')
-        print(f'::set-env name=NEW_VERSION::{major}.{minor}.{int(patch) + 1}')
+        print(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> $GITHUB_ENV')
         """
 
     - name: Use Node 11
@@ -153,7 +153,7 @@ jobs:
         import sys
         current_version = sys.stdin.read().strip().split(\"'\")[1]
         major, minor, patch = current_version.split('.')
-        print(f'::set-env name=NEW_VERSION::{major}.{minor}.{int(patch) + 1}')
+        print(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> $GITHUB_ENV')
         """
 
     - name: Use Node 11

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,12 +20,12 @@ jobs:
 
     - name: Bump version patch
       run: |
-        grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec |
-            python3 -c """
+        grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec | python3 -c """
         import sys
+        import os
         current_version = sys.stdin.read().strip().split(\"'\")[1]
         major, minor, patch = current_version.split('.')
-        print(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> $GITHUB_ENV')
+        os.system(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> \$GITHUB_ENV')
         """
 
     - name: Use Node 11
@@ -148,12 +148,12 @@ jobs:
 
     - name: Bump version patch
       run: |
-        grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec |
-            python3 -c """
+        grep -E "[0-9]+\.[0-9]+\.[0-9]+" FluentIcons.podspec | python3 -c """
         import sys
+        import os
         current_version = sys.stdin.read().strip().split(\"'\")[1]
         major, minor, patch = current_version.split('.')
-        print(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> $GITHUB_ENV')
+        os.system(f'echo \"NEW_VERSION={major}.{minor}.{int(patch) + 1}\" >> \$GITHUB_ENV')
         """
 
     - name: Use Node 11


### PR DESCRIPTION
Due to the [deprecation of set-env](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) we need to change the publish.yml for handling the new version.