### PR TITLE
Update template to call wrapIcon to build react icons

### DIFF
--- a/packages/react-icons/README.md
+++ b/packages/react-icons/README.md
@@ -12,7 +12,7 @@ User story
 
 There are different sizes of each icon, as well as `Filled` and `Regular` versions of each icon, so you can choose what works best for your application.
 
-There are also helpful interfaces that will allow you to add styling to fit the icons to your specific application, as well as add aria properties to increase the accessibility of the icons.
+There are also helpful interfaces that will allow you to add styling to fit the icons to your specific application
 
 User flows
 ---
@@ -21,23 +21,21 @@ In order to use these icons, simply import them as `import { [Componentname][siz
 ```tsx
 import { AccessTime24Filled } from "@fluentui/react-icons";
 ```
-You can also style the icons using the `IFluentIconsProps`interface and wrap the icon in a container using the `wrapIcon` method. You can then pass containter props like `aria-label` along with the regular `IFluentIconsProps`
+You can also style the icons using the `IFluentIconsProps`interface, with the `className` prop or the `primaryFill` prop
 
 ```tsx
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { AccessTime24Filled, wrapIcon } from "@fluentui/react-icons";
+import { AccessTime24Filled } from "@fluentui/react-icons";
 
 const iconStyleProps: IFluentIconsProps = {
     primaryFill: "purple",
     className: "iconClass"
 };
-const WrappedAccessTime24Filled = wrapIcon(<AccessTime24Filled />);
 const rootElement = document.getElementById("root");
 ReactDOM.render(
     <div>
-        <AccessTime24Filled iconProps={...iconStyleProps}  />
-        <WrappedAccessTime24Filled iconProps={...iconStyleProps} aria-label="AccessTime24"/>
+        <AccessTime24Filled aria-label="AccessTime24Filled" {...iconStyleProps}  />
     </div>, 
     rootElement
     )

--- a/packages/react-icons/convert.js
+++ b/packages/react-icons/convert.js
@@ -87,7 +87,21 @@ function processFolder(srcPath, destPath) {
       }
       indexLocation = path.join(indexLocation, destFilename)
       var iconContent = fs.readFileSync(srcFile, { encoding: "utf8" })
-      jsCode = svgr.default.sync(iconContent, svgrOpts, { filePath: file })
+      
+      var jsxCode = svgr.default.sync(iconContent, svgrOpts, { filePath: file })
+      var jsCode = 
+`import * as React from 'react';
+import  wrapIcon from '../utils/wrapIcon';
+import { IFluentIconsProps } from '../utils/IFluentIconsProps.types';
+
+const rawSvg = (iconProps: IFluentIconsProps) => {
+  const { className, primaryFill } = iconProps;
+  return ${jsxCode};
+}
+
+const ${destFilename} = wrapIcon(rawSvg({}), '${destFilename}');
+export default ${destFilename};
+      `
       indexContents += '\nexport { default as ' + destFilename + ' } from \'./' + indexLocation + '\''
       fs.writeFileSync(destFile, jsCode, (err) => {
         if (err) throw err;
@@ -109,17 +123,6 @@ function fileTemplate(
 
   componentName.name = componentName.name.substring(3)
   componentName.name = componentName.name.replace('IcFluent', '')
-  exports.declaration.name = componentName.name
-
-  return tpl.ast`
-		import * as React from "react";
-		import { IFluentIconsProps } from '../utils/IFluentIconsProps.types';
-
-		const ${componentName}: JSX.Element = (iconProps: IFluentIconsProps) => {
-		const { primaryFill, className } = iconProps;
-		return ${jsx};
-		}
-		
-		${exports}
-	`
+  
+	return jsx;
 }

--- a/packages/react-icons/example/package.json
+++ b/packages/react-icons/example/package.json
@@ -1,17 +1,18 @@
 {
 	"name": "fabric-starter-sandbox",
 	"version": "1.0.0",
-    "private": true,
+	"private": true,
 	"description": "",
 	"keywords": [],
 	"main": "src/index.tsx",
 	"dependencies": {
 		"react": "16.8.4",
 		"react-dom": "16.8.6",
-		"react-scripts": "4.0.3"
+		"react-scripts": "4.0.3",
+		"sass": "^1.34.0"
 	},
 	"devDependencies": {
-		"@fluentui/react-icons": "^1.1.110",
+		"@fluentui/react-icons": "^1.1.127",
 		"@types/react": "16.8.8",
 		"@types/react-dom": "16.8.2",
 		"typescript": "3.3.3"

--- a/packages/react-icons/src/utils/wrapIcon.tsx
+++ b/packages/react-icons/src/utils/wrapIcon.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { IFluentIconsProps } from "./IFluentIconsProps.types";
 
-const wrapIcon = (icon: JSX.Element) => {
+const wrapIcon = (icon: JSX.Element, displayName?: string) => {
     const Component: React.FC<React.HTMLAttributes<HTMLSpanElement> & IFluentIconsProps> = (props) => {
+        const { className, primaryFill = 'currentColor' } = props;
         const containerProps = props['aria-label'] || props['aria-labelledby'] || props.title
         ? {
             role: 'img',
@@ -12,17 +13,18 @@ const wrapIcon = (icon: JSX.Element) => {
           };
             
         return (
-            <span {...props} {...containerProps}>
+            <span  {...props} {...containerProps}>
                 {React.cloneElement(
                     icon,
                     {
-                        className:  props.className,
-                        primaryFill: props.primaryFill
+                        className: className,
+                        fill: primaryFill
                     }
                 )}
             </span>
         )
     }
+    Component.displayName = displayName;
     return Component;
 }
 


### PR DESCRIPTION
This PR updates the react-icons library template to build the icons by calling `wrapIcon`. This is in order to provide default support for adding container props as well as aria props to the icons. 