### PR TITLE
Allow "Color" to be atomic icon name

### DIFF
--- a/packages/react-icons/per-icon.writer.js
+++ b/packages/react-icons/per-icon.writer.js
@@ -212,7 +212,7 @@ function normalizeBaseName(fileName, styleVariants = ICON_STYLE_VARIANTS) {
   const parts = normalized.split('-');
   const styleSet = new Set(styleVariants);
 
-  while (parts.length > 0) {
+  while (parts.length > 1) {
     const last = parts[parts.length - 1];
     // treat pure numbers and tokens that are in styleTokens or contain 'color' as variant markers
     if (/^\d+$/.test(last) || styleSet.has(last) || last.includes('color')) {

--- a/packages/react-icons/per-icon.writer.test.js
+++ b/packages/react-icons/per-icon.writer.test.js
@@ -53,6 +53,7 @@ describe('normalizeBaseName', () => {
     expect(normalizeBaseName('zoom-in-16-regular')).toBe('zoom-in');
     expect(normalizeBaseName('my-icon-32-light.tsx')).toBe('my-icon');
     expect(normalizeBaseName('color-test-20_color.tsx')).toBe('color-test');
+    expect(normalizeBaseName('color-16-filled')).toBe('color');
     // numeric-only token
     expect(normalizeBaseName('example-24')).toBe('example');
   });


### PR DESCRIPTION
The current atomic icon file generation removes "color" in the `Color` icon as a style variant, leading to files like `color-16-filled.js` that should just be `color.js`.

This PR assumes the first "part" (separated by `-`) of the icon name is not a style variant and is actually the icon's name.

This will be a breaking change because all the `color-${size}-${variant}.js` files will be removed in favour of `color.js`

Fixes #928 