### PR TITLE
Fix bundleIcon primaryFill behavior

### DIFF
--- a/packages/react-icons/src/utils/bundleIcon.tsx
+++ b/packages/react-icons/src/utils/bundleIcon.tsx
@@ -23,7 +23,7 @@ const bundleIcon = (FilledIcon: FluentIcon, RegularIcon: FluentIcon) => {
                         iconFilledClassName,
                         className
                     )}
-                    fill={primaryFill}
+                    primaryFill={primaryFill}
                 />
                 <RegularIcon
                     {...rest}
@@ -33,7 +33,7 @@ const bundleIcon = (FilledIcon: FluentIcon, RegularIcon: FluentIcon) => {
                       iconRegularClassName,
                       className
                     )}
-                    fill={primaryFill}
+                    primaryFill={primaryFill}
                 />
             </React.Fragment>
         )


### PR DESCRIPTION
The bundleIcon util is not successfully carrying the primaryFill prop down to its regular or filled child. The `fill` prop it is passing the primaryFill value to does not actually apply a color change as of the latest package version, tested on Chrome/macOS with the latest stable version of Fluent v9.

See this issue:

https://github.com/microsoft/fluentui/issues/30272

