### PR TITLE
feat(react-icons): add export map for svg atoms imports to support old TypeScript 'moduleResolution:node' setting

### DIFF
--- a/packages/react-icons/README.md
+++ b/packages/react-icons/README.md
@@ -183,6 +183,8 @@ function MyComponent() {
 
 Without this setting, TypeScript will not be able to resolve the individual icon exports from the grouped files.
 
+**NOTE:** TypeScript users that are still using _old_ `"moduleResolution": "node"`, can use `@fluentui/react-icons/lib/atoms/svg/*` - for SVG-based atomic icon imports
+
 ### Using API via build transform
 
 Migrating a larger codebase to the new performant atomic imports might be a daunting task. To make this migration more straightforward, you can leverage build-time import transforms to get all the benefits without modifying your actual code.

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -109,6 +109,11 @@
       "import": "./lib/atoms/svg/*.js",
       "require": "./lib-cjs/atoms/svg/*.js"
     },
+    "./lib/atoms/svg/*": {
+      "types": "./lib/atoms/svg/*.d.ts",
+      "import": "./lib/atoms/svg/*.js",
+      "require": "./lib-cjs/atoms/svg/*.js"
+    },
     "./lib/svg": {
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",


### PR DESCRIPTION
Adds verbatim path export for us svg atoms to support users with `moduleResolution:node` TypeScript setting


**Example**

```ts
// > modern typescript / moduleResolution: bundler

import { AccessTime20Filled, AccessTime24Filled, AccessTime20Regular } from "@fluentui/react-icons/svg/access-time";
```

```ts
// > old typescript / moduleResolution: node
import { AccessTime20Filled, AccessTime24Filled, AccessTime20Regular } from "@fluentui/react-icons/lib/atoms/svg/access-time";
```