### PR TITLE
Fixed the broken link of svg-icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,20 @@ Fluent UI System Icons are a collection of familiar, friendly and modern icons f
 [View the full list of icons](icons.md)
 
 ## Installation
+
 ### Android
+
 The library is published via JCenter, please ensure that the `jcenter()` repository has been added to the root `build.gradle` file:
+
 ```groovy
 repositories {
     ...
     jcenter()
 }
 ```
+
 Include the following dependency in your project's `build.gradle`
+
 ```groovy
 implementation 'com.microsoft.design:fluent-system-icons:1.1.111'
 ```
@@ -27,6 +32,7 @@ implementation 'com.microsoft.design:fluent-system-icons:1.1.111'
 For library docs, see [android/README.md](android/README.md).
 
 ### iOS and macOS
+
 #### CocoaPods
 
 ```ruby
@@ -57,7 +63,7 @@ For library docs, see [flutter/README.md](flutter/README.md)
 
 ### Plain svg
 
-Inline svg directly. See [packages\svg-icons\README.md](packages\svg-icons\README.md).
+Inline svg directly. See [packages/svg-icons/README.md](packages/svg-icons/README.md).
 
 ## Contributing
 
@@ -66,17 +72,20 @@ Inline svg directly. See [packages\svg-icons\README.md](packages\svg-icons\READM
 The importer generates the Android and iOS libraries from the icons in the `assets` directory.
 
 Jump into the directory
+
 ```
 cd importer
 ```
 
 Install npm dependencies
+
 ```
 npm install
 npm run clean
 ```
 
 List all the available commands
+
 ```
 npm run
 ```
@@ -90,23 +99,29 @@ Our [build pipeline](https://github.com/microsoft/fluentui-system-icons/actions)
 You can build and run the demo apps following the steps below.
 
 ### Android
+
 1. Follow the **Importer** section above and run the command `npm run deploy:android`
 2. Open the [android](android) directory in Android Studio
 3. Select the `sample-showcase` in the build configuration dropdown
-4. Click run 
+4. Click run
 
 ### Flutter
-Prerequisite: Make sure you have flutter configured in Android Studio 
+
+Prerequisite: Make sure you have flutter configured in Android Studio
+
 1. Open the [flutter](flutter) directory in Android Studio
 2. Select the 'example' in the directory and open it in Android Studio
 3. Click run
 
 ## Contact
+
 Please feel free to [open a GitHub issue](https://github.com/microsoft/fluentui-system-icons/issues/new) and assign to the following points of contact with questions or requests.
-* Jason Custer([@jasoncuster](https://github.com/jasoncuster)) / Spencer Nelson([@spencer-nelson](https://github.com/spencer-nelson)) / Joe Woodward([@thewoodpecker](https://github.com/thewoodpecker)) - Design
-* Nick Romano([@rickromano](https://github.com/nickromano)) - iOS
-* Will Hou([@willhou](https://github.com/willhou)) - Android
-* Akashdeep Singh([@aakash1313](https://github.com/aakash1313)) - Flutter
+
+- Jason Custer([@jasoncuster](https://github.com/jasoncuster)) / Spencer Nelson([@spencer-nelson](https://github.com/spencer-nelson)) / Joe Woodward([@thewoodpecker](https://github.com/thewoodpecker)) - Design
+- Nick Romano([@rickromano](https://github.com/nickromano)) - iOS
+- Will Hou([@willhou](https://github.com/willhou)) - Android
+- Akashdeep Singh([@aakash1313](https://github.com/aakash1313)) - Flutter
 
 ## Code of Conduct
+
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct) or contact opencode@microsoft.com with any additional questions or comments.


### PR DESCRIPTION
Hey Maintainer!

I changed the file path for the svg-icons in the `README.md` doc from:
`[packages\svg-icons\README.md](packages\svg-icons\README.md)` to `[packages/svg-icons/README.md](packages/svg-icons/README.md)`

And that fixed the issue #214 where the Readme wasn't redirecting to the required page!