### PR TITLE
fix: wrapIcon has type error on Ref 

### DIFF
--- a/packages/react-icons/src/utils/FluentIconsProps.types.ts
+++ b/packages/react-icons/src/utils/FluentIconsProps.types.ts
@@ -1,9 +1,14 @@
 import * as React from "react";
 
-export type FluentIconsProps<TBaseAttributes extends (React.SVGAttributes<SVGElement> | React.HTMLAttributes<HTMLElement>) = React.SVGAttributes<SVGElement>> 
-= TBaseAttributes & React.RefAttributes<HTMLElement> & {
-	primaryFill?: string
-	className?: string
-	filled?: boolean
-	title?: string
-}
+export type FluentIconsProps<
+  TBaseAttributes extends
+    | React.SVGAttributes<SVGElement>
+    | React.HTMLAttributes<HTMLElement> = React.SVGAttributes<SVGElement>,
+  TRefType extends HTMLElement | SVGSVGElement = SVGSVGElement
+> = TBaseAttributes &
+  React.RefAttributes<TRefType> & {
+    primaryFill?: string;
+    className?: string;
+    filled?: boolean;
+    title?: string;
+  };

--- a/packages/react-icons/src/utils/fonts/createFluentFontIcon.tsx
+++ b/packages/react-icons/src/utils/fonts/createFluentFontIcon.tsx
@@ -76,12 +76,12 @@ export type CreateFluentFontIconOptions = {
     flipInRtl?: boolean;
 }
 
