### PR TITLE
Re-enable publish to npm registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,7 +107,7 @@ jobs:
         rm flutter/pubspec.yaml.bk
 
     # Needs to be "-E" instead of "-r" on macOS
-    - name: Replace version number in package.json
+    - name: Replace version number in svg-icons/package.json
       run: |
         sed -i.bk -r "s/\"version\": \"[0-9]+\.[0-9]+\.[0-9]+\"/\"version\": \"$NEW_VERSION\"/g" packages/svg-icons/package.json
         rm packages/svg-icons/package.json.bk
@@ -157,6 +157,12 @@ jobs:
       run: |
         npm run build
       working-directory: packages/react-native-icons 
+
+    - uses: JS-DevTools/npm-publish@v1
+      with:
+        token: ${{ secrets.NPM_TOKEN }}
+        access: public
+        package: packages/svg-icons/package.json
 
     - uses: JS-DevTools/npm-publish@v1
       with:


### PR DESCRIPTION
The `@fluentui/svg-icons` package hasn't been updated since version 1.1.198. After some investigation, I discovered that the `npm-publish` task was removed in this pull request #548 probably by accident. 

Add back the `npm-publish` task to re-enable publish to npm. This should also address #623 