### PR TITLE
Fix code that tries to mutate read-only props object

### DIFF
--- a/packages/react-icons/src/utils/fonts/createFluentFontIcon.tsx
+++ b/packages/react-icons/src/utils/fonts/createFluentFontIcon.tsx
@@ -73,8 +73,8 @@ export function createFluentFontIcon(displayName: string, codepoint: string, fon
     const Component: React.FC<FluentIconsProps<React.HTMLAttributes<HTMLElement>>> = (props) => {
         useStaticStyles();
         const styles = useRootStyles();
-        props.className = mergeClasses(styles.root, styles[font], props.className);
-        const { primaryFill, ...state } = useIconState<React.HTMLAttributes<HTMLElement>>(props);
+        const className = mergeClasses(styles.root, styles[font], props.className);
+        const { primaryFill, ...state } = useIconState<React.HTMLAttributes<HTMLElement>>({...props, className});
 
 
         // We want to keep the same API surface as the SVG icons, so translate `primaryFill` to `color`


### PR DESCRIPTION
In non-production builds, React will throw an error if you attempt to mutate the props object passed in. This PR fixes one case where the code was trying to do that.