### PR TITLE
ci(pr): enable Nx affected pipelines on npm packages

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -147,8 +147,20 @@ jobs:
         node-version: 20.x
 
     - run: npm ci
+    # Use once allowed
+    # - uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
 
-    - uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
+    - name: Set NX_BASE and NX_HEAD
+      run: |
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          echo "NX_BASE=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
+          echo "NX_HEAD=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+        else
+          echo "NX_BASE=${{ github.event.before }}" >> $GITHUB_ENV
+          echo "NX_HEAD=${{ github.sha }}" >> $GITHUB_ENV
+        fi
+        echo "Base SHA: $NX_BASE"
+        echo "Head SHA: $NX_HEAD"
 
     - name: Run build
       run: npx nx affected -t build --projects=svg-icons
@@ -172,7 +184,19 @@ jobs:
 
     - run: npm ci
 
-    - uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
+    # Use once allowed
+    # - uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
+    - name: Set NX_BASE and NX_HEAD
+      run: |
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          echo "NX_BASE=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
+          echo "NX_HEAD=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+        else
+          echo "NX_BASE=${{ github.event.before }}" >> $GITHUB_ENV
+          echo "NX_HEAD=${{ github.sha }}" >> $GITHUB_ENV
+        fi
+        echo "Base SHA: $NX_BASE"
+        echo "Head SHA: $NX_HEAD"
 
     - name: Lint/Test/Build @fluentui/react-icons
       run: |


### PR DESCRIPTION
- Enables affected pipelines for npm packages in the repo
- Removes `-u` which ignored failing tests for `react-icons`
- this new flow won't trigger `react-icons` pipeline on `/assets` changes (cc @spencer-nelson)

**Workflow configuration and optimization:**

* Set environment variables `NX_PARALLEL` and `NX_VERBOSE_LOGGING` globally to control parallelism and enable verbose logging for Nx commands, which should improve build performance and debugging.
* Updated all build and test commands in the `build-svg` and `build-react` jobs to use `npx nx affected` with explicit project targeting, replacing generic npm scripts and ensuring only affected projects are built or tested.
* Added logic to set `NX_BASE` and `NX_HEAD` environment variables based on the pull request or push event, improving Nx's ability to determine the correct range of changes for affected commands.

**Security and best practices:**

* Added explicit `permissions` for `contents` and `actions` as `read` in both `build-svg` and `build-react` jobs to follow GitHub Actions security best practices.
* Ensured `actions/checkout` uses `fetch-depth: 0` to fetch the full git history, which is required for accurate Nx affected calculations.