### PR TITLE
chore(importer): add types, unify CLI arg processing and more context

### DIFF
--- a/importer/generate.js
+++ b/importer/generate.js
@@ -1,18 +1,76 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+// @ts-check
+
 const fs = require("fs");
 const path = require("path");
 const process = require("process");
-const argv = require("yargs").boolean("selector").default("selector", false).boolean("keepdirs").default("keepdirs", false).argv;
 const _ = require("lodash");
+const yargs = require('yargs');
 
-const SRC_PATH = argv.source;
-const DEST_PATH = argv.dest;
-const EXTENSION = argv.extension;
-const TARGET = argv.target;
-const SELECTOR = argv.selector;
-const KEEP_DIRS = argv.keepdirs;
+const parseArgs = (args=process.argv.slice(2)) => {
+  const argv = yargs(args)
+    .usage('Usage: $0 --source <src> --dest <dest> --extension <ext> [options]')
+    .option('source', {
+      type: 'string',
+      describe: 'Icon source folder',
+      demandOption: true,
+    })
+    .option('dest', {
+      type: 'string',
+      describe: 'Output destination folder',
+      demandOption: true,
+    })
+    .option('extension', {
+      type: 'string',
+      describe: 'Desired icon extension (e.g. svg, xml, pdf, tsx)',
+      demandOption: true,
+    })
+    .option('target', {
+      type: 'string',
+      describe: 'Target platform (react|android|ios|flutter)',
+      default: 'android',
+    })
+    .option('selector', {
+      type: 'boolean',
+      describe: 'Generate selector files when applicable',
+      default: false,
+    })
+    .option('keepdirs', {
+      type: 'boolean',
+      describe: 'Keep original directories in output',
+      default: false,
+    })
+    .help()
+    .wrap(Math.min(120, process.stdout.columns || 120))
+    .argv;
+
+  /**
+   * @typedef {'react'|'android'|'ios'|'flutter'} TargetType
+   * @typedef {'svg'|'xml'|'pdf'|'tsx'} ExtensionType
+   *
+   * @typedef {{
+   *   SRC_PATH: string,
+   *   DEST_PATH: string,
+   *   EXTENSION: ExtensionType,
+   *   TARGET: TargetType,
+   *   SELECTOR: boolean,
+   *   KEEP_DIRS: boolean
+   * }} ParseResult
+   */
+
+  return /** @type {ParseResult} */ ({
+    SRC_PATH: argv.source,
+    DEST_PATH: argv.dest,
+    EXTENSION: /** @type {ExtensionType} */ (argv.extension),
+    TARGET: /** @type {TargetType} */ (argv.target),
+    SELECTOR: Boolean(argv.selector),
+    KEEP_DIRS: Boolean(argv.keepdirs),
+  });
+};
+
+const { SRC_PATH, DEST_PATH, EXTENSION, TARGET, SELECTOR, KEEP_DIRS } = parseArgs();
 const ICON_OUTLINE_STYLE = '_regular'
 const ICON_FILLED_STYLE = '_filled'
 const ICON_LIGHT_STYLE = '_light'
@@ -28,22 +86,31 @@ const TSX_EXTENSION = '.tsx'
 const iconNames = new Set();
 const date = new Date();
 
-if (!SRC_PATH) {
-  throw new Error("Icon source folder not specified by --source");
-}
-if (!DEST_PATH) {
-  throw new Error("Output destination folder not specified by --dest");
-}
-if (!EXTENSION) {
-  throw new Error("Desired icon extension not specified by --extension");
-}
-
 if (!fs.existsSync(DEST_PATH)) {
   fs.mkdirSync(DEST_PATH);
 }
 
 processFolder(SRC_PATH, DEST_PATH, 0)
 
