### PR TITLE
 Upgrade swift-argument-parser to version 1.0.2

### DIFF
--- a/ios/remove-unused-fluent-icons/Package.resolved
+++ b/ios/remove-unused-fluent-icons/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "9f04d1ff1afbccd02279338a2c91e5f27c45e93a",
-          "version": "0.0.5"
+          "revision": "e1465042f195f374b94f915ba8ca49de24300a0d",
+          "version": "1.0.2"
         }
       }
     ]

--- a/ios/remove-unused-fluent-icons/Package.swift
+++ b/ios/remove-unused-fluent-icons/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     .executable(name: "remove-unused-fluent-icons", targets: ["remove-unused-fluent-icons"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-argument-parser", from: "0.0.5"),
+    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
## Overview
The stable version of swift-argument-parse has been released.
Therefore, we will upgrade swift-argument-parser to version 1.0.2.

## Reference
https://github.com/apple/swift-argument-parser/releases