### PR TITLE
Update export maps to include implicit exports

### DIFF
--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -71,10 +71,20 @@
         "require": "./lib-cjs/index.js"
       }
     },
+    "./fonts": {
+      "types": "./lib/fonts/index.d.ts",
+      "import": "./lib/fonts/index.js",
+      "require": "./lib-cjs/fonts/index.js"
+    },
     "./lib/fonts": {
       "types": "./lib/fonts/index.d.ts",
       "import": "./lib/fonts/index.js",
       "require": "./lib-cjs/fonts/index.js"
+    },
+    "./svg": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.js",
+      "require": "./lib-cjs/index.js"
     },
     "./lib/svg": {
       "types": "./lib/index.d.ts",
@@ -82,6 +92,11 @@
       "require": "./lib-cjs/index.js"
     },
     "./providers": {
+      "types": "./lib/providers.d.ts",
+      "import": "./lib/providers.js",
+      "require": "./lib-commonjs/providers.js"
+    },
+    "./lib/providers": {
       "types": "./lib/providers.d.ts",
       "import": "./lib/providers.js",
       "require": "./lib-commonjs/providers.js"


### PR DESCRIPTION
This PR is to add export maps to the `package.json` of react-icons.  Currently the svg icons and font icons export maps are `./lib/svg` and `./lib/fonts`. This adds an export map of `./svg` and `./fonts` for folks with the proper node resolution, and also adds `./lib/providers/` to the providers export map.