### PR TITLE
Fix Cocoapods publish step

### DIFF
--- a/.github/workflows/cocoapods-publish.yml
+++ b/.github/workflows/cocoapods-publish.yml
@@ -1,0 +1,24 @@
+name: Cocoapods publish
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+
+jobs:
+  # Only runs on the version update commit
+  # We need the new podspec available to publish to CocoaPods
+  publish-to-cocoapods:
+    if: "contains(github.event.head_commit.author.email, 'flubuild@microsoft.com')"
+    name: Publish to CocoaPods
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Deploy to CocoaPods
+      run: |
+        pod spec lint --allow-warnings
+        pod trunk push --allow-warnings
+      env:
+        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -255,20 +255,3 @@ jobs:
         group: Public
         file: android/sample-showcase/build/outputs/apk/release/sample-showcase-release.apk
         releaseNotes: Please enjoy this latest version(${{ env.NEW_VERSION }}) of Fluent System Icons Demo.
-
-  # Only runs on the version update commit
-  # We need the new podspec available to publish to CocoaPods
-  publish-to-cocoapods:
-    if: "contains(github.event.head_commit.author.email, 'flubuild@microsoft.com')"
-    name: Publish to CocoaPods
-    runs-on: macos-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Deploy to CocoaPods
-      run: |
-        pod spec lint --allow-warnings
-        pod trunk push --allow-warnings
-      env:
-        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}


### PR DESCRIPTION
Since [this change](https://github.com/microsoft/fluentui-system-icons/commit/b58ad57ae9421806e9bdad1c4d750595945630aa) we haven't been publishing to Cocoapods. This PR pulls out the job for Cocoapods publish so it is no longer is filtered by the assets check.