### PR TITLE
update module to use esnext and add interface for accessibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ xcuserdata
 packages/react-icons/intermediate
 packages/react-icons/src/components
 packages/react-icons/src/index.tsx
+packages/react-icons/src/index.tsx
+packages/react-icons/lib/
+packages/react-icons/yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,5 @@ xcuserdata
 packages/react-icons/intermediate
 packages/react-icons/src/components
 packages/react-icons/src/index.tsx
-packages/react-icons/src/index.tsx
 packages/react-icons/lib/
 packages/react-icons/yarn.lock

--- a/packages/react-icons/convert.js
+++ b/packages/react-icons/convert.js
@@ -45,8 +45,8 @@ function processFolder(srcPath, destPath) {
     // See https://react-svgr.com/docs/options/ for more info
     var svgrOpts = {
       template: fileTemplate,
-      expandProps: 'start', // HTML attributes/props for things like accessibility can be passed in, and will be expanded on the svg object at the start of the object
-      svgProps: { className: '{className}' }, // In order to provide styling, className will be used
+      expandProps: false, // HTML attributes/props for things like accessibility can be passed in, and will be expanded on the svg object at the start of the object
+      svgProps: { className: '{className}', ariaPrefixlabel:'{props["aria-label"]}', ariaPrefixhidden:'{props["aria-hidden"]}'}, // In order to provide styling, className will be used
       replaceAttrValues: { '#212121': '{primaryFill}' }, // We are designating primaryFill as the primary color for filling. If not provided, it defaults to null.
       typescript: true,
     }
@@ -73,6 +73,8 @@ function processFolder(srcPath, destPath) {
 
     // Finally add the interface definition and then write out the index.
     indexContents += '\nexport { IFluentIconsProps } from \'./IFluentIconsProps.types\''
+    indexContents += '\nexport { ILabelIconProps } from \'./ILabelIconProps.types\''
+    indexContents += '\nexport { IPresentationIconProps } from \'./IPresentationIconProps.types\''
     fs.writeFileSync(destPath + '/index.tsx', indexContents, (err) => {
       if (err) throw err;
     });
@@ -92,12 +94,13 @@ function fileTemplate(
   exports.declaration.name = componentName.name
 
   return tpl.ast`
-		import * as React from "react"
-		import { JSX } from "react-jsx"
+		import * as React from "react";
 
-		import { IFluentIconsProps } from '../IFluentIconsProps.types'
+		import { IFluentIconsProps } from '../IFluentIconsProps.types';
+    import { ILabelIconProps } from '../ILabelIconProps.types';
+    import { IPresentationIconProps } from '../IPresentationIconProps.types';
 
-		const ${componentName} = (iconProps: IFluentIconsProps, props: React.HTMLAttributes<HTMLElement>) : JSX.Element=> {
+		const ${componentName} = (iconProps: IFluentIconsProps, props: (ILabelIconProps | IPresentationIconProps)) : JSX.Element=> {
 		const { primaryFill, className } = iconProps;
 		return ${jsx};
 		}

--- a/packages/react-icons/convert.js
+++ b/packages/react-icons/convert.js
@@ -100,7 +100,7 @@ function fileTemplate(
     import { ILabelIconProps } from '../ILabelIconProps.types';
     import { IPresentationIconProps } from '../IPresentationIconProps.types';
 
-		const ${componentName} = (iconProps: IFluentIconsProps, props: (ILabelIconProps | IPresentationIconProps)) : JSX.Element=> {
+		const ${componentName} = (iconProps: IFluentIconsProps, props: (ILabelIconProps | IPresentationIconProps)): JSX.Element=> {
 		const { primaryFill, className } = iconProps;
 		return ${jsx};
 		}

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-icons",
+  "name": "@fluentui/react-icons-preview",
   "version": "1.1.105",
   "main": "lib/esm/index.js",
   "module": "lib/esm/index.js",
@@ -28,9 +28,7 @@
     "react": "^17.0.1",
     "renamer": "^2.0.1",
     "svgo": "^1.3.2",
+    "tslib": "^2.1.0",
     "yargs": "^14.0.0"
-  },
-  "dependencies": {
-    "tslib": "^2.1.0"
   }
 }

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -1,6 +1,9 @@
 {
-  "name": "@fluentui/react-icons-preview",
+  "name": "@fluentui/react-icons",
   "version": "1.1.105",
+  "main": "lib/cjs/index.js",
+  "module": "lib/cjs/index.js",
+  "typings": "lib/cjs/index.d.ts",
   "description": "Fluent System Icons are a collection of familiar, friendly, and modern icons from Microsoft.",
   "license": "MIT",
   "repository": {
@@ -14,16 +17,20 @@
     "convert": "node convert.js --source=./intermediate --dest=./src",
     "optimize": "svgo --folder=./intermediate --precision=2 --disable=removeViewBox,mergePaths",
     "unfill": "find ./intermediate -type f -name \"*.svg\" -exec sed -i.bak 's/fill=\"none\"//g' {} \\; && find ./intermediate -type f -name \"*.bak\" -delete",
-    "build": "npm run copy && npm run optimize && npm run unfill && npm run convert && npm run cleanSvg"
+    "hyphenate": "find ./src/components -type f -name \"*.tsx\" -exec sed -i.bak 's/ariaPrefix/aria-/g' {} \\; && find ./src/components -type f -name \"*.bak\" -delete",
+    "build": "npm run copy && npm run optimize && npm run unfill && npm run convert && npm run hyphenate && npm run cleanSvg && npm run build:esm",
+    "build:esm": "tsc"
   },
   "devDependencies": {
     "@svgr/core": "^5.5.0",
     "@types/react": "^17.0.2",
     "lodash": "^4.17.21",
     "react": "^17.0.1",
-    "react-jsx": "^1.0.0",
     "renamer": "^2.0.1",
     "svgo": "^1.3.2",
     "yargs": "^14.0.0"
+  },
+  "dependencies": {
+    "tslib": "^2.1.0"
   }
 }

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@fluentui/react-icons",
   "version": "1.1.105",
-  "main": "lib/cjs/index.js",
-  "module": "lib/cjs/index.js",
-  "typings": "lib/cjs/index.d.ts",
+  "main": "lib/esm/index.js",
+  "module": "lib/esm/index.js",
+  "typings": "lib/esm/index.d.ts",
   "description": "Fluent System Icons are a collection of familiar, friendly, and modern icons from Microsoft.",
   "license": "MIT",
   "repository": {

--- a/packages/react-icons/src/ILabelIconProps.types.ts
+++ b/packages/react-icons/src/ILabelIconProps.types.ts
@@ -1,0 +1,6 @@
+import * as React from 'react';
+
+export interface ILabelIconProps extends React.HTMLAttributes<HTMLElement> {
+    'aria-label': string,
+    'aria-hidden': false | undefined
+}

--- a/packages/react-icons/src/IPresentationIconProps.types.ts
+++ b/packages/react-icons/src/IPresentationIconProps.types.ts
@@ -1,0 +1,6 @@
+import * as React from 'react';
+
+export interface IPresentationIconProps extends React.HTMLAttributes<HTMLElement> {
+    'aria-label': undefined,
+    'aria-hidden': true
+}

--- a/packages/react-icons/tsconfig.json
+++ b/packages/react-icons/tsconfig.json
@@ -1,8 +1,18 @@
 {
   "compilerOptions": {
+    "outDir": "lib/esm",
     "target": "ES6",
-    "module": "commonjs",
+    "module": "esnext",
+    "lib": ["es6", "dom"],
+    "declaration": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "forceConsistentCasingInFileNames": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node",
     "sourceMap": true,
     "jsx": "react"
-  }
+  },
+  "include": ["src"],
+  "exclude": ["lib"]
 }


### PR DESCRIPTION
This PR updates the `tsconfig.json` to use the esnext module instead of commonjs. This is in order to enable the `react-icons` package to be treeshakeable. It also adds 2 interfaces to the icon definitions, in order to help the user provide props needed for narrators. This is in order to make the icons more accessible. Finally, this PR updates the files that will be ignored in the .gitignore