### PR TITLE
Use SVGs for iOS image sets

### DIFF
--- a/importer/package.json
+++ b/importer/package.json
@@ -14,7 +14,7 @@
     "finalize:android": "find ./dist/ -type f ! -name '*_selector.xml' -exec replace '#212121' '@color/fluent_default_icon_tint' {} \\; && replace '\"http://schemas.android.com/apk/res/android\"' '\"http://schemas.android.com/apk/res/android\" android:autoMirrored=\"true\"' $(awk '$0=\"./dist/\"$0\".xml\"' rtl.txt)",
     "create:android": "npm run generate:svg-android && find ./dist/ -type d -exec sh -c 'tools/vd-tool/bin/vd-tool -c -in {} -out {}' \\;",
     "optimize:android": "find ./dist/ -type f -name '*.svg' -delete && find ./dist/ -type d ! -name '*_selector.xml' -exec sh -c 'avocado -q {}' \\;",
-    "build:ios": "npm run generate:pdf",
+    "build:ios": "npm run generate:svg",
     "build:react": "npm run generate:react",
     "deploy:android": "npm run build:android && rm -rf ../android/library/src/main/res/drawable && mkdir ../android/library/src/main/res/drawable && find ./dist/ -type f -name \"*.xml\" -exec cp {} ../android/library/src/main/res/drawable \\; && npm run clean",
     "deploy:react": "npm run build:react && rm -rf ../react/src/components && mkdir ../react/src/components && find ./dist/ -type f -name \"*.tsx\" -exec cp {} ../react/src/components \\; && npm run clean",

--- a/importer/process_ios_assets.py
+++ b/importer/process_ios_assets.py
@@ -17,10 +17,10 @@ def to_camel_case(snake_str):
 RESERVED_WORDS = ['repeat', 'import', 'class']
 
 ICON_PREFIX = "ic_fluent_"
-
+IMAGE_FORMAT = ".svg"
 
 def get_icon_name(file_name):
-    return file_name.replace('.pdf', '').replace('__', '_').replace('_ltr_', '_').replace('_rtl_', '_')
+    return file_name.replace(IMAGE_FORMAT, '').replace('__', '_').replace('_ltr_', '_').replace('_rtl_', '_')
 
 
 def bucket_array(array, bucket_size):
@@ -151,11 +151,10 @@ def create_icon_set(file_names, original_icon_names, icon_assets_path):
 def process_assets():
     project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-    # print(os.listdir("dist"))
     file_names = []
     loc_names = []
     for file_name in os.listdir("dist"):
-        if file_name.endswith('.pdf'):
+        if file_name.endswith(IMAGE_FORMAT):
             file_names.append(file_name)
         elif os.path.isdir(os.path.join("dist", file_name)):
             loc_names.append(file_name)
@@ -190,12 +189,12 @@ def process_assets():
         gn_file.write("import(\"//build/config/ios/asset_catalog.gni\")\n\n")
 
         for file_name in file_names:
-            icon_name = file_name.replace('.pdf', '')
+            icon_name = file_name.replace(IMAGE_FORMAT, '')
 
             gn_file.write("imageset(\"{}\")".format(icon_name) + " {\n")
             gn_file.write("  sources = [\n")
             gn_file.write("    \"FluentIcons/Assets/IconAssets.xcassets/{}.imageset/Contents.json\"".format(icon_name) + ",\n")
-            gn_file.write("    \"FluentIcons/Assets/IconAssets.xcassets/{icon_name}.imageset/{icon_name}.pdf\"".format(icon_name=icon_name) + ",\n")
+            gn_file.write("    \"FluentIcons/Assets/IconAssets.xcassets/{icon_name}.imageset/{icon_name}{image_format}\"".format(icon_name=icon_name, image_format=IMAGE_FORMAT) + ",\n")
             gn_file.write("  ]\n")
             gn_file.write("}\n\n")
     swift_enum_path = os.path.join(ios_directory, LIBRARY_NAME + "s", "Classes", LIBRARY_NAME + ".swift")
@@ -210,7 +209,7 @@ def process_assets():
         """
         Remove first and last two components
 
-        Before: ic_fluent_flash_off_24_regular.pdf
+        Before: ic_fluent_flash_off_24_regular.svg
         After:  flash_off_24
         """
         icon_name = get_icon_name(file_name).replace(ICON_PREFIX, '')


### PR DESCRIPTION
Description
SVGs and PDFs without vector representation provide similar performance (size impact and runtime performance) so changing iOS image set default file format to SVGs instead of PDFs for consistency across platform. A detailed analysis on iOS image file format can be found here: https://microsoft.github.io/apple-ux-guide/ 

VERIFICATION
-Running `npm run deploy:ios` locally did generate imagesets containing SVG images.

Impact
This changes the image file format for iOS image assets from PDF to SVG.