### PR TITLE
Scaffold Icondirection context

### DIFF
--- a/packages/react-icons/convert.js
+++ b/packages/react-icons/convert.js
@@ -69,6 +69,8 @@ function processFiles(src, dest) {
   indexContents.push('export { default as bundleIcon } from \'./utils/bundleIcon\'');
   indexContents.push('export * from \'./utils/useIconState\'');
   indexContents.push('export * from \'./utils/constants\'');
+  indexContents.push('export { IconDirectionContextProvider, useIconContext } from \'./contexts/index\'');
+  indexContents.push('export type { IconDirectionContextValue } from \'./contexts/index\'');
 
   fs.writeFileSync(indexPath, indexContents.join('\n'), (err) => {
     if (err) throw err;

--- a/packages/react-icons/src/contexts/IconDirectionContext.ts
+++ b/packages/react-icons/src/contexts/IconDirectionContext.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+const IconDirectionContext = React.createContext<IconDirectionContextValue | undefined>(undefined);
+
+export interface IconDirectionContextValue {
+  textDirection?: 'ltr' | 'rtl'
+}
+
+const IconDirectionContextDefaultValue: IconDirectionContextValue = {};
+
+export const IconDirectionContextProvider = IconDirectionContext.Provider;
+
+export const useIconContext = () => React.useContext(IconDirectionContext) ?? IconDirectionContextDefaultValue;

--- a/packages/react-icons/src/contexts/index.ts
+++ b/packages/react-icons/src/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from './IconDirectionContext';


### PR DESCRIPTION
This PR is the first part of splitting #560. It adds just the context, with the rest of the build logic to be added when the rtl file is received.