-export function createFluentFontIcon(displayName: string, codepoint: string, font: FontFile, fontSize?: number, options?: CreateFluentFontIconOptions): React.FC<FluentIconsProps<React.HTMLAttributes<HTMLElement>>> & { codepoint: string} {
-    const Component: React.FC<FluentIconsProps<React.HTMLAttributes<HTMLElement>>> & { codepoint: string} = (props) => {
+export function createFluentFontIcon(displayName: string, codepoint: string, font: FontFile, fontSize?: number, options?: CreateFluentFontIconOptions): React.FC<FluentIconsProps<React.HTMLAttributes<HTMLElement>, HTMLElement>> & { codepoint: string} {
+    const Component: React.FC<FluentIconsProps<React.HTMLAttributes<HTMLElement>, HTMLElement>> & { codepoint: string} = (props) => {
         useStaticStyles();
         const styles = useRootStyles();
         const className = mergeClasses(styles.root, styles[font], props.className);
-        const state = useIconState<React.HTMLAttributes<HTMLElement>>({...props, className}, { flipInRtl: options?.flipInRtl });
+        const state = useIconState<React.HTMLAttributes<HTMLElement>, HTMLElement>({...props, className}, { flipInRtl: options?.flipInRtl });
 
 
         // We want to keep the same API surface as the SVG icons, so translate `primaryFill` to `color`

--- a/packages/react-icons/src/utils/useIconState.tsx
+++ b/packages/react-icons/src/utils/useIconState.tsx
@@ -20,13 +20,21 @@ export type UseIconStateOptions = {
   flipInRtl?: boolean;
 }
 
-export const useIconState = <TBaseAttributes extends (React.SVGAttributes<SVGElement> | React.HTMLAttributes<HTMLElement>) = React.SVGAttributes<SVGElement>>(props: FluentIconsProps<TBaseAttributes>, options?: UseIconStateOptions): Omit<FluentIconsProps<TBaseAttributes>, 'primaryFill'> => {
+export const useIconState = <
+  TBaseAttributes extends
+    | React.SVGAttributes<SVGElement>
+    | React.HTMLAttributes<HTMLElement> = React.SVGAttributes<SVGElement>,
+  TRefType extends HTMLElement | SVGSVGElement = SVGSVGElement,
+>(
+  props: FluentIconsProps<TBaseAttributes, TRefType>,
+  options?: UseIconStateOptions,
+): Omit<FluentIconsProps<TBaseAttributes, TRefType>, 'primaryFill'> => {
     const { title, primaryFill = "currentColor", ...rest } = props;
     const state = {
       ...rest,
       title: undefined,
       fill: primaryFill
-    } as Omit<FluentIconsProps<TBaseAttributes>, 'primaryFill'>;
+    } as Omit<FluentIconsProps<TBaseAttributes, TRefType>, 'primaryFill'>;
   
     const styles = useRootStyles();
     const iconContext = useIconContext();

--- a/packages/react-icons/src/utils/wrapIcon.tsx
+++ b/packages/react-icons/src/utils/wrapIcon.tsx
@@ -3,16 +3,22 @@ import { FluentIconsProps } from "./FluentIconsProps.types";
 import { useIconState } from "./useIconState";
 import { CreateFluentIconOptions, FluentIcon } from "./createFluentIcon";
 
-const wrapIcon = (Icon: (iconProps: FluentIconsProps) => JSX.Element, displayName?: string, options?: CreateFluentIconOptions) => {
-    const WrappedIcon = React.forwardRef((props: FluentIconsProps, ref: React.Ref<HTMLElement>) => { 
-        const state = {
-            ...useIconState(props, { flipInRtl: options?.flipInRtl }),
-            ref
-        };
-        return <Icon {...state} />
-    }) as FluentIcon
-    WrappedIcon.displayName = displayName;
-    return WrappedIcon;
-}
+const wrapIcon = (
+  Icon: (iconProps: FluentIconsProps) => JSX.Element,
+  displayName?: string,
+  options?: CreateFluentIconOptions
+) => {
+  const WrappedIcon = React.forwardRef(
+    (props: FluentIconsProps, ref: FluentIconsProps["ref"]) => {
+      const state = {
+        ...useIconState(props, { flipInRtl: options?.flipInRtl }),
+        ref,
+      };
+      return <Icon {...state} />;
+    }
+  ) as FluentIcon;
+  WrappedIcon.displayName = displayName;
+  return WrappedIcon;
+};
 
 export default wrapIcon;

--- a/packages/react-icons/src/utils/wrapIcon.tsx
+++ b/packages/react-icons/src/utils/wrapIcon.tsx
@@ -14,5 +14,6 @@ const wrapIcon = (Icon: (iconProps: FluentIconsProps) => JSX.Element, displayNam
     WrappedIcon.displayName = displayName;
     return WrappedIcon;
 }
+ 
 
 export default wrapIcon;

--- a/packages/react-icons/src/utils/wrapIcon.tsx
+++ b/packages/react-icons/src/utils/wrapIcon.tsx
@@ -3,22 +3,16 @@ import { FluentIconsProps } from "./FluentIconsProps.types";
 import { useIconState } from "./useIconState";
 import { CreateFluentIconOptions, FluentIcon } from "./createFluentIcon";
 
-const wrapIcon = (
-  Icon: (iconProps: FluentIconsProps) => JSX.Element,
-  displayName?: string,
-  options?: CreateFluentIconOptions
-) => {
-  const WrappedIcon = React.forwardRef(
-    (props: FluentIconsProps, ref: FluentIconsProps["ref"]) => {
-      const state = {
-        ...useIconState(props, { flipInRtl: options?.flipInRtl }),
-        ref,
-      };
-      return <Icon {...state} />;
-    }
-  ) as FluentIcon;
-  WrappedIcon.displayName = displayName;
-  return WrappedIcon;
-};
+const wrapIcon = (Icon: (iconProps: FluentIconsProps) => JSX.Element, displayName?: string, options?: CreateFluentIconOptions) => {
+    const WrappedIcon = React.forwardRef((props: FluentIconsProps, ref: FluentIconsProps["ref"]) => { 
+        const state = {
+            ...useIconState(props, { flipInRtl: options?.flipInRtl }),
+            ref
+        };
+        return <Icon {...state} />
+    }) as FluentIcon
+    WrappedIcon.displayName = displayName;
+    return WrappedIcon;
+}
 
 export default wrapIcon;


### PR DESCRIPTION
When using wrapIcon to create icon with svg, it can have below error: 
https://codesandbox.io/s/amazing-cartwright-lwwdyf?file=/example.tsx
<img width="806" alt="image" src="https://github.com/microsoft/fluentui-system-icons/assets/28751745/e688c4ba-5016-46b8-8b47-3b0a71a13e0b">
This is because `FluentIconsProps` is typed with `React.RefAttributes<HTMLElement>` and it can't be used on SVG element.

This PR replaced HTMLElement with generic TRefType and set the default to be SVGSVGElement. It ensures the backward compatibility for anyone using HTMLElement ref.