### PR TITLE
Update style injection in font icon files

### DIFF
--- a/packages/react-icons/src/utils/fonts/createFluentFontIcon.tsx
+++ b/packages/react-icons/src/utils/fonts/createFluentFontIcon.tsx
@@ -85,7 +85,7 @@ export function createFluentFontIcon(displayName: string, codepoint: string, fon
 
 
         // We want to keep the same API surface as the SVG icons, so translate `primaryFill` to `color`
-        if (props.primaryFill) {
+        if (props.primaryFill && props.primaryFill.toLowerCase() !== 'currentcolor') {
             state.style = {
                 ...state.style,
                 color: props.primaryFill


### PR DESCRIPTION
This PR updates the logic for injecting the style tag to the font icons to only do so when `primaryFill` has an attribute that is not `currentColor`