### PR TITLE
Revert "Remove conformance to Equatable and CaseIterable to improve compile time"

### DIFF
--- a/importer/process_ios_assets.py
+++ b/importer/process_ios_assets.py
@@ -177,7 +177,7 @@ def process_assets():
         swift_enum_file.write("/// View the full list of icons here:\n")
         swift_enum_file.write("/// https://github.com/microsoft/fluentui-system-icons/blob/master/icons.md\n")
         swift_enum_file.write("///\n")
-        swift_enum_file.write("@objc public enum {}: Int".format(LIBRARY_NAME) + " {\n")
+        swift_enum_file.write("@objc public enum {}: Int, Equatable, CaseIterable".format(LIBRARY_NAME) + " {\n")
 
         cases_output = []
         resource_strings = []


### PR DESCRIPTION
It turns out it's not possible to conform to CaseIterable from another file.