### PR TITLE
Fix bug in translating 'primaryFill' to 'color' for font icons

### DIFF
--- a/packages/react-icons/src/utils/fonts/createFluentFontIcon.tsx
+++ b/packages/react-icons/src/utils/fonts/createFluentFontIcon.tsx
@@ -74,14 +74,14 @@ export function createFluentFontIcon(displayName: string, codepoint: string, fon
         useStaticStyles();
         const styles = useRootStyles();
         const className = mergeClasses(styles.root, styles[font], props.className);
-        const { primaryFill, ...state } = useIconState<React.HTMLAttributes<HTMLElement>>({...props, className});
+        const state = useIconState<React.HTMLAttributes<HTMLElement>>({...props, className});
 
 
         // We want to keep the same API surface as the SVG icons, so translate `primaryFill` to `color`
-        if (primaryFill) {
+        if (props.primaryFill) {
             state.style = {
                 ...state.style,
-                color: primaryFill
+                color: props.primaryFill
             }
         }
 


### PR DESCRIPTION
`useIconState` translates `primaryFill` to `fill` in the returned object. The typing on the returned object of `primaryFill: string | undefined` is *technically* not wrong, but was misleading.

This change fixes the intended logic to read `primaryFill` directly from the `props`.