### PR TITLE
Fix react-icons version number script to emit the right version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,11 +40,7 @@ jobs:
         current_version = current_version.split('\"')[1]
         major,minor,asset,beta = current_version.split('.')
         asset = asset.replace('-beta','')
-        react_major = {major}
-        react_minor = {minor}
-        react_sized_major = {major}
-        react_sized_minor = {minor}
-        os.system(f'echo \"REACT_VERSION={react_major}.{react_minor}.{int(asset) + 1}-beta.{beta}\" >> \$GITHUB_ENV')
+        os.system(f'echo \"REACT_VERSION={major}.{minor}.{int(asset) + 1}-beta.{beta}\" >> \$GITHUB_ENV')
         """
 
     - name: Use Node 11


### PR DESCRIPTION
This PR fixes an issue where the version number in react-icons package.json is changed incorrectly, causing the publish step to fail