### PR TITLE
Remove conformance to Equatable and CaseIterable to improve compile time

### DIFF
--- a/importer/process_ios_assets.py
+++ b/importer/process_ios_assets.py
@@ -177,7 +177,7 @@ def process_assets():
         swift_enum_file.write("/// View the full list of icons here:\n")
         swift_enum_file.write("/// https://github.com/microsoft/fluentui-system-icons/blob/master/icons.md\n")
         swift_enum_file.write("///\n")
-        swift_enum_file.write("@objc public enum {}: Int, Equatable, CaseIterable".format(LIBRARY_NAME) + " {\n")
+        swift_enum_file.write("@objc public enum {}: Int".format(LIBRARY_NAME) + " {\n")
 
         cases_output = []
         resource_strings = []


### PR DESCRIPTION
Not many apps are using these and they affect compile time. If an app does want to use this they can add the following in their app instead:

```swift
extension FluentIcon: Equatable, CaseIterable {}
```