### PR TITLE
Add providers to export map

### DIFF
--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -80,6 +80,11 @@
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "require": "./lib-cjs/index.js"
+    },
+    "./providers": {
+      "types": "./lib/providers.d.ts",
+      "import": "./lib/providers.js",
+      "require": "./lib-commonjs/providers.js"
     }
   }
 }

--- a/packages/react-icons/src/providers.ts
+++ b/packages/react-icons/src/providers.ts
@@ -1,0 +1,2 @@
+export { IconDirectionContextProvider, useIconContext } from './contexts/index';
+export type { IconDirectionContextValue } from './contexts/index';


### PR DESCRIPTION
This PR is to add a `providers` export to the `package.json` export maps. Part of https://github.com/microsoft/fluentui/issues/30909