+/**
+ * Recursively processes a source directory of icon assets and produces copied and/or generated outputs in a destination directory.
+ *
+ * This function traverses srcPath and for each file/directory:
+ * - Recurses into subdirectories.
+ * - Skips hidden files and names that start with an underscore.
+ * - Filters files to include only those that match the configured icon styles and the desired EXTENSION.
+ * - Ensures filenames use the "ic_fluent_" prefix (adds it when missing).
+ * - Creates destination directories as needed and copies matching files from source to destination.
+ *
+ * Notes and side effects:
+ * - Mutates module-level state (e.g., the iconNames Set) to detect paired icon variants.
+ * - Destination directory layout depends on KEEP_DIRS and the folderDepth argument (folderDepth == 0 for the initial call).
+ *
+ * @param {string} srcPath - Path to the source folder to traverse (absolute or relative).
+ * @param {string} destPath - Path to the destination folder where files and generated artifacts will be written.
+ * @param {number} folderDepth - Current recursion depth (0 for the top-level call). Influences destination directory creation when KEEP_DIRS is false.
+ * @returns {void} - Performs file system side effects; does not return a meaningful value.
+ */
 function processFolder(srcPath, destPath, folderDepth) {
   fs.readdir(srcPath, function (err, files) {
     if (err) {
@@ -53,13 +120,13 @@ function processFolder(srcPath, destPath, folderDepth) {
 
     files.forEach(function (file, index) {
       var srcFile = path.join(srcPath, file);
-  
+
       fs.stat(srcFile, function (error, stat) {
         if (error) {
           console.error("Error stating file.", error);
           return;
         }
-  
+
         if (stat.isDirectory()) {
           const folderName = path.basename(srcFile)
           let locPath = destPath
@@ -89,12 +156,12 @@ function processFolder(srcPath, destPath, folderDepth) {
           // Only include icons in the desired configs
           return;
         }
-        
+
         // Apply 'fluent_' prefix
         if (file.indexOf("_fluent_") < 0) {
           file = file.replace("ic_", "ic_fluent_");
         }
-        
+
         var destFile = path.join(destPath, file);
         if (!fs.existsSync(destPath)) {
           fs.mkdirSync(destPath)
@@ -123,9 +190,14 @@ function processFolder(srcPath, destPath, folderDepth) {
   });
 }
 
+/**
+ * Generate the selector XML file for the specified icon.
+ * @param {string} destPath - The destination path for the selector file.
+ * @param {string} iconName - The name of the icon.
+ */
 function generateSelector(destPath, iconName) {
   var selectorFile = path.join(destPath, iconName + SELECTOR_SUFFIX + XML_EXTENSION);
-  var code = 
+  var code =
 `<?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Copyright (c) ${date.getFullYear()}.
@@ -140,17 +212,23 @@ function generateSelector(destPath, iconName) {
 </selector>
 `;
   fs.writeFile(selectorFile, code, (err) => {
-    if (err) throw err; 
+    if (err) throw err;
   });
 }
 
+/**
+ * Generate the React component file for the specified icon.
+ * @param {string} destPath - The destination path for the React component file.
+ * @param {string} iconName - The name of the icon.
+ * @param {string} srcFile - The source file of the icon.
+ */
 function generateReact(destPath, iconName, srcFile) {
   iconName = iconName.replace("ic_fluent_", "")
   iconName = _.camelCase(iconName)
   iconName = iconName.replace(iconName.substring(0, 1), iconName.substring(0, 1).toUpperCase())
   var iconContent = fs.readFileSync(srcFile, { encoding: "utf8"})
   var selectorFile = path.join(destPath, iconName + REACT_SUFFIX + TSX_EXTENSION);
-  var code = 
+  var code =
 `import * as React from 'react';
   const ${iconName + REACT_SUFFIX} = () => {
     return(
@@ -159,6 +237,6 @@ function generateReact(destPath, iconName, srcFile) {
 export default ${iconName + REACT_SUFFIX};
 `;
   fs.writeFile(selectorFile, code, (err) => {
-    if (err) throw err; 
+    if (err) throw err;
   });
 }

--- a/importer/tsconfig.json
+++ b/importer/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "target": "es2015",
+    "strict": true,
+    "noEmit": true,
+    "allowJs": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["dist","tools/"]
+}


### PR DESCRIPTION
This pull request refactors the argument parsing logic in the `importer` scripts to use structured parsing via `yargs`, improves type safety and documentation with JSDoc comments and TypeScript checks, and modernizes filesystem imports. These changes make the scripts easier to maintain, more robust, and clearer for future contributors.