### PR TITLE
fix(react-icons): allow React 18 in peerDependencies

### DIFF
--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -51,8 +51,7 @@
     "tslib": "^2.1.0"
   },
   "peerDependencies": {
-    "@griffel/react": "^1.0.0",
-    "react": ">=16.8.0 <=18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "files": [
     "lib/",
@@ -83,3 +82,4 @@
     }
   }
 }
+


### PR DESCRIPTION
Fixes #517.
See title 👆