### PR TITLE
Unify non-icon exports in svg/font indices

### DIFF
--- a/packages/react-icons/addRexportsToIndex.js
+++ b/packages/react-icons/addRexportsToIndex.js
@@ -3,7 +3,7 @@ module.exports = function addRexportsToIndex(indexContents, rootPath = `.`) {
     indexContents.push(`export { default as wrapIcon } from \'${rootPath}/utils/wrapIcon\'`);
     indexContents.push(`export { default as bundleIcon } from \'${rootPath}/utils/bundleIcon\'`);
     indexContents.push(`export { createFluentIcon } from \'${rootPath}/utils/createFluentIcon\'`);
-    indexContents.push(`export { createFluentFontIcon } from \'${rootPath}./utils/fonts/createFluentFontIcon\'`);
+    indexContents.push(`export { createFluentFontIcon } from \'${rootPath}/utils/fonts/createFluentFontIcon\'`);
     indexContents.push(`export type { FluentIcon } from \'${rootPath}/utils/createFluentIcon\'`);
     indexContents.push(`export * from \'${rootPath}/utils/useIconState\'`);
     indexContents.push(`export * from \'${rootPath}/utils/constants\'`);

--- a/packages/react-icons/addRexportsToIndex.js
+++ b/packages/react-icons/addRexportsToIndex.js
@@ -1,0 +1,12 @@
+module.exports = function addRexportsToIndex(indexContents) {
+    indexContents.push('export { FluentIconsProps } from \'./utils/FluentIconsProps.types\'');
+    indexContents.push('export { default as wrapIcon } from \'./utils/wrapIcon\'');
+    indexContents.push('export { default as bundleIcon } from \'./utils/bundleIcon\'');
+    indexContents.push('export { createFluentIcon } from \'./utils/createFluentIcon\'');
+    indexContents.push('export { createFluentFontIcon } from \'../utils/fonts/createFluentFontIcon\'');
+    indexContents.push('export type { FluentIcon } from \'./utils/createFluentIcon\'');
+    indexContents.push('export * from \'./utils/useIconState\'');
+    indexContents.push('export * from \'./utils/constants\'');
+    indexContents.push('export { IconDirectionContextProvider, useIconContext } from \'./contexts/index\'');
+    indexContents.push('export type { IconDirectionContextValue } from \'./contexts/index\'');
+}

--- a/packages/react-icons/addRexportsToIndex.js
+++ b/packages/react-icons/addRexportsToIndex.js
@@ -1,12 +1,12 @@
-module.exports = function addRexportsToIndex(indexContents) {
-    indexContents.push('export { FluentIconsProps } from \'./utils/FluentIconsProps.types\'');
-    indexContents.push('export { default as wrapIcon } from \'./utils/wrapIcon\'');
-    indexContents.push('export { default as bundleIcon } from \'./utils/bundleIcon\'');
-    indexContents.push('export { createFluentIcon } from \'./utils/createFluentIcon\'');
-    indexContents.push('export { createFluentFontIcon } from \'../utils/fonts/createFluentFontIcon\'');
-    indexContents.push('export type { FluentIcon } from \'./utils/createFluentIcon\'');
-    indexContents.push('export * from \'./utils/useIconState\'');
-    indexContents.push('export * from \'./utils/constants\'');
-    indexContents.push('export { IconDirectionContextProvider, useIconContext } from \'./contexts/index\'');
-    indexContents.push('export type { IconDirectionContextValue } from \'./contexts/index\'');
+module.exports = function addRexportsToIndex(indexContents, rootPath = `.`) {
+    indexContents.push(`export { FluentIconsProps } from \'${rootPath}/utils/FluentIconsProps.types\'`);
+    indexContents.push(`export { default as wrapIcon } from \'${rootPath}/utils/wrapIcon\'`);
+    indexContents.push(`export { default as bundleIcon } from \'${rootPath}/utils/bundleIcon\'`);
+    indexContents.push(`export { createFluentIcon } from \'${rootPath}/utils/createFluentIcon\'`);
+    indexContents.push(`export { createFluentFontIcon } from \'${rootPath}./utils/fonts/createFluentFontIcon\'`);
+    indexContents.push(`export type { FluentIcon } from \'${rootPath}/utils/createFluentIcon\'`);
+    indexContents.push(`export * from \'${rootPath}/utils/useIconState\'`);
+    indexContents.push(`export * from \'${rootPath}/utils/constants\'`);
+    indexContents.push(`export { IconDirectionContextProvider, useIconContext } from \'${rootPath}/contexts/index\'`);
+    indexContents.push(`export type { IconDirectionContextValue } from \'${rootPath}/contexts/index\'`);
 }

--- a/packages/react-icons/convert-font.js
+++ b/packages/react-icons/convert-font.js
@@ -12,6 +12,7 @@ const mkdirp = require('mkdirp');
 const { promisify } = require('util');
 const { option } = require("yargs");
 const glob = promisify(require('glob'));
+const addRexportsToIndex = require('./addRexportsToIndex');
 
 // @ts-ignore
 const SRC_PATH = argv.source;
@@ -69,15 +70,7 @@ async function processFiles(src, dest) {
 
   const indexPath = path.join(dest, 'index.tsx')
   // Finally add the interface definition and then write out the index.
-  indexContents.push('export { FluentIconsProps } from \'../utils/FluentIconsProps.types\'');
-  indexContents.push('export { default as wrapIcon } from \'../utils/wrapIcon\'');
-  indexContents.push('export { default as bundleIcon } from \'../utils/bundleIcon\'');
-  indexContents.push('export { createFluentFontIcon } from \'../utils/fonts/createFluentFontIcon\'');
-  indexContents.push('export type { FluentIcon } from \'../utils/createFluentIcon\'');
-  indexContents.push('export * from \'../utils/useIconState\'');
-  indexContents.push('export * from \'../utils/constants\'');
-  indexContents.push('export { IconDirectionContextProvider, useIconContext } from \'../contexts/index\'');
-  indexContents.push('export type { IconDirectionContextValue } from \'../contexts/index\'');
+  addRexportsToIndex(indexContents);
 
 
   await fs.writeFile(indexPath, indexContents.join('\n'));

--- a/packages/react-icons/convert-font.js
+++ b/packages/react-icons/convert-font.js
@@ -70,7 +70,7 @@ async function processFiles(src, dest) {
 
   const indexPath = path.join(dest, 'index.tsx')
   // Finally add the interface definition and then write out the index.
-  addRexportsToIndex(indexContents);
+  addRexportsToIndex(indexContents, '..');
 
 
   await fs.writeFile(indexPath, indexContents.join('\n'));

--- a/packages/react-icons/convert.js
+++ b/packages/react-icons/convert.js
@@ -5,6 +5,7 @@ const fs = require("fs");
 const path = require("path");
 const argv = require("yargs").boolean("selector").default("selector", false).argv;
 const _ = require("lodash");
+const addRexportsToIndex = require('./addRexportsToIndex');
 
 const SRC_PATH = argv.source;
 const DEST_PATH = argv.dest;
@@ -68,20 +69,11 @@ function processFiles(src, dest) {
 
   const indexPath = path.join(dest, 'index.tsx')
   // Finally add the interface definition and then write out the index.
-  indexContents.push('export { FluentIconsProps } from \'./utils/FluentIconsProps.types\'');
-  indexContents.push('export { default as wrapIcon } from \'./utils/wrapIcon\'');
-  indexContents.push('export { default as bundleIcon } from \'./utils/bundleIcon\'');
-  indexContents.push('export { createFluentIcon } from \'./utils/createFluentIcon\'');
-  indexContents.push('export type { FluentIcon } from \'./utils/createFluentIcon\'');
-  indexContents.push('export * from \'./utils/useIconState\'');
-  indexContents.push('export * from \'./utils/constants\'');
-  indexContents.push('export { IconDirectionContextProvider, useIconContext } from \'./contexts/index\'');
-  indexContents.push('export type { IconDirectionContextValue } from \'./contexts/index\'');
+  addRexportsToIndex(indexContents);
 
   fs.writeFileSync(indexPath, indexContents.join('\n'), (err) => {
     if (err) throw err;
   });
-
 }
 
 /**


### PR DESCRIPTION
There were some differences in re-exports from the normal (svg) and font-based index files (namely, `createFluentIcon`/`createFluentFontIcon`). This change unifies the non-icon re-exports from both index files to a single shared script.