### PR TITLE
Xuehua/GitHub app integration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -276,8 +276,7 @@ jobs:
 
     - name: Push release
       run: |
-        REMOTE_REPO="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-        git push $REMOTE_REPO HEAD:main --follow-tags --tags
+        git push origin HEAD:main --follow-tags --tags
 
   # publish-android-demo:
   #   name: Publish Android demo app

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,16 @@ jobs:
       actions: write
 
     steps:
+    - name: Generate a token
+      id: generate-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.GH_FLUENT_CI_APP_ID }}
+        private-key: ${{ secrets.GH_FLUENT_CI_PRIVATE_KEY }}
+
     - uses: actions/checkout@v2
       with:
-        token: ${{ secrets.CI_GITHUB_TOKEN }}
+        token: ${{ steps.generate-token.outputs.token }}
 
     - name: Bump version patch
       run: |


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/publish.yml` file to enhance the security and efficiency of the CI workflow.

Security and efficiency improvements:

* Added a step to generate a GitHub App token using the `actions/create-github-app-token@v1` action, which replaces the usage of a static token with a dynamically generated one. (`.github/workflows/publish.yml`)
* Updated the `actions/checkout@v2` step to use the newly generated token instead of a static token. (`.github/workflows/publish.yml`)
* Simplified the `Push release` step by removing the explicit remote repository URL and using `git push origin` instead. (`.github/workflows/publish.yml`)