### PR TITLE
Add permission to create releases to publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
     if: "!contains(github.event.head_commit.author.email, 'flubuild@microsoft.com')"
     name: Publish icon libraries
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Our publish job no longer has permission to create releases. I believe this broke with an org change to limit the permissions for Github Actions.

<img width="664" alt="Screenshot 2025-02-24 at 11 59 47 AM" src="https://github.com/user-attachments/assets/c8089f68-5d29-4358-9bbc-a0a0e8f7a2e1" />

The recommended approach now is to add the necessary permissions for specific jobs. `contents: write` should be enough to push tags.