### PR TITLE
Add context to provide rtl support for react-icons

### DIFF
--- a/packages/react-icons/convert.js
+++ b/packages/react-icons/convert.js
@@ -67,11 +67,13 @@ function processFiles(src, dest) {
 
   const indexPath = path.join(dest, 'index.tsx')
   // Finally add the interface definition and then write out the index.
-  indexContents.push('export { FluentIconsProps } from \'./utils/FluentIconsProps.types\'');
+  indexContents.push('export type { FluentIconsProps } from \'./utils/FluentIconsProps.types\'');
   indexContents.push('export { default as wrapIcon } from \'./utils/wrapIcon\'');
   indexContents.push('export { default as bundleIcon } from \'./utils/bundleIcon\'');
   indexContents.push('export * from \'./utils/useIconState\'');
   indexContents.push('export * from \'./utils/constants\'');
+  indexContents.push('export { IconContextProvider, useIconContext } from \'./contexts/index\'');
+  indexContents.push('export type { IconContextValue } from \'./contexts/index\'');
 
   fs.writeFileSync(indexPath, indexContents.join('\n'), (err) => {
     if (err) throw err;

--- a/packages/react-icons/src/contexts/IconDirectionContext.ts
+++ b/packages/react-icons/src/contexts/IconDirectionContext.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+const IconDirectionContext = React.createContext<IconDirectionContextValue | undefined>(undefined);
+
+export interface IconDirectionContextValue {
+  textDirection?: 'ltr' | 'rtl'
+}
+
+const IconDirectionContextDefaultValue: IconDirectionContextValue = {};
+
+export const IconDirectionContextProvider = IconDirectionContext.Provider;
+
+export const useIconContext = () => React.useContext(IconDirectionContext) ?? IconDirectionContextDefaultValue;

--- a/packages/react-icons/src/contexts/index.ts
+++ b/packages/react-icons/src/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from './IconDirectionContext';

--- a/packages/react-icons/src/utils/useIconState.tsx
+++ b/packages/react-icons/src/utils/useIconState.tsx
@@ -1,5 +1,6 @@
 import { FluentIconsProps } from "./FluentIconsProps.types";
 import { makeStyles, mergeClasses } from "@griffel/react";
+import { useIconContext } from "../contexts";
 
 const useRootStyles = makeStyles({
     root: {
@@ -9,11 +10,15 @@ const useRootStyles = makeStyles({
         "@media (forced-colors: active)": {
           forcedColorAdjust: 'auto',
         }
+    },
+    flipped: {
+      transform: 'scaleX(-1)'
     }
 });
 
 export const useIconState = <TBaseAttributes extends (React.SVGAttributes<SVGElement> | React.HTMLAttributes<HTMLElement>) = React.SVGAttributes<SVGElement>>(props: FluentIconsProps<TBaseAttributes>): Omit<FluentIconsProps<TBaseAttributes>, 'primaryFill'> => {
     const { title, primaryFill = "currentColor", ...rest } = props;
+    const iconContext = useIconContext();
     const state = {
       ...rest,
       title: undefined,
@@ -22,7 +27,7 @@ export const useIconState = <TBaseAttributes extends (React.SVGAttributes<SVGEle
   
     const styles = useRootStyles();
   
-    state.className = mergeClasses(styles.root, state.className);
+    state.className = mergeClasses(styles.root, iconContext.textDirection === 'rtl' && styles.flipped, state.className);
   
     if (title) {
       state['aria-label'] = title;


### PR DESCRIPTION
This PR is to add a react context to the icon build that will allow icons to flip in rtl. This is the first step of the process. The next step is to create/update a list of flippable icons to apply the rtl styling to. Part of #553 