### PR TITLE
Bump macOS deployment target for Cocoapods

### DIFF
--- a/ios/FluentIcons.podspec
+++ b/ios/FluentIcons.podspec
@@ -21,7 +21,7 @@ FluentIcons
   s.source           = { :git => 'https://github.com/microsoft/fluentui-system-icons.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '12.0'
-  s.osx.deployment_target  = '10.12'
+  s.osx.deployment_target  = '10.13'
 
   # This podspec is symlinked to the root directory of this repo
   # so all paths will need the prefix `ios/FluentIcons`


### PR DESCRIPTION
Cocoapods no longer supports macOS 10.12 so this PR updates the requirement in our Podspec.