### PR TITLE
Basic React Server Components support

### DIFF
--- a/packages/react-icons/convert-font.js
+++ b/packages/react-icons/convert-font.js
@@ -118,6 +118,7 @@ async function processFolder(srcPath, codepointMapDestFolder, resizable) {
 
   for (const chunk of iconChunks) {
     chunk.unshift(`import {createFluentFontIcon} from "../../utils/fonts/createFluentFontIcon";`)
+    chunk.unshift(`"use client";`);
   }
 
   /** @type string[] */

--- a/packages/react-icons/convert.js
+++ b/packages/react-icons/convert.js
@@ -137,6 +137,7 @@ function processFolder(srcPath, destPath, resizable) {
   for(const chunk of iconChunks) {
     chunk.unshift(`import { createFluentIcon } from "../utils/createFluentIcon";`);
     chunk.unshift(`import type { FluentIcon } from "../utils/createFluentIcon";`);
+    chunk.unshift(`"use client";`);
   }
 
   /** @type string[] */


### PR DESCRIPTION
Related issue: https://github.com/microsoft/fluentui-system-icons/issues/606

This PR is a small QOL improvement for those who use RSC.

With this change, there will be no need to [re-export](https://nextjs.org/docs/app/building-your-application/rendering/composition-patterns#using-third-party-packages-and-providers) icons somewhere in a codebase to be able to use them in Server Components.