### PR TITLE
Bumping version to .294

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ repositories {
 Include the following dependency in your project's `build.gradle`:
 
 ```groovy
-implementation 'com.microsoft.design:fluent-system-icons:1.1.293@aar'
+implementation 'com.microsoft.design:fluent-system-icons:1.1.294@aar'
 ```
 
 For library docs, see [android/README.md](android/README.md).
@@ -48,13 +48,13 @@ For library docs, see [android/README.md](android/README.md).
 ```ruby
 use_frameworks!
 
-pod "FluentIcons", "1.1.293"
+pod "FluentIcons", "1.1.294"
 ```
 
 #### Carthage
 
 ```bash
-git "git@github.com:microsoft/fluentui-system-icons.git" "1.1.293"
+git "git@github.com:microsoft/fluentui-system-icons.git" "1.1.294"
 ```
 
 For library docs, see [ios/README.md](ios/README.md).
@@ -66,7 +66,7 @@ In the `pubspec.yaml` of your flutter project, add the following dependency:
 ```yaml
 dependencies:
   ...
-  fluentui_system_icons: ^1.1.293
+  fluentui_system_icons: ^1.1.294
 ```
 
 For library docs, see [flutter/README.md](flutter/README.md).

--- a/flutter/CHANGELOG.md
+++ b/flutter/CHANGELOG.md
@@ -1,1 +1,1 @@
-## [1.1.293] - Complete change log present here https://github.com/microsoft/fluentui-system-icons/tags
+## [1.1.294] - Complete change log present here https://github.com/microsoft/fluentui-system-icons/tags

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluentui_system_icons
 description: Fluent UI System Icons are a collection of familiar, friendly and modern icons from Microsoft.
-version: 1.1.293
+version: 1.1.294
 homepage: https://github.com/microsoft/fluentui-system-icons/tree/main
 
 environment:

--- a/ios/FluentIcons.podspec
+++ b/ios/FluentIcons.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'FluentIcons'
-  s.version          = '1.1.293'
+  s.version          = '1.1.294'
   s.summary          = 'FluentIcons'
 
   s.description      = <<-DESC

--- a/ios/README.md
+++ b/ios/README.md
@@ -6,13 +6,13 @@
 
 ```ruby
 use_frameworks!
-pod "FluentIcons", "1.1.293"
+pod "FluentIcons", "1.1.294"
 ```
 
 ### Carthage
 
 ```bash
-git "git@github.com:microsoft/fluentui-system-icons.git" "1.1.293"
+git "git@github.com:microsoft/fluentui-system-icons.git" "1.1.294"
 ```
 
 ## Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -15496,7 +15496,7 @@
     },
     "packages/svg-icons": {
       "name": "@fluentui/svg-icons",
-      "version": "1.1.293",
+      "version": "1.1.294",
       "license": "MIT",
       "devDependencies": {
         "renamer": "^2.0.1",
@@ -15566,7 +15566,7 @@
     },
     "packages/svg-sprites": {
       "name": "@fluentui/svg-sprites",
-      "version": "1.1.293",
+      "version": "1.1.294",
       "license": "MIT",
       "devDependencies": {
         "renamer": "^2.0.1",

--- a/packages/react-icons-font-subsetting-webpack-plugin/package.json
+++ b/packages/react-icons-font-subsetting-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-icons-font-subsetting-webpack-plugin",
-  "version": "2.0.293",
+  "version": "2.0.294",
   "description": "Webpack plugin to subset the icon fonts used by @fluentui/react-icons based on which icons are used.",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-icons",
-  "version": "2.0.293",
+  "version": "2.0.294",
   "sideEffects": false,
   "main": "lib-cjs/index.js",
   "module": "lib/index.js",

--- a/packages/react-native-icons/package.json
+++ b/packages/react-native-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-native-icons",
-  "version": "2.0.293",
+  "version": "2.0.294",
   "sideEffects": false,
   "main": "lib-cjs/index.js",
   "module": "lib/index.js",

--- a/packages/svg-icons/package.json
+++ b/packages/svg-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/svg-icons",
-  "version": "1.1.293",
+  "version": "1.1.294",
   "description": "Fluent System Icons are a collection of familiar, friendly, and modern icons from Microsoft.",
   "license": "MIT",
   "repository": {

--- a/packages/svg-sprites/package.json
+++ b/packages/svg-sprites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/svg-sprites",
-  "version": "1.1.293",
+  "version": "1.1.294",
   "description": "Fluent System Icons are a collection of familiar, friendly, and modern icons from Microsoft.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This pull request includes several version updates across various files to upgrade the `fluent-system-icons` library from version `1.1.293` to `1.1.294`. The most important changes are as follows:

Version updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R39): Updated the dependency versions for `gradle`, `ruby`, and `flutter` examples to `1.1.294`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R39) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-R57) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R69)
* [`flutter/CHANGELOG.md`](diffhunk://#diff-261f88497644be892c94d7d5e6d62cfb38596901f58fbb1fdbf560f34713388eL1-R1): Updated the version number in the changelog to `1.1.294`.
* [`flutter/pubspec.yaml`](diffhunk://#diff-c0a78019e56374c596e5fa15cdac3a297f4ab052de3615e91c156d1aba6c5e8bL3-R3): Updated the package version to `1.1.294`.
* [`ios/FluentIcons.podspec`](diffhunk://#diff-2251ea5fe25bbb02b72c4c8d1d0e2b40d099f855aecaa92e6a66b0388ac55b8eL11-R11): Updated the podspec version to `1.1.294`.
* `packages/react-icons-font-subsetting-webpack-plugin/package.json`, `packages/react-icons/package.json`, `packages/react-native-icons/package.json`, `packages/svg-icons/package.json`, `packages/svg-sprites/package.json`: Updated the package versions to `1.1.294`. [[1]](diffhunk://#diff-ad55b4d1b7eae649393ab9626b6330bc3a964a2b2597a956912b4783248e5cf2L3-R3) [[2]](diffhunk://#diff-0b58898192f3a93bd457e0d2b375c2332892ac70a93dafce4607816fec786d0fL3-R3) [[3]](diffhunk://#diff-1d9c1d8b93e969c1588fe05756c3ae3164142f99b6c1765af24e0988208c0b8dL3-R3) [[4]](diffhunk://#diff-d113c2c6db4069206963879c54517af5c08ec67da8fb10d48c3b2c04f166a647L3-R3) [[5]](diffhunk://#diff-db96728d2d3c85c5f6be0d80732b45ec0d76be1bbb7f40a3abf422fae77e8a95L3-R3)