### PR TITLE
fix: use primaryFill correctly with svgr

### DIFF
--- a/packages/react-icons/convert.js
+++ b/packages/react-icons/convert.js
@@ -136,7 +136,7 @@ function processFolder(srcPath, destPath, resizable) {
 `
 
 const ${destFilename}Icon = (props: FluentIconsProps) => {
-  const { primaryFill = 'currentColor', className } = props;
+  const { fill: primaryFill = 'currentColor', className } = props;
   return ${jsxCode};
 }
 export const ${destFilename} = /*#__PURE__*/wrapIcon(/*#__PURE__*/${destFilename}Icon, '${destFilename}');


### PR DESCRIPTION
https://github.com/microsoft/fluentui-system-icons/blob/e663405d81150b015a96d0701d1d3998ffd9ec2c/packages/react-icons/src/utils/useIconState.tsx#L20

`useIconState` actually renames the `primaryFill` prop to `fill`. This means that the destructure result

```ts
const {
    primaryFill = 'currentColor',
    className
  } = props;
```

is always `currentColor` which breaks the `primaryFill` prop on every icon

Repro: https://codesandbox.io/s/exciting-nash-g6fqdf?file=/example.tsx