### PR TITLE
Removing 'unsepecified' dependencies from maven pom file

### DIFF
--- a/android/library/build.gradle
+++ b/android/library/build.gradle
@@ -20,8 +20,4 @@ android {
 
 }
 
-dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-}
-
 apply from: "${rootDir}/scripts/publish-module.gradle"


### PR DESCRIPTION
When the package is published to maven the pom file that is generated contains a list of dependencies. However since this package only specified a local lib folder and wasn't filtering it during packaging it was being added to the pom file as "unspecified":

```xml
<dependencies>
    <dependency>
      <groupId/>
      <artifactId>unspecified</artifactId>
      <version/>
    </dependency>
  </dependencies>
```

Since there are no dependencies either local libs or maven ones I removed the dependency block so that the resulting pomfile will look like this:

```xml
<dependencies />
```