### PR TITLE
Do all npm install/build before publishing anything

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,17 +137,17 @@ jobs:
         npm run build
       working-directory: packages/svg-icons
 
-    - uses: JS-DevTools/npm-publish@v1
-      with:
-        token: ${{ secrets.NPM_TOKEN }}
-        access: public
-        package: packages/svg-icons/package.json
-
     - name: Build React library
       run: |
         npm install
         npm run build
       working-directory: packages/react-icons
+
+    - uses: JS-DevTools/npm-publish@v1
+      with:
+        token: ${{ secrets.NPM_TOKEN }}
+        access: public
+        package: packages/svg-icons/package.json
 
     - uses: JS-DevTools/npm-publish@v1
       with:


### PR DESCRIPTION
I believe that previously it caused npm install failure due to the publish workflow adding a .npmrc file. Earlier tests in the pr validation with dry-run publishing were fine in this order, so going with it here.