### PR TITLE
Fix `cleanupIds` option in svgo.config.js

### DIFF
--- a/packages/svg-icons/svgo.config.js
+++ b/packages/svg-icons/svgo.config.js
@@ -6,7 +6,7 @@ module.exports = {
         overrides: {
           removeViewBox: false,
           mergePaths: false,
-          cleanupIDs: false
+          cleanupIds: false
         },
       },
     },


### PR DESCRIPTION
The current version of SVGO config causes an error during the build:

```
You are trying to configure cleanupIDs which is not part of preset-default.
Try to put it before or after, for example

plugins: [
  {
    name: 'preset-default',
  },
  'cleanupIDs'
]
```

This is due to the fact that `cleanupIDs` is misspelled. It should be `cleanupIds`, as per the [SVGO docs](https://github.com/svg/svgo?tab=readme-ov-file#default-preset).

This PR fixes the issue.