### PR TITLE
(fix): revert breaking bundleIcon change

### DIFF
--- a/packages/react-icons/src/utils/bundleIcon.tsx
+++ b/packages/react-icons/src/utils/bundleIcon.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
-import { iconFilledClassName, iconRegularClassName, iconLightClassName } from "./constants";
-import { FluentIconsProps } from "./FluentIconsProps.types";
+import { iconFilledClassName, iconRegularClassName } from "./constants";
 import { makeStyles, mergeClasses } from "@griffel/react";
 import { FluentIcon } from "./createFluentIcon";
 
@@ -9,7 +8,7 @@ const useBundledIconStyles = makeStyles({
     visible: { display: "inline" }
 });
 
-const bundleIcon = (FilledIcon: FluentIcon, RegularIcon: FluentIcon, LightIcon: FluentIcon) => {
+const bundleIcon = (FilledIcon: FluentIcon, RegularIcon: FluentIcon) => {
     const Component: FluentIcon = (props) => {
         const { className, filled, ...rest } = props;
         const styles = useBundledIconStyles();
@@ -30,15 +29,6 @@ const bundleIcon = (FilledIcon: FluentIcon, RegularIcon: FluentIcon, LightIcon: 
                       styles.root,
                       !filled && styles.visible,
                       iconRegularClassName,
-                      className
-                    )}
-                />
-                <LightIcon 
-                    {...rest}
-                    className={mergeClasses(
-                      styles.root,
-                      !filled && styles.visible,
-                      iconLightClassName,
                       className
                     )}
                 />


### PR DESCRIPTION
This PR reverts a change to the `bundleIcon` utility function introduced in #726. Light icons were introduced in the system-icons design repo, and integrated into the `react-icons` package build system, including the addition of `LightIcon` as a parameter in the `bundleIcon` utility function. This is a breaking change, as it was introduced as a required parameter, not an optional one. 

After this PR there will be a follow-up that will properly introduce the Light Icons into the `bundleIcon` utility, with a focus on maintaining the established functionality without increasing bundle size. 

Fixes #727 