### PR TITLE
Fix peerDependencies of react-native-icons

### DIFF
--- a/packages/react-native-icons/package.json
+++ b/packages/react-native-icons/package.json
@@ -47,6 +47,7 @@
   },
   "peerDependencies": {
     "react": ">=16.8.0 <19.0.0",
+    "react-native": ">=0.68.0",
     "react-native-svg": ">=12.5.0"
   },
   "files": [


### PR DESCRIPTION
React-native should be declared as a peerDependency of react-native-icons package.