### PR TITLE
feat(react-icons): improve .d.ts performance and emit time. introduce FluentFontIcon prop as public api

### DIFF
--- a/packages/react-icons/build-verify.test.js
+++ b/packages/react-icons/build-verify.test.js
@@ -423,14 +423,14 @@ describe('Build Verification', () => {
         export * from './sizedIcons/chunk-17';
         export * from './sizedIcons/chunk-18';
         export * from './sizedIcons/chunk-19';
-        export { FluentIconsProps } from './utils/FluentIconsProps.types';
         export { default as wrapIcon } from './utils/wrapIcon';
         export { default as bundleIcon } from './utils/bundleIcon';
         export { createFluentIcon } from './utils/createFluentIcon';
-        export type { FluentIcon } from './utils/createFluentIcon';
         export * from './utils/useIconState';
         export * from './utils/constants';
         export { IconDirectionContextProvider, useIconContext } from './contexts/index';
+        export type { FluentIconsProps } from './utils/FluentIconsProps.types';
+        export type { FluentIcon } from './utils/createFluentIcon';
         export type { IconDirectionContextValue } from './contexts/index';
         "
       `);
@@ -539,14 +539,14 @@ describe('Build Verification', () => {
         export * from './sizedIcons/chunk-17';
         export * from './sizedIcons/chunk-18';
         export * from './sizedIcons/chunk-19';
-        export { FluentIconsProps } from './utils/FluentIconsProps.types';
         export { default as wrapIcon } from './utils/wrapIcon';
         export { default as bundleIcon } from './utils/bundleIcon';
         export { createFluentIcon } from './utils/createFluentIcon';
-        export type { FluentIcon } from './utils/createFluentIcon';
         export * from './utils/useIconState';
         export * from './utils/constants';
         export { IconDirectionContextProvider, useIconContext } from './contexts/index';
+        export type { FluentIconsProps } from './utils/FluentIconsProps.types';
+        export type { FluentIcon } from './utils/createFluentIcon';
         export type { IconDirectionContextValue } from './contexts/index';
         "
       `)
@@ -664,15 +664,16 @@ describe('Build Verification', () => {
         export * from './sizedIcons/chunk-34';
         export * from './sizedIcons/chunk-35';
         export * from './sizedIcons/chunk-36';
-        export { FluentIconsProps } from '../utils/FluentIconsProps.types';
         export { default as wrapIcon } from '../utils/wrapIcon';
         export { default as bundleIcon } from '../utils/bundleIcon';
         export { createFluentIcon } from '../utils/createFluentIcon';
         export { createFluentFontIcon } from '../utils/fonts/createFluentFontIcon';
-        export type { FluentIcon } from '../utils/createFluentIcon';
         export * from '../utils/useIconState';
         export * from '../utils/constants';
         export { IconDirectionContextProvider, useIconContext } from '../contexts/index';
+        export type { FluentIconsProps } from '../utils/FluentIconsProps.types';
+        export type { FluentIcon } from '../utils/createFluentIcon';
+        export type { FluentFontIcon } from '../utils/fonts/createFluentFontIcon';
         export type { IconDirectionContextValue } from '../contexts/index';
         "
       `);
@@ -833,15 +834,16 @@ describe('Build Verification', () => {
         export * from './sizedIcons/chunk-34';
         export * from './sizedIcons/chunk-35';
         export * from './sizedIcons/chunk-36';
-        export { FluentIconsProps } from '../utils/FluentIconsProps.types';
         export { default as wrapIcon } from '../utils/wrapIcon';
         export { default as bundleIcon } from '../utils/bundleIcon';
         export { createFluentIcon } from '../utils/createFluentIcon';
         export { createFluentFontIcon } from '../utils/fonts/createFluentFontIcon';
-        export type { FluentIcon } from '../utils/createFluentIcon';
         export * from '../utils/useIconState';
         export * from '../utils/constants';
         export { IconDirectionContextProvider, useIconContext } from '../contexts/index';
+        export type { FluentIconsProps } from '../utils/FluentIconsProps.types';
+        export type { FluentIcon } from '../utils/createFluentIcon';
+        export type { FluentFontIcon } from '../utils/fonts/createFluentFontIcon';
         export type { IconDirectionContextValue } from '../contexts/index';
         "
       `)
@@ -1267,36 +1269,36 @@ describe('Build Verification', () => {
         const dtsContent = await readFile(dtsFile, 'utf8');
         const trimmedDTSContent = trimContentForSnapshot(dtsContent);
         expect(trimmedDTSContent).toMatchInlineSnapshot(`
-          "export declare const AccessTimeFilled: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessTimeRegular: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessibilityFilled: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessibilityRegular: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessibilityCheckmarkFilled: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessibilityCheckmarkRegular: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessibilityErrorFilled: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessibilityErrorRegular: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessibilityMoreFilled: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessibilityMoreRegular: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
+          "import type { FluentFontIcon } from "../../utils/fonts/createFluentFontIcon";
+          export declare const AccessTimeFilled: FluentFontIcon;
+          export declare const AccessTimeRegular: FluentFontIcon;
+          export declare const AccessibilityFilled: FluentFontIcon;
+          export declare const AccessibilityRegular: FluentFontIcon;
+          export declare const AccessibilityCheckmarkFilled: FluentFontIcon;
+          export declare const AccessibilityCheckmarkRegular: FluentFontIcon;
+          export declare const AccessibilityErrorFilled: FluentFontIcon;
+          export declare const AccessibilityErrorRegular: FluentFontIcon;
+          export declare const AccessibilityMoreFilled: FluentFontIcon;
+          export declare const AccessibilityMoreRegular: FluentFontIcon;
+          export declare const AccessibilityQuestionMarkFilled: FluentFontIcon;
+          export declare const AccessibilityQuestionMarkRegular: FluentFontIcon;
+          export declare const AddFilled: FluentFontIcon;
+          export declare const AddRegular: FluentFontIcon;
+          export declare const AddCircleFilled: FluentFontIcon;
+          export declare const AddCircleRegular: FluentFontIcon;
+          export declare const AddSquareFilled: FluentFontIcon;
+          export declare const AddSquareRegular: FluentFontIcon;
+          export declare const AddSquareMultipleFilled: FluentFontIcon;
+          export declare const AddSquareMultipleRegular: FluentFontIcon;
+          export declare const AddStarburstFilled: FluentFontIcon;
+          export declare const AddStarburstRegular: FluentFontIcon;
+          export declare const AddSubtractCircleFilled: FluentFontIcon;
+          export declare const AddSubtractCircleRegular: FluentFontIcon;
+          export declare const AgentsFilled: FluentFontIcon;
+          export declare const AgentsRegular: FluentFontIcon;
+          export declare const AgentsAddFilled: FluentFontIcon;
+          export declare const AgentsAddRegular: FluentFontIcon;
+          export declare const AirplaneFilled: FluentFontIcon;
           ... (content truncated for snapshot)"
         `);
       }
@@ -1358,36 +1360,36 @@ describe('Build Verification', () => {
         const dtsContent = await readFile(dtsFile, 'utf8');
         const trimmedDTSContent = trimContentForSnapshot(dtsContent);
         expect(trimmedDTSContent).toMatchInlineSnapshot(`
-          "export declare const AccessTimeFilled: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessTimeRegular: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessibilityFilled: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessibilityRegular: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessibilityCheckmarkFilled: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessibilityCheckmarkRegular: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessibilityErrorFilled: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessibilityErrorRegular: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessibilityMoreFilled: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AccessibilityMoreRegular: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
+          "import type { FluentFontIcon } from "../../utils/fonts/createFluentFontIcon";
+          export declare const AccessTimeFilled: FluentFontIcon;
+          export declare const AccessTimeRegular: FluentFontIcon;
+          export declare const AccessibilityFilled: FluentFontIcon;
+          export declare const AccessibilityRegular: FluentFontIcon;
+          export declare const AccessibilityCheckmarkFilled: FluentFontIcon;
+          export declare const AccessibilityCheckmarkRegular: FluentFontIcon;
+          export declare const AccessibilityErrorFilled: FluentFontIcon;
+          export declare const AccessibilityErrorRegular: FluentFontIcon;
+          export declare const AccessibilityMoreFilled: FluentFontIcon;
+          export declare const AccessibilityMoreRegular: FluentFontIcon;
+          export declare const AccessibilityQuestionMarkFilled: FluentFontIcon;
+          export declare const AccessibilityQuestionMarkRegular: FluentFontIcon;
+          export declare const AddFilled: FluentFontIcon;
+          export declare const AddRegular: FluentFontIcon;
+          export declare const AddCircleFilled: FluentFontIcon;
+          export declare const AddCircleRegular: FluentFontIcon;
+          export declare const AddSquareFilled: FluentFontIcon;
+          export declare const AddSquareRegular: FluentFontIcon;
+          export declare const AddSquareMultipleFilled: FluentFontIcon;
+          export declare const AddSquareMultipleRegular: FluentFontIcon;
+          export declare const AddStarburstFilled: FluentFontIcon;
+          export declare const AddStarburstRegular: FluentFontIcon;
+          export declare const AddSubtractCircleFilled: FluentFontIcon;
+          export declare const AddSubtractCircleRegular: FluentFontIcon;
+          export declare const AgentsFilled: FluentFontIcon;
+          export declare const AgentsRegular: FluentFontIcon;
+          export declare const AgentsAddFilled: FluentFontIcon;
+          export declare const AgentsAddRegular: FluentFontIcon;
+          export declare const AirplaneFilled: FluentFontIcon;
           ... (content truncated for snapshot)"
         `);
       }
@@ -1449,36 +1451,36 @@ describe('Build Verification', () => {
         const dtsContent = await readFile(dtsFile, 'utf8');
         const trimmedDTSContent = trimContentForSnapshot(dtsContent);
         expect(trimmedDTSContent).toMatchInlineSnapshot(`
-          "export declare const AccessibilityCheckmark32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const Add32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const Alert32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AppFolder32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AppGeneric32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const Archive32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const ArchiveSettings32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const ArrowClockwise32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const ArrowDown32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const ArrowDownload32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
+          "import type { FluentFontIcon } from "../../utils/fonts/createFluentFontIcon";
+          export declare const AccessibilityCheckmark32Light: FluentFontIcon;
+          export declare const Add32Light: FluentFontIcon;
+          export declare const Alert32Light: FluentFontIcon;
+          export declare const AppFolder32Light: FluentFontIcon;
+          export declare const AppGeneric32Light: FluentFontIcon;
+          export declare const Archive32Light: FluentFontIcon;
+          export declare const ArchiveSettings32Light: FluentFontIcon;
+          export declare const ArrowClockwise32Light: FluentFontIcon;
+          export declare const ArrowDown32Light: FluentFontIcon;
+          export declare const ArrowDownload32Light: FluentFontIcon;
+          export declare const ArrowForward32Light: FluentFontIcon;
+          export declare const ArrowHookDownLeft32Light: FluentFontIcon;
+          export declare const ArrowHookDownRight32Light: FluentFontIcon;
+          export declare const ArrowHookUpLeft32Light: FluentFontIcon;
+          export declare const ArrowHookUpRight32Light: FluentFontIcon;
+          export declare const ArrowRedo32Light: FluentFontIcon;
+          export declare const ArrowReply32Light: FluentFontIcon;
+          export declare const ArrowReplyAll32Light: FluentFontIcon;
+          export declare const ArrowUndo32Light: FluentFontIcon;
+          export declare const Attach32Light: FluentFontIcon;
+          export declare const AutoFit32Light: FluentFontIcon;
+          export declare const AutoFitWidth32Light: FluentFontIcon;
+          export declare const Autocorrect32Light: FluentFontIcon;
+          export declare const BreakoutRoom32Light: FluentFontIcon;
+          export declare const Broom32Light: FluentFontIcon;
+          export declare const Calendar3Day32Light: FluentFontIcon;
+          export declare const CalendarClock32Light: FluentFontIcon;
+          export declare const CalendarDataBar32Light: FluentFontIcon;
+          export declare const CalendarDay32Light: FluentFontIcon;
           ... (content truncated for snapshot)"
         `);
       }
@@ -1540,36 +1542,36 @@ describe('Build Verification', () => {
         const dtsContent = await readFile(dtsFile, 'utf8');
         const trimmedDTSContent = trimContentForSnapshot(dtsContent);
         expect(trimmedDTSContent).toMatchInlineSnapshot(`
-          "export declare const AccessibilityCheckmark32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const Add32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const Alert32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AppFolder32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const AppGeneric32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const Archive32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const ArchiveSettings32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const ArrowClockwise32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const ArrowDown32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
-          export declare const ArrowDownload32Light: import("react").FC<import("..").FluentIconsProps<import("react").HTMLAttributes<HTMLElement>, HTMLElement>> & {
-              codepoint: string;
-          };
+          "import type { FluentFontIcon } from "../../utils/fonts/createFluentFontIcon";
+          export declare const AccessibilityCheckmark32Light: FluentFontIcon;
+          export declare const Add32Light: FluentFontIcon;
+          export declare const Alert32Light: FluentFontIcon;
+          export declare const AppFolder32Light: FluentFontIcon;
+          export declare const AppGeneric32Light: FluentFontIcon;
+          export declare const Archive32Light: FluentFontIcon;
+          export declare const ArchiveSettings32Light: FluentFontIcon;
+          export declare const ArrowClockwise32Light: FluentFontIcon;
+          export declare const ArrowDown32Light: FluentFontIcon;
+          export declare const ArrowDownload32Light: FluentFontIcon;
+          export declare const ArrowForward32Light: FluentFontIcon;
+          export declare const ArrowHookDownLeft32Light: FluentFontIcon;
+          export declare const ArrowHookDownRight32Light: FluentFontIcon;
+          export declare const ArrowHookUpLeft32Light: FluentFontIcon;
+          export declare const ArrowHookUpRight32Light: FluentFontIcon;
+          export declare const ArrowRedo32Light: FluentFontIcon;
+          export declare const ArrowReply32Light: FluentFontIcon;
+          export declare const ArrowReplyAll32Light: FluentFontIcon;
+          export declare const ArrowUndo32Light: FluentFontIcon;
+          export declare const Attach32Light: FluentFontIcon;
+          export declare const AutoFit32Light: FluentFontIcon;
+          export declare const AutoFitWidth32Light: FluentFontIcon;
+          export declare const Autocorrect32Light: FluentFontIcon;
+          export declare const BreakoutRoom32Light: FluentFontIcon;
+          export declare const Broom32Light: FluentFontIcon;
+          export declare const Calendar3Day32Light: FluentFontIcon;
+          export declare const CalendarClock32Light: FluentFontIcon;
+          export declare const CalendarDataBar32Light: FluentFontIcon;
+          export declare const CalendarDay32Light: FluentFontIcon;
           ... (content truncated for snapshot)"
         `);
       }

--- a/packages/react-icons/convert-font.js
+++ b/packages/react-icons/convert-font.js
@@ -69,15 +69,16 @@ async function processFiles(src, dest) {
 
   const indexPath = path.join(dest, 'index.tsx')
   // Finally add the interface definition and then write out the index.
-  indexContents.push('export { FluentIconsProps } from \'../utils/FluentIconsProps.types\'');
   indexContents.push('export { default as wrapIcon } from \'../utils/wrapIcon\'');
   indexContents.push('export { default as bundleIcon } from \'../utils/bundleIcon\'');
   indexContents.push('export { createFluentIcon } from \'../utils/createFluentIcon\'');
   indexContents.push('export { createFluentFontIcon } from \'../utils/fonts/createFluentFontIcon\'');
-  indexContents.push('export type { FluentIcon } from \'../utils/createFluentIcon\'');
   indexContents.push('export * from \'../utils/useIconState\'');
   indexContents.push('export * from \'../utils/constants\'');
   indexContents.push('export { IconDirectionContextProvider, useIconContext } from \'../contexts/index\'');
+  indexContents.push('export type { FluentIconsProps } from \'../utils/FluentIconsProps.types\'');
+  indexContents.push('export type { FluentIcon } from \'../utils/createFluentIcon\'');
+  indexContents.push('export type { FluentFontIcon } from \'../utils/fonts/createFluentFontIcon\'');
   indexContents.push('export type { IconDirectionContextValue } from \'../contexts/index\'');
 
 
@@ -123,6 +124,7 @@ async function processFolder(srcPath, codepointMapDestFolder, resizable) {
   }
 
   for (const chunk of iconChunks) {
+    chunk.unshift(`import type {FluentFontIcon} from "../../utils/fonts/createFluentFontIcon";`)
     chunk.unshift(`import {createFluentFontIcon} from "../../utils/fonts/createFluentFontIcon";`)
     chunk.unshift(`"use client";`);
   }
@@ -162,7 +164,7 @@ function generateReactIconEntries(iconEntries, resizable) {
     let destFilename = getReactIconNameFromGlyphName(iconName, resizable);
     var flipInRtl = metadata[destFilename] === 'mirror';
     let iconStyle = /filled$/i.test(iconName) ? 0 /* Filled */ : /regular$/i.test(iconName) ? 1 /* Regular */ : 3 /* Light */
-    var jsCode = `export const ${destFilename} = (/*#__PURE__*/createFluentFontIcon(${JSON.stringify(destFilename)
+    var jsCode = `export const ${destFilename}: FluentFontIcon = (/*#__PURE__*/createFluentFontIcon(${JSON.stringify(destFilename)
       }, ${JSON.stringify(String.fromCodePoint(codepoint))
       }, ${resizable ? 2 /* Resizable */ : iconStyle
       }, ${resizable ? undefined : ` ${/(?<=_)\d+(?=_filled|_regular|_light)/.exec(iconName)?.[0]}`

--- a/packages/react-icons/convert.js
+++ b/packages/react-icons/convert.js
@@ -68,14 +68,15 @@ function processFiles(src, dest) {
 
   const indexPath = path.join(dest, 'index.tsx')
   // Finally add the interface definition and then write out the index.
-  indexContents.push('export { FluentIconsProps } from \'./utils/FluentIconsProps.types\'');
   indexContents.push('export { default as wrapIcon } from \'./utils/wrapIcon\'');
   indexContents.push('export { default as bundleIcon } from \'./utils/bundleIcon\'');
   indexContents.push('export { createFluentIcon } from \'./utils/createFluentIcon\'');
-  indexContents.push('export type { FluentIcon } from \'./utils/createFluentIcon\'');
   indexContents.push('export * from \'./utils/useIconState\'');
   indexContents.push('export * from \'./utils/constants\'');
   indexContents.push('export { IconDirectionContextProvider, useIconContext } from \'./contexts/index\'');
+  // types
+  indexContents.push('export type { FluentIconsProps } from \'./utils/FluentIconsProps.types\'');
+  indexContents.push('export type { FluentIcon } from \'./utils/createFluentIcon\'');
   indexContents.push('export type { IconDirectionContextValue } from \'./contexts/index\'');
 
   fs.writeFileSync(indexPath, indexContents.join('\n'), (err) => {
@@ -126,11 +127,11 @@ function processFolder(srcPath, destPath, resizable) {
       if (color) {
         // For color icons, extract the entire SVG inner content
         const innerSvg = iconContent.replace(/^[\s\S]*?<svg[^>]*>/, '').replace(/<\/svg>[\s\S]*$/, '').trim();
-        jsCode = `export const ${destFilename} = (/*#__PURE__*/createFluentIcon('${destFilename}', ${width}, \`${innerSvg}\`${options}));`
+        jsCode = `export const ${destFilename}: FluentIcon = (/*#__PURE__*/createFluentIcon('${destFilename}', ${width}, \`${innerSvg}\`${options}));`
       } else {
         // For non-color icons, keep the old path-based approach
         const paths = getAttr("d").join(',');
-        jsCode = `export const ${destFilename} = (/*#__PURE__*/createFluentIcon('${destFilename}', ${width}, [${paths}]${options}));`
+        jsCode = `export const ${destFilename}: FluentIcon = (/*#__PURE__*/createFluentIcon('${destFilename}', ${width}, [${paths}]${options}));`
       }
       iconExports.push(jsCode);
     }

--- a/packages/react-icons/src/utils/fonts/createFluentFontIcon.tsx
+++ b/packages/react-icons/src/utils/fonts/createFluentFontIcon.tsx
@@ -12,8 +12,10 @@ export type CreateFluentFontIconOptions = {
     flipInRtl?: boolean;
 }
 
-export function createFluentFontIcon(displayName: string, codepoint: string, font: FontFile, fontSize?: number, options?: CreateFluentFontIconOptions): React.FC<FluentIconsProps<React.HTMLAttributes<HTMLElement>, HTMLElement>> & { codepoint: string} {
-    const Component: React.FC<FluentIconsProps<React.HTMLAttributes<HTMLElement>, HTMLElement>> & { codepoint: string} = (props) => {
+export type FluentFontIcon = React.FC<FluentIconsProps<React.HTMLAttributes<HTMLElement>, HTMLElement>> & { codepoint: string};
+
+export function createFluentFontIcon(displayName: string, codepoint: string, font: FontFile, fontSize?: number, options?: CreateFluentFontIconOptions): FluentFontIcon {
+    const Component: FluentFontIcon = (props) => {
         useStaticStyles();
         const styles = useRootStyles();
         const className = mergeClasses(styles.root, styles[font], fontIconClassName, props.className);


### PR DESCRIPTION
Introducing explicit `FluentIconFont` to drastically improve `tsc` emit for all generated assets within `fonts/*`

**Before:** 
<img width="1161" height="112" alt="image" src="https://github.com/user-attachments/assets/05bf3b7d-1b51-40f0-a9bb-eb2c94b0db69" />

**After:**
<img width="854" height="76" alt="image" src="https://github.com/user-attachments/assets/f2ae73f3-991b-4691-8595-259b9219f004" />


### Performance

| task | Before | After |
|--------|--------|--------|
| `npm run build` | 7m 13s | 3m 34s / **𝚫50% FASTER** |
| `tsc emit` | 2m 35s | 18s / **𝚫88% FASTER** | 