### PR TITLE
chore(release): onboard react-icons-font-subsetting-webpack-plugin to nx release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -150,11 +150,6 @@ jobs:
         sed -i.bk -r "s/\"version\": \"[0-9]+\.[0-9]+\.[0-9]+\"/\"version\": \"$REACT_VERSION\"/g" packages/react-native-icons/package.json
         rm packages/react-native-icons/package.json.bk
 
-    # Needs to be "-E" instead of "-r" on macOS
-    - name: Replace version number in react-icons-font-subsetting-webpack-plugin/package.json
-      run: |
-        sed -i.bk -r "s/\"version\": \"[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?(-rc\.[0-9]+)?\"/\"version\": \"$REACT_VERSION\"/g" packages/react-icons-font-subsetting-webpack-plugin/package.json
-        rm packages/react-icons-font-subsetting-webpack-plugin/package.json.bk
 
     - name: Build SVG library
       run: |
@@ -182,8 +177,8 @@ jobs:
         npx nx run react-icons:build
         npx nx run react-icons:build-verify -u
 
-    # NX Release
-    - name: react-icons prepare release
+    # NX Release (react-icons + react-icons-font-subsetting-webpack-plugin)
+    - name: Prepare NPM release (version + changelog)
       run: |
         npx nx release version $REACT_VERSION --verbose ${{ inputs.dry-run && '--dry-run' || '' }}
         npx nx release changelog $REACT_VERSION --from $CURRENT_VERSION --no-git-tag --no-git-commit --verbose ${{ inputs.dry-run && '--dry-run' || '' }}

--- a/nx.json
+++ b/nx.json
@@ -12,7 +12,7 @@
     "sharedGlobals": []
   },
   "release": {
-    "projects": ["packages/react-icons"],
+    "projects": ["packages/react-icons","packages/react-icons-font-subsetting-webpack-plugin"],
     "projectsRelationship": "independent",
     "version": {
       "conventionalCommits": true,

--- a/packages/react-icons-font-subsetting-webpack-plugin/CHANGELOG.md
+++ b/packages/react-icons-font-subsetting-webpack-plugin/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 2.0.317 (2026-01-21)
+
+This release contains icon updates


### PR DESCRIPTION
- adopts same release automation as react-icons