### PR TITLE
ci(publish): disable automatic release trigger on PR merge

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,16 +8,14 @@ on:
         required: false
         default: false
         type: boolean
-  push:
-    branches: [ main ]
-    paths:
-      - 'assets/**'
 
 env:
   LIBRARY_VERSION: 1.1.${{ github.run_number }}
 
 jobs:
   publish-library:
+    # Prevent infinite loops: skip if the commit was made by the build system itself
+    # (e.g., the "Release X.Y.Z" commit pushed at the end of this workflow)
     if: "!contains(github.event.head_commit.author.email, 'flubuild@microsoft.com')"
     name: Publish icon libraries
     runs-on: ubuntu-latest
@@ -289,7 +287,7 @@ jobs:
       if: ${{ !inputs.dry-run }}
       run: |
         git add -A
-        git commit -m "Release $NEW_VERSION"
+        git commit -m "Release $NEW_VERSION [skip ci]"
 
     - name: Tag release
       if: ${{ !inputs.dry-run }}


### PR DESCRIPTION
**Before:**

any PR which changed `assets/**` merged to master will trigger release of all packages.

While this shouldn't happen as we have scheduled releases by design sprint, nothing is preventing someone to merge a PR and accidentally trigger release affecting all packages in the monorepo

**After:**

Releases are triggered only manually by Maintainers. This is also compliant with our security practices

<img width="1454" height="509" alt="image" src="https://github.com/user-attachments/assets/d71a6594-cd99-401f-adb3-3ae9d4dd64b1" />
