### PR TITLE
Update Android dependency definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ repositories {
 Include the following dependency in your project's `build.gradle`
 
 ```groovy
-implementation 'com.microsoft.design:fluent-system-icons:1.1.127'
+implementation 'com.microsoft.design:fluent-system-icons:1.1.127@aar'
 ```
 
 For library docs, see [android/README.md](android/README.md).


### PR DESCRIPTION
This change updates the doc to include `@aar` prefix for the Android dependency definition. With this change, consuming modules would explicitly request for the aar hosted on Maven Central instead of a jar(by default). 

Closes #240 