### PR TITLE
Migrate flutter package to sound null safety

### DIFF
--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.1.102
 homepage: https://github.com/microsoft/fluentui-system-icons/tree/master
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Small PR to migrate fluentui_system_icons Flutter package to dart v2.12 and flutter v2.0.0 with sound null safety.
