### PR TITLE
[flutter] adds staticIconProvider annotation to allow icon font to be…

### DIFF
--- a/flutter/lib/src/fluent_icons.dart
+++ b/flutter/lib/src/fluent_icons.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/widgets.dart';
 
+@staticIconProvider
 class FluentIcons {
 
   // This class is not meant to be instantiated or extended; this constructor

--- a/importer/generate_flutter_lib_class.js
+++ b/importer/generate_flutter_lib_class.js
@@ -21,6 +21,7 @@ const ICON_CLASS_HEADER =
 
 import 'package:flutter/widgets.dart';
 
+@staticIconProvider
 class FluentIcons {
 
   // This class is not meant to be instantiated or extended; this constructor


### PR DESCRIPTION
… more thoroughly tree-shaken

See here for more info: https://api.flutter.dev/flutter/widgets/staticIconProvider-constant.html

Without this annotation, when building for web only around 16% of each icon font was tree-shaken.

With this annotation, all icons can be tree-shaken.