### PR TITLE
Temporarily disable flutter job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -97,35 +97,36 @@ jobs:
       run: python3 generate_build_gn_android.py
       working-directory: importer
 
-  build-flutter:
-    name: Build Flutter library
-    runs-on: ubuntu-latest
+  # Disabling for now until the pipeline job is fixed
+  # build-flutter:
+  #   name: Build Flutter library
+  #   runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v2
+  #   steps:
+  #   - uses: actions/checkout@v2
 
-    - name: Use Node 18
-      uses: actions/setup-node@v1
-      with:
-        node-version: 18.x
+  #   - name: Use Node 18
+  #     uses: actions/setup-node@v1
+  #     with:
+  #       node-version: 18.x
 
-    - run: npm install
+  #   - run: npm install
 
-    - name: Run generate script
-      run: npm run deploy:flutter
-      working-directory: importer
+  #   - name: Run generate script
+  #     run: npm run deploy:flutter
+  #     working-directory: importer
 
-    # Build Flutter library
-    # The name should be same as the package name on pub.dev
-    # Tokens are placeholder strings in order for the action to run on forked repos.
-    - name: 'fluentui_system_icons'
-      uses: k-paxian/dart-package-publisher@master
-      with:
-        relativePath: 'flutter'
-        skipTests: true
-        dryRunOnly: true
-        accessToken: "placeholder"
-        refreshToken: "placeholder"
+  #   # Build Flutter library
+  #   # The name should be same as the package name on pub.dev
+  #   # Tokens are placeholder strings in order for the action to run on forked repos.
+  #   - name: 'fluentui_system_icons'
+  #     uses: k-paxian/dart-package-publisher@master
+  #     with:
+  #       relativePath: 'flutter'
+  #       skipTests: true
+  #       dryRunOnly: true
+  #       accessToken: "placeholder"
+  #       refreshToken: "placeholder"
 
   build-svg:
     name: Build svg library

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,18 +62,19 @@ jobs:
       working-directory: importer
 
     ## Flutter
-    - name: Run Flutter generate script
-      run: npm run deploy:flutter
-      working-directory: importer
+    # Disabling for now until the pipeline job is fixed
+    # - name: Run Flutter generate script
+    #   run: npm run deploy:flutter
+    #   working-directory: importer
 
-    # The name should be same as the package name on pub.dev
-    - name: 'fluentui_system_icons'
-      uses: k-paxian/dart-package-publisher@master
-      with:
-        relativePath: 'flutter'
-        skipTests: true
-        accessToken: ${{ secrets.FLUTTER_OAUTH_ACCESS_TOKEN }}
-        refreshToken: ${{ secrets.FLUTTER_OAUTH_REFRESH_TOKEN }}
+    # # The name should be same as the package name on pub.dev
+    # - name: 'fluentui_system_icons'
+    #   uses: k-paxian/dart-package-publisher@master
+    #   with:
+    #     relativePath: 'flutter'
+    #     skipTests: true
+    #     accessToken: ${{ secrets.FLUTTER_OAUTH_ACCESS_TOKEN }}
+    #     refreshToken: ${{ secrets.FLUTTER_OAUTH_REFRESH_TOKEN }}
 
     ## Publish
     # Needs to be "-E" instead of "-r" on macOS
@@ -94,17 +95,18 @@ jobs:
         sed -i.bk -r "s/[0-9]+\.[0-9]+\.[0-9]+/$NEW_VERSION/g" ios/FluentIcons.podspec
         rm ios/FluentIcons.podspec.bk
 
-    # Needs to be "-E" instead of "-r" on macOS
-    - name: Replace version number in flutter/CHANGELOG.md
-      run: |
-        sed -i.bk -r "s/[0-9]+\.[0-9]+\.[0-9]+/$NEW_VERSION/g" flutter/CHANGELOG.md
-        rm flutter/CHANGELOG.md.bk
+    # Disabling Flutter version updates for now until the pipeline is fixed
+    # # Needs to be "-E" instead of "-r" on macOS
+    # - name: Replace version number in flutter/CHANGELOG.md
+    #   run: |
+    #     sed -i.bk -r "s/[0-9]+\.[0-9]+\.[0-9]+/$NEW_VERSION/g" flutter/CHANGELOG.md
+    #     rm flutter/CHANGELOG.md.bk
 
-    # Needs to be "-E" instead of "-r" on macOS
-    - name: Replace version number in flutter/pubspec.yaml
-      run: |
-        sed -i.bk -r "s/version: [0-9]+\.[0-9]+\.[0-9]+/version: $NEW_VERSION/g" flutter/pubspec.yaml
-        rm flutter/pubspec.yaml.bk
+    # # Needs to be "-E" instead of "-r" on macOS
+    # - name: Replace version number in flutter/pubspec.yaml
+    #   run: |
+    #     sed -i.bk -r "s/version: [0-9]+\.[0-9]+\.[0-9]+/version: $NEW_VERSION/g" flutter/pubspec.yaml
+    #     rm flutter/pubspec.yaml.bk
 
     # Needs to be "-E" instead of "-r" on macOS
     - name: Replace version number in svg-icons/package.json


### PR DESCRIPTION
Both the pr and publish jobs are currently failing on the fluent step. This PR just temporarily disables it to unblock the other platforms.

PR: https://github.com/microsoft/fluentui-system-icons/actions/runs/13317570257/job/37195207303?pr=796
Publish: https://github.com/microsoft/fluentui-system-icons/actions/runs/13317351843/job/37194518533
