### PR TITLE
feat(react-icons-font-subsetting-webpack-plugin): add react-icons atomic imports support

### DIFF
--- a/packages/react-icons-font-subsetting-webpack-plugin/README.md
+++ b/packages/react-icons-font-subsetting-webpack-plugin/README.md
@@ -1,10 +1,34 @@
 # @fluentui/react-icons-font-subsetting-webpack-plugin
 
-This package includes a plugin for `webpack@>=5.0.0` to subset the icon font files used by `@fluentui/react-icons` when using the `"fluentIconFont"` condition in `resolve.conditionNames`.
+This package includes a plugin for `webpack@>=5.0.0` to subset the icon font files used by `@fluentui/react-icons` when using font-based icon implementations.
 
 If `optimization.usedExports` is enabled (as it is by default in webpack `production` mode), this plugin will subset the font files to only include the glyphs actually used by your build.
 
+## Supported Import Patterns
+
+The plugin supports the following import patterns from `@fluentui/react-icons`:
+
+### 1. Using the `fluentIconFont` condition
+
+```js
+// Uses font implementation via resolve.conditionNames
+import { AddRegular, DeleteFilled } from '@fluentui/react-icons';
+```
+
+### 2. Using atomic imports from `@fluentui/react-icons/fonts/*`
+
+```js
+// Direct atomic imports - no conditionNames required
+import { AddRegular, AddFilled } from '@fluentui/react-icons/fonts/add';
+import { DeleteRegular } from '@fluentui/react-icons/fonts/delete';
+```
+
+Atomic imports provide better tree-shaking and faster build times for applications using a small number of icons.
+
 ## Usage
+
+### With `fluentIconFont` condition
+
 ```js
 // webpack.config.js
 const {default: FluentUIReactIconsFontSubsettingPlugin} = require('@fluentui/react-icons-font-subsetting-webpack-plugin');
@@ -22,6 +46,29 @@ module.exports = {
     resolve: {
         // Include 'fluentIconFont' to use the font implementation of the Fluent icons
         conditionNames: ['fluentIconFont', 'import']
+    },
+    plugins: [
+        // Include this plugin
+        new FluentUIReactIconsFontSubsettingPlugin(),
+    ],
+};
+```
+
+### With atomic imports (no conditionNames required)
+
+```js
+// webpack.config.js
+const {default: FluentUIReactIconsFontSubsettingPlugin} = require('@fluentui/react-icons-font-subsetting-webpack-plugin');
+
+module.exports = {
+    module: {
+        rules: [
+            // Treat the font files as webpack assets
+            {
+                test: /\.(ttf|woff2?)$/,
+                type: 'asset',
+            }
+        ]
     },
     plugins: [
         // Include this plugin

--- a/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
@@ -106,7 +106,10 @@ function isNormalModule(m: webpack.Module): m is webpack.NormalModule {
 
 function isFluentUIReactFontChunk(m: webpack.Module): m is webpack.NormalModule {
     if (isNormalModule(m)) {
-        return /react-icons[\/\\]lib(-cjs)?[\/\\]fonts[\/\\](sizedIcons|icons)[\/\\]chunk-\d+\.js$/.test(m.resource)
+        // Match both chunk files and atomic font imports:
+        // - lib/fonts/sizedIcons/chunk-0.js (chunk-based)
+        // - lib/atoms/fonts/access-time.js (atomic imports)
+        return /react-icons[\/\\]lib(-cjs)?[\/\\](fonts[\/\\](sizedIcons|icons)[\/\\]chunk-\d+|atoms[\/\\]fonts[\/\\][\w-]+)\.js$/.test(m.resource)
     }
     return false;
 }

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/src/atoms.js
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/src/atoms.js
@@ -1,0 +1,11 @@
+// @ts-check
+import {XboxConsole24Filled} from '@fluentui/react-icons/fonts/xbox-console';
+import {BoardGames20Regular} from '@fluentui/react-icons/fonts/board-games';
+import {GamesFilled} from '@fluentui/react-icons/fonts/games';
+
+console.log('atomic fonts loaded');
+console.dir({
+    XboxConsole24Filled,
+    BoardGames20Regular,
+    GamesFilled
+})

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/src/index.js
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/src/index.js
@@ -1,5 +1,7 @@
+// @ts-check
 import {XboxConsole24Filled, BoardGames20Regular, GamesFilled} from '@fluentui/react-icons';
 
+console.log('chunk fonts loaded');
 console.dir({
     XboxConsole24Filled,
     BoardGames20Regular,

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/webpack.config.js
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/webpack.config.js
@@ -30,8 +30,13 @@ module.exports = {
             }
         ]
     },
+    entry: {
+        index: './src/index.js',
+        atoms: './src/atoms.js',
+    },
     output: {
         path: resolve(__dirname, 'dist'),
+        filename: '[name].js',
     },
     resolve: {
         conditionNames: ['fluentIconFont', 'import']

--- a/packages/react-icons-font-subsetting-webpack-plugin/tsconfig.json
+++ b/packages/react-icons-font-subsetting-webpack-plugin/tsconfig.json
@@ -27,7 +27,7 @@
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
     "rootDir": "./src",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
- [x] needs https://github.com/microsoft/fluentui-system-icons/pull/960

---

Adds support for font subsetting when using atomic imports  `@fluentui/react-icons/fonts/*`