### PR TITLE
Update Installation for Flutter code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In the `pubspec.yaml` of your flutter project, add the following dependency:
 ```yaml
 dependencies:
   ...
-  fluentui_system_icons: "1.1.91"
+  fluentui_system_icons: ^1.1.91
 ```
 
 For library docs, see [flutter/README.md](flutter/README.md)


### PR DESCRIPTION
https://pub.dev/packages/fluentui_system_icons/install uses ^x.y.z instead of "x.y.z". Most people use ^ in pubpec.yaml for Flutter projects.

I am not sure whether any GitHub actions or other automated version number updating script needs to be edited as well.