### PR TITLE
Manual version bump to get around the Android publish failure.

### DIFF
--- a/flutter/CHANGELOG.md
+++ b/flutter/CHANGELOG.md
@@ -1,1 +1,1 @@
-## [1.1.164] - Complete change log present here https://github.com/microsoft/fluentui-system-icons/tags
+## [1.1.165] - Complete change log present here https://github.com/microsoft/fluentui-system-icons/tags

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluentui_system_icons
 description: Fluent UI System Icons are a collection of familiar, friendly and modern icons from Microsoft.
-version: 1.1.164
+version: 1.1.165
 homepage: https://github.com/microsoft/fluentui-system-icons/tree/master
 
 environment:

--- a/ios/FluentIcons.podspec
+++ b/ios/FluentIcons.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'FluentIcons'
-  s.version          = '1.1.164'
+  s.version          = '1.1.165'
   s.summary          = 'FluentIcons'
 
   s.description      = <<-DESC

--- a/ios/README.md
+++ b/ios/README.md
@@ -6,13 +6,13 @@
 
 ```ruby
 use_frameworks!
-pod "FluentIcons", "1.1.164"
+pod "FluentIcons", "1.1.165"
 ```
 
 ### Carthage
 
 ```bash
-git "git@github.com:microsoft/fluentui-system-icons.git" "1.1.164"
+git "git@github.com:microsoft/fluentui-system-icons.git" "1.1.165"
 ```
 
 ## Usage

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-icons",
-  "version": "2.0.164-rc.2",
+  "version": "2.0.165-rc.2",
   "sideEffects": false,
   "main": "lib-cjs/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
It had been published at 1.1.165 but the tag/version update wasn't pushed to GH because of the SvgList error. This is the workaround