### PR TITLE
Change the @fluentui/react-icon package name for now

### DIFF
--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-icons",
+  "name": "@fluentui/react-icons-preview",
   "version": "1.1.100",
   "description": "Fluent System Icons are a collection of familiar, friendly, and modern icons from Microsoft.",
   "license": "MIT",


### PR DESCRIPTION
Given the previous package and need to handle proper messaging, we should use -preview for this to get it out while we give people a heads-up about the change