### PR TITLE
Remove primaryFill from bundleIcon prop bag

### DIFF
--- a/packages/react-icons/src/utils/bundleIcon.tsx
+++ b/packages/react-icons/src/utils/bundleIcon.tsx
@@ -11,7 +11,7 @@ const useBundledIconStyles = makeStyles({
 
 const bundleIcon = (FilledIcon: FluentIcon, RegularIcon: FluentIcon) => {
     const Component: FluentIcon = (props) => {
-        const { className, primaryFill = 'currentColor', filled, ...rest } = props;
+        const { className, filled, ...rest } = props;
         const styles = useBundledIconStyles();
         return (
             <React.Fragment>
@@ -23,7 +23,6 @@ const bundleIcon = (FilledIcon: FluentIcon, RegularIcon: FluentIcon) => {
                         iconFilledClassName,
                         className
                     )}
-                    primaryFill={primaryFill}
                 />
                 <RegularIcon
                     {...rest}
@@ -33,7 +32,6 @@ const bundleIcon = (FilledIcon: FluentIcon, RegularIcon: FluentIcon) => {
                       iconRegularClassName,
                       className
                     )}
-                    primaryFill={primaryFill}
                 />
             </React.Fragment>
         )


### PR DESCRIPTION
This PR is to modify the `bundleIcon` utility function to remove the explicit passing in of the `primaryFill` prop to each of the bundled icons. This is to remove any react warnings that result from the `primaryFill` being explicitly passed in, while still allowing the `primaryFill` prop to be passed into the resulting bundled icon.