### PR TITLE
Fix signing key info env names

### DIFF
--- a/android/scripts/publish-root.gradle
+++ b/android/scripts/publish-root.gradle
@@ -17,8 +17,8 @@ if (secretPropsFile.exists()) {
     ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
     ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
     ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
-    ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
-    ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
+    ext["signing.keyId"] = System.getenv('GPG_SIGNING_KEY_ID')
+    ext["signing.password"] = System.getenv('GPG_SIGNING_PASSWORD')
     ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_SECRET_KEY_RING_FILE')
 }
 


### PR DESCRIPTION
Should be `GPG_SIGNING_KEY_ID` and `GPG_SIGNING_PASSWORD` instead of `SIGNING_KEY_ID` and `SIGNING_PASSWORD`