### PR TITLE
@fluentui/react-icons: update FluentIconsProps

### DIFF
--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-icons",
-  "version": "2.0.151-beta.2",
+  "version": "2.0.151-beta.3",
   "sideEffects": false,
   "main": "lib-cjs/index.js",
   "module": "lib/index.js",

--- a/packages/react-icons/src/utils/useIconState.tsx
+++ b/packages/react-icons/src/utils/useIconState.tsx
@@ -10,7 +10,7 @@ const useRootStyles = makeStyles({
     }
 });
 
-export const useIconState = (props: FluentIconsProps) => {
+export const useIconState = (props: FluentIconsProps): FluentIconsProps => {
     const { title, primaryFill="currentColor" } = props;
     const state = {
       ...props,


### PR DESCRIPTION
This PR adds return type to `useIconState()` hook to simplify generated TypeScript definitions.

### Before

![image](https://user-images.githubusercontent.com/14183168/142939852-70cf07af-4868-46ff-bcd0-a10fca805573.png)

### After

![image](https://user-images.githubusercontent.com/14183168/142939801-8d960b35-6139-4302-87b7-f5c889e43a73.png)

---

Because of emitting `<reference types="react" />`it creates a lot of noise for [API Extractor](https://api-extractor.com/):

![image](https://user-images.githubusercontent.com/14183168/142940299-c0197cf8-860d-47d8-b622-0377d336716d.png)

https://github.com/microsoft/fluentui/pull/20563