### PR TITLE
Reduce size of package brought in by react-native-icons to RN bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14947,7 +14947,7 @@
     },
     "packages/react-icons": {
       "name": "@fluentui/react-icons",
-      "version": "2.0.273",
+      "version": "2.0.278",
       "license": "MIT",
       "dependencies": {
         "@griffel/react": "^1.0.0",
@@ -14975,7 +14975,7 @@
     },
     "packages/react-icons-font-subsetting-webpack-plugin": {
       "name": "@fluentui/react-icons-font-subsetting-webpack-plugin",
-      "version": "2.0.273",
+      "version": "2.0.278",
       "license": "MIT",
       "dependencies": {
         "subset-font": "^1.4.0"
@@ -15065,10 +15065,9 @@
     },
     "packages/react-native-icons": {
       "name": "@fluentui/react-native-icons",
-      "version": "2.0.273",
+      "version": "2.0.278",
       "license": "MIT",
       "dependencies": {
-        "@griffel/react": "^1.0.0",
         "@types/react-native": "^0.68.0",
         "tslib": "^2.1.0"
       },
@@ -15077,7 +15076,6 @@
         "@babel/core": "^7.16.0",
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.16.7",
-        "@griffel/babel-preset": "^1.0.0",
         "@svgr/core": "^6.5.1",
         "@types/react": "^17.0.2",
         "cpy-cli": "^4.1.0",
@@ -15498,7 +15496,7 @@
     },
     "packages/svg-icons": {
       "name": "@fluentui/svg-icons",
-      "version": "1.1.273",
+      "version": "1.1.278",
       "license": "MIT",
       "devDependencies": {
         "renamer": "^2.0.1",
@@ -16939,8 +16937,6 @@
         "@babel/core": "^7.16.0",
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.16.7",
-        "@griffel/babel-preset": "^1.0.0",
-        "@griffel/react": "^1.0.0",
         "@svgr/core": "^6.5.1",
         "@types/react": "^17.0.2",
         "@types/react-native": "^0.68.0",

--- a/packages/react-native-icons/convert-rn.js
+++ b/packages/react-native-icons/convert-rn.js
@@ -16,7 +16,7 @@ const _ = require("lodash");
 const SRC_PATH = argv.source;
 const DEST_PATH = argv.dest;
 const REACT_NATIVE = argv.native;
-const TSX_EXTENSION = '.tsx'
+const exportNameRegex = /export const (\S*)/gm;
 
 const rnSvgElements = ['Path', 'Circle', 'Ellipse', 'G', 'Line', 'Polygon', 'Polyline', 'Rect', 'Symbol', 'Text', 'Use', 'Defs', 'LinearGradient', 'RadialGradient', 'Stop', 'ClipPath', 'Pattern', 'Mask'];
 
@@ -49,7 +49,8 @@ function processFiles(src, dest) {
   iconContents.forEach((chunk, i) => {
     const chunkFileName = `chunk-${i}`
     const chunkPath = path.resolve(iconPath, `${chunkFileName}.tsx`);
-    indexContents.push(`export * from './icons/${chunkFileName}'`);
+    const exportNames = Array.from(chunk.matchAll(exportNameRegex), m => m[1]);
+    indexContents.push(`export { ${exportNames.join(', ')} } from './icons/${chunkFileName}'`);
     fs.writeFileSync(chunkPath, chunk, (err) => {
       if (err) throw err;
     });
@@ -66,7 +67,8 @@ function processFiles(src, dest) {
   sizedIconContents.forEach((chunk, i) => {
     const chunkFileName = `chunk-${i}`
     const chunkPath = path.resolve(sizedIconPath, `${chunkFileName}.tsx`);
-    indexContents.push(`export * from './sizedIcons/${chunkFileName}'`);
+    const exportNames = Array.from(chunk.matchAll(exportNameRegex), m => m[1]);
+    indexContents.push(`export { ${exportNames.join(', ')} } from './sizedIcons/${chunkFileName}'`);
     fs.writeFileSync(chunkPath, chunk, (err) => {
       if (err) throw err;
     });
@@ -76,8 +78,7 @@ function processFiles(src, dest) {
   // Finally add the interface definition and then write out the index.
   indexContents.push('export { FluentIconsProps } from \'./utils/FluentIconsProps.types\'');
   indexContents.push('export { default as wrapIcon } from \'./utils/wrapIcon\'');
-  indexContents.push('export * from \'./utils/useIconState\'');
-  indexContents.push('export * from \'./utils/constants\'');
+  indexContents.push('export { useIconState } from \'./utils/useIconState\'');
 
   fs.writeFileSync(indexPath, indexContents.join('\n'), (err) => {
     if (err) throw err;

--- a/packages/react-native-icons/package.json
+++ b/packages/react-native-icons/package.json
@@ -17,7 +17,7 @@
     "copy": "node ../../importer/generate.js --source=../../assets --dest=./intermediate --extension=svg --target=react",
     "convert:rnsvg": "node ../react-native-icons/convert-rn.js --source=./intermediate --dest=./src --native=true",
     "rollup": "node ./generateRollup.js",
-    "optimize": "svgo --config svgo.config.js --folder=./intermediate --precision=2",
+    "optimize": "svgo --config svgo.config.js --folder=./intermediate --precision=2 --quiet",
     "unfill": "find ./intermediate -type f -name \"*.svg\" -exec sed -i.bak 's/fill=\"none\"//g' {} \\; && find ./intermediate -type f -name \"*.bak\" -delete",
     "build": "npm run copy && npm run optimize && npm run unfill && npm run convert:rnsvg && npm run cleanSvg && npm run build:esm && npm run build:cjs",
     "build:cjs": "tsc --module commonjs --outDir lib-cjs && babel lib-cjs --out-dir lib-cjs",
@@ -28,7 +28,6 @@
     "@babel/core": "^7.16.0",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.16.7",
-    "@griffel/babel-preset": "^1.0.0",
     "@svgr/core": "^6.5.1",
     "@types/react": "^17.0.2",
     "cpy-cli": "^4.1.0",
@@ -43,7 +42,6 @@
     "yargs": "^14.0.0"
   },
   "dependencies": {
-    "@griffel/react": "^1.0.0",
     "@types/react-native": "^0.68.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-native-icons/src/utils/FluentIconsProps.types.ts
+++ b/packages/react-native-icons/src/utils/FluentIconsProps.types.ts
@@ -1,8 +1,8 @@
-import * as React from "react";
+import type { ColorValue, TextProps } from "react-native";
+import type { SvgProps } from "react-native-svg";
 
-export type FluentIconsProps<TBaseAttributes extends (React.SVGAttributes<SVGElement> | React.HTMLAttributes<HTMLElement>) = React.SVGAttributes<SVGElement>> = (TBaseAttributes) & {
-	primaryFill?: string
-	className?: string
+export type FluentIconsProps<TBaseAttributes extends (SvgProps | TextProps) = SvgProps> = (TBaseAttributes) & {
+	primaryFill?: ColorValue
 	filled?: boolean
 	title?: string
 }

--- a/packages/react-native-icons/src/utils/constants.tsx
+++ b/packages/react-native-icons/src/utils/constants.tsx
@@ -1,3 +1,0 @@
-export const iconFilledClassName = "fui-Icon-filled";
-export const iconRegularClassName = "fui-Icon-regular";
-export const iconLightClassName = "fui-Icon-light";

--- a/packages/react-native-icons/src/utils/fonts/createFluentFontIcon.tsx
+++ b/packages/react-native-icons/src/utils/fonts/createFluentFontIcon.tsx
@@ -1,23 +1,28 @@
 import * as React from 'react';
-import { FluentIconsProps } from '../FluentIconsProps.types';
-import { makeStyles, makeStaticStyles, mergeClasses } from "@griffel/react";
+import type { FluentIconsProps } from '../FluentIconsProps.types';
+import type { TextProps } from 'react-native';
+import { Text } from 'react-native';
 import { useIconState } from '../useIconState';
 
-import fontFilledTtf from './FluentSystemIcons-Filled.ttf';
-import fontFilledWoff from './FluentSystemIcons-Filled.woff';
-import fontFilledWoff2 from './FluentSystemIcons-Filled.woff2';
+// Comment out font work for RN - it's currently using
+// web-specific logic and not being exported to the RN package,
+// but good to have this here for future reference
 
-import fontRegularTtf from './FluentSystemIcons-Regular.ttf';
-import fontRegularWoff from './FluentSystemIcons-Regular.woff';
-import fontRegularWoff2 from './FluentSystemIcons-Regular.woff2';
+// import fontFilledTtf from './FluentSystemIcons-Filled.ttf';
+// import fontFilledWoff from './FluentSystemIcons-Filled.woff';
+// import fontFilledWoff2 from './FluentSystemIcons-Filled.woff2';
 
-import fontLightTtf from './FluentSystemIcons-Light.ttf';
-import fontLightWoff from './FluentSystemIcons-Light.woff';
-import fontLightWoff2 from './FluentSystemIcons-Light.woff2';
+// import fontRegularTtf from './FluentSystemIcons-Regular.ttf';
+// import fontRegularWoff from './FluentSystemIcons-Regular.woff';
+// import fontRegularWoff2 from './FluentSystemIcons-Regular.woff2';
 
-import fontOneSizeTtf from './FluentSystemIcons-Resizable.ttf';
-import fontOneSizeWoff from './FluentSystemIcons-Resizable.woff';
-import fontOneSizeWoff2 from './FluentSystemIcons-Resizable.woff2';
+// import fontLightTtf from './FluentSystemIcons-Light.ttf';
+// import fontLightWoff from './FluentSystemIcons-Light.woff';
+// import fontLightWoff2 from './FluentSystemIcons-Light.woff2';
+
+// import fontOneSizeTtf from './FluentSystemIcons-Resizable.ttf';
+// import fontOneSizeWoff from './FluentSystemIcons-Resizable.woff';
+// import fontOneSizeWoff2 from './FluentSystemIcons-Resizable.woff2';
 
 export const enum FontFile {
     Filled = 0,
@@ -26,89 +31,83 @@ export const enum FontFile {
     Light = 3
 }
 
-const FONT_FAMILY_MAP = {
-    [FontFile.Filled]: 'FluentSystemIconsFilled',
-    [FontFile.Regular]: 'FluentSystemIconsRegular',
-    [FontFile.Resizable]: 'FluentSystemIcons',
-} as const;
+// const FONT_FAMILY_MAP = {
+//     [FontFile.Filled]: 'FluentSystemIconsFilled',
+//     [FontFile.Regular]: 'FluentSystemIconsRegular',
+//     [FontFile.Resizable]: 'FluentSystemIcons',
+// } as const;
 
-const useStaticStyles = makeStaticStyles(`
-@font-face {
-    font-family: ${FONT_FAMILY_MAP[FontFile.Filled]};
-    src: url(${JSON.stringify(fontFilledWoff2)}) format("woff2"),
-    url(${JSON.stringify(fontFilledWoff)}) format("woff"),
-    url(${JSON.stringify(fontFilledTtf)}) format("truetype");
-}
-@font-face {
-    font-family: ${FONT_FAMILY_MAP[FontFile.Regular]};
-    src: url(${JSON.stringify(fontRegularWoff2)}) format("woff2"),
-    url(${JSON.stringify(fontRegularWoff)}) format("woff"),
-    url(${JSON.stringify(fontRegularTtf)}) format("truetype");
-}
+// const useStaticStyles = makeStaticStyles(`
+// @font-face {
+//     font-family: ${FONT_FAMILY_MAP[FontFile.Filled]};
+//     src: url(${JSON.stringify(fontFilledWoff2)}) format("woff2"),
+//     url(${JSON.stringify(fontFilledWoff)}) format("woff"),
+//     url(${JSON.stringify(fontFilledTtf)}) format("truetype");
+// }
+// @font-face {
+//     font-family: ${FONT_FAMILY_MAP[FontFile.Regular]};
+//     src: url(${JSON.stringify(fontRegularWoff2)}) format("woff2"),
+//     url(${JSON.stringify(fontRegularWoff)}) format("woff"),
+//     url(${JSON.stringify(fontRegularTtf)}) format("truetype");
+// }
 
-@font-face {
-    font-family: ${FONT_FAMILY_MAP[FontFile.Light]};
-    src: url(${JSON.stringify(fontLightWoff2)}) format("woff2"),
-    url(${JSON.stringify(fontLightWoff)}) format("woff"),
-    url(${JSON.stringify(fontLightTtf)}) format("truetype");
-}
+// @font-face {
+//     font-family: ${FONT_FAMILY_MAP[FontFile.Light]};
+//     src: url(${JSON.stringify(fontLightWoff2)}) format("woff2"),
+//     url(${JSON.stringify(fontLightWoff)}) format("woff"),
+//     url(${JSON.stringify(fontLightTtf)}) format("truetype");
+// }
 
-@font-face {
-    font-family: ${FONT_FAMILY_MAP[FontFile.Resizable]};
-    src: url(${JSON.stringify(fontOneSizeWoff2)}) format("woff2"),
-    url(${JSON.stringify(fontOneSizeWoff)}) format("woff"),
-    url(${JSON.stringify(fontOneSizeTtf)}) format("truetype");
-}
-`)
+// @font-face {
+//     font-family: ${FONT_FAMILY_MAP[FontFile.Resizable]};
+//     src: url(${JSON.stringify(fontOneSizeWoff2)}) format("woff2"),
+//     url(${JSON.stringify(fontOneSizeWoff)}) format("woff"),
+//     url(${JSON.stringify(fontOneSizeTtf)}) format("truetype");
+// }
+// `)
 
-const useRootStyles = makeStyles({
-    root: {
-        display: 'inline-block',
-        fontStyle: 'normal',
-        lineHeight: '1em',
+// const useRootStyles = makeStyles({
+//     root: {
+//         display: 'inline-block',
+//         fontStyle: 'normal',
+//         lineHeight: '1em',
 
-        "@media (forced-colors: active)": {
-            forcedColorAdjust: 'auto',
+//         "@media (forced-colors: active)": {
+//             forcedColorAdjust: 'auto',
+//         }
+//     },
+//     [FontFile.Filled]: {
+//         fontFamily: 'FluentSystemIconsFilled',
+//     },
+//     [FontFile.Regular]: {
+//         fontFamily: 'FluentSystemIconsRegular',
+//     },
+//     [FontFile.Resizable]: {
+//         fontFamily: 'FluentSystemIcons',
+//     },
+//     [FontFile.Light]: {
+//         fontFamily: 'FluentSystemIconsLight',
+//     }
+// });
+
+export function createFluentFontIcon(displayName: string, codepoint: string, _font: FontFile, fontSize?: number): React.FC<FluentIconsProps<TextProps>> & { codepoint: string} {
+    const Component: React.FC<FluentIconsProps<TextProps>> & { codepoint: string} = (props) => {
+        const state = useIconState<TextProps>(props);
+
+        if (state.style == undefined && (props.primaryFill || fontSize)) {
+            state.style = {};
         }
-    },
-    [FontFile.Filled]: {
-        fontFamily: 'FluentSystemIconsFilled',
-    },
-    [FontFile.Regular]: {
-        fontFamily: 'FluentSystemIconsRegular',
-    },
-    [FontFile.Resizable]: {
-        fontFamily: 'FluentSystemIcons',
-    },
-    [FontFile.Light]: {
-        fontFamily: 'FluentSystemIconsLight',
-    }
-});
-
-export function createFluentFontIcon(displayName: string, codepoint: string, font: FontFile, fontSize?: number): React.FC<FluentIconsProps<React.HTMLAttributes<HTMLElement>>> & { codepoint: string} {
-    const Component: React.FC<FluentIconsProps<React.HTMLAttributes<HTMLElement>>> & { codepoint: string} = (props) => {
-        useStaticStyles();
-        const styles = useRootStyles();
-        const className = mergeClasses(styles.root, styles[font], props.className);
-        const state = useIconState<React.HTMLAttributes<HTMLElement>>({...props, className});
-
 
         // We want to keep the same API surface as the SVG icons, so translate `primaryFill` to `color`
         if (props.primaryFill) {
-            state.style = {
-                ...state.style,
-                color: props.primaryFill
-            }
+            state.style['color'] = props.primaryFill;
         }
 
         if (fontSize) {
-            state.style = {
-                ...state.style,
-                fontSize
-            }
+            state.style['fontSize'] = fontSize;
         }
 
-        return <i {...state}>{codepoint}</i>
+        return <Text {...state}>{codepoint}</Text>
     }
     Component.displayName = displayName;
     Component.codepoint = codepoint;

--- a/packages/react-native-icons/src/utils/useIconState.tsx
+++ b/packages/react-native-icons/src/utils/useIconState.tsx
@@ -1,28 +1,14 @@
-import { FluentIconsProps } from "./FluentIconsProps.types";
-import { makeStyles, mergeClasses } from "@griffel/react";
+import type { SvgProps } from "react-native-svg";
+import type { FluentIconsProps } from "./FluentIconsProps.types";
+import type { TextProps } from "react-native";
 
-const useRootStyles = makeStyles({
-    root: {
-        display: 'inline',
-        lineHeight: 0,
-
-        "@media (forced-colors: active)": {
-          forcedColorAdjust: 'auto',
-        }
-    }
-});
-
-export const useIconState = <TBaseAttributes extends (React.SVGAttributes<SVGElement> | React.HTMLAttributes<HTMLElement>) = React.SVGAttributes<SVGElement>>(props: FluentIconsProps<TBaseAttributes>): Omit<FluentIconsProps<TBaseAttributes>, 'primaryFill'> => {
+export const useIconState = <TBaseAttributes extends (SvgProps | TextProps) = SvgProps>(props: FluentIconsProps<TBaseAttributes>): Omit<FluentIconsProps<TBaseAttributes>, 'primaryFill'> => {
     const { title, primaryFill = "currentColor", ...rest } = props;
     const state = {
       ...rest,
       title: undefined,
       fill: primaryFill
     } as Omit<FluentIconsProps<TBaseAttributes>, 'primaryFill'>;
-  
-    const styles = useRootStyles();
-  
-    state.className = mergeClasses(styles.root, state.className);
   
     if (title) {
       state['aria-label'] = title;


### PR DESCRIPTION
We would like to support using this package in React Native scenarios in order to pull icons from a centralized place.
Unfortunately, due to how the exports of the package are currently set up, the package ends up pulling in information about all the chunks exported by the package and adding a lot of bloat. Specifically, `export *` causes problems for esbuild's tree shaking, so instead we should be exporting all the icons by name instead.

Additionally, some of the logic and typings in the package are not necessary for React Native scenarios or do not align with React Native usage, so I am fixing those up too. This also allows removing the griffel styling package and using PlatformColors, needed for HC scenarios.

Reduction in package size that gets pulled in from adding the @fluentui/react-native-icons package from what I've seen in the release bundle is about 30KB.