### PR TITLE
feat(react-icons): expand /utils api endpoint with additional utils to completely streamline build transforms to atomic imports

### DIFF
--- a/packages/react-icons/README.md
+++ b/packages/react-icons/README.md
@@ -164,6 +164,7 @@ Icons are available via two export maps:
 The following utility module is also available:
 
 - `@fluentui/react-icons/utils` - General icon helper utilities
+- `@fluentui/react-icons/providers` - React Context related apis
 
 ```tsx
 // Import individual icon variants from grouped files
@@ -230,21 +231,16 @@ module.exports = {
       {
         '@fluentui/react-icons': {
           transform: (importName) => {
-            // Handle utility imports (bundleIcon, className constants)
-            const utilityExports = [
-              'bundleIcon',
-              'iconClassName',
-              'iconFilledClassName',
-              'iconRegularClassName',
-              'iconColorClassName',
-              'iconLightClassName',
-            ];
+            if (importName === 'useIconContext' || importName === 'IconDirectionContextProvider') {
+              return '@fluentui/react-icons/providers';
+            }
 
-            if (utilityExports.includes(importName)) {
+            // Icons end with a style suffix
+            const isIcon = importName.match(/(\d*)?(Regular|Filled|Light|Color)$/);
+            if (!isIcon) {
               return '@fluentui/react-icons/utils';
             }
 
-            // Handle icon imports
             const withoutSuffix = importName.replace(/(\d*)?(Regular|Filled|Light|Color)$/, '');
 
             const kebabCase = withoutSuffix.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
@@ -275,16 +271,15 @@ If you use SWC for transpilation, add [@swc/plugin-transform-imports](https://ww
           {
             "@fluentui/react-icons": {
               "transform": [
-                // Transform utility imports to /utils
-                [
-                  "^(bundleIcon|iconClassName|iconFilledClassName|iconRegularClassName|iconColorClassName|iconLightClassName)$",
-                  "@fluentui/react-icons/utils",
-                ],
+                // Transform provider imports to /providers
+                ["^(useIconContext|IconDirectionContextProvider)$", "@fluentui/react-icons/providers"],
                 // Transform icon imports to /svg/{icon-name}
                 [
-                  "(\\D*)(\\d*)?(Regular|Filled|Light|Color)",
+                  "(\\D*)(\\d*)?(Regular|Filled|Light|Color)$",
                   "@fluentui/react-icons/svg/{{ kebabCase memberMatches.[1] }}",
                 ],
+                // Fallback: all other exports are utilities
+                [".*", "@fluentui/react-icons/utils"],
               ],
               "preventFullImport": false,
               "skipDefaultConversion": true,

--- a/packages/react-icons/build-verify.test.js
+++ b/packages/react-icons/build-verify.test.js
@@ -482,7 +482,7 @@ describe('Build Verification', () => {
         export * from './sizedIcons/chunk-27';
         export * from './sizedIcons/chunk-28';
         export * from './sizedIcons/chunk-29';
-        export { default as wrapIcon } from './utils/wrapIcon';
+        export { wrapIcon } from './utils/wrapIcon';
         export { bundleIcon } from './utils/bundleIcon';
         export { createFluentIcon } from './utils/createFluentIcon';
         export * from './utils/useIconState';
@@ -551,7 +551,7 @@ describe('Build Verification', () => {
         export * from './sizedIcons/chunk-27';
         export * from './sizedIcons/chunk-28';
         export * from './sizedIcons/chunk-29';
-        export { default as wrapIcon } from './utils/wrapIcon';
+        export { wrapIcon } from './utils/wrapIcon';
         export { bundleIcon } from './utils/bundleIcon';
         export { createFluentIcon } from './utils/createFluentIcon';
         export * from './utils/useIconState';
@@ -635,7 +635,7 @@ describe('Build Verification', () => {
         tslib_1.__exportStar(require("./sizedIcons/chunk-28"), exports);
         tslib_1.__exportStar(require("./sizedIcons/chunk-29"), exports);
         var wrapIcon_1 = require("./utils/wrapIcon");
-        Object.defineProperty(exports, "wrapIcon", { enumerable: true, get: function () { return tslib_1.__importDefault(wrapIcon_1).default; } });
+        Object.defineProperty(exports, "wrapIcon", { enumerable: true, get: function () { return wrapIcon_1.wrapIcon; } });
         var bundleIcon_1 = require("./utils/bundleIcon");
         Object.defineProperty(exports, "bundleIcon", { enumerable: true, get: function () { return bundleIcon_1.bundleIcon; } });
         var createFluentIcon_1 = require("./utils/createFluentIcon");
@@ -708,7 +708,7 @@ describe('Build Verification', () => {
         export * from './sizedIcons/chunk-27';
         export * from './sizedIcons/chunk-28';
         export * from './sizedIcons/chunk-29';
-        export { default as wrapIcon } from './utils/wrapIcon';
+        export { wrapIcon } from './utils/wrapIcon';
         export { bundleIcon } from './utils/bundleIcon';
         export { createFluentIcon } from './utils/createFluentIcon';
         export * from './utils/useIconState';
@@ -788,7 +788,7 @@ describe('Build Verification', () => {
         export * from './sizedIcons/chunk-27';
         export * from './sizedIcons/chunk-28';
         export * from './sizedIcons/chunk-29';
-        export { default as wrapIcon } from '../utils/wrapIcon';
+        export { wrapIcon } from '../utils/wrapIcon';
         export { bundleIcon } from '../utils/bundleIcon';
         export { createFluentIcon } from '../utils/createFluentIcon';
         export { createFluentFontIcon } from '../utils/fonts/createFluentFontIcon';
@@ -858,7 +858,7 @@ describe('Build Verification', () => {
         export * from './sizedIcons/chunk-27';
         export * from './sizedIcons/chunk-28';
         export * from './sizedIcons/chunk-29';
-        export { default as wrapIcon } from '../utils/wrapIcon';
+        export { wrapIcon } from '../utils/wrapIcon';
         export { bundleIcon } from '../utils/bundleIcon';
         export { createFluentIcon } from '../utils/createFluentIcon';
         export { createFluentFontIcon } from '../utils/fonts/createFluentFontIcon';
@@ -945,7 +945,7 @@ describe('Build Verification', () => {
         tslib_1.__exportStar(require("./sizedIcons/chunk-28"), exports);
         tslib_1.__exportStar(require("./sizedIcons/chunk-29"), exports);
         var wrapIcon_1 = require("../utils/wrapIcon");
-        Object.defineProperty(exports, "wrapIcon", { enumerable: true, get: function () { return tslib_1.__importDefault(wrapIcon_1).default; } });
+        Object.defineProperty(exports, "wrapIcon", { enumerable: true, get: function () { return wrapIcon_1.wrapIcon; } });
         var bundleIcon_1 = require("../utils/bundleIcon");
         Object.defineProperty(exports, "bundleIcon", { enumerable: true, get: function () { return bundleIcon_1.bundleIcon; } });
         var createFluentIcon_1 = require("../utils/createFluentIcon");
@@ -1020,7 +1020,7 @@ describe('Build Verification', () => {
         export * from './sizedIcons/chunk-27';
         export * from './sizedIcons/chunk-28';
         export * from './sizedIcons/chunk-29';
-        export { default as wrapIcon } from '../utils/wrapIcon';
+        export { wrapIcon } from '../utils/wrapIcon';
         export { bundleIcon } from '../utils/bundleIcon';
         export { createFluentIcon } from '../utils/createFluentIcon';
         export { createFluentFontIcon } from '../utils/fonts/createFluentFontIcon';

--- a/packages/react-icons/convert-font.js
+++ b/packages/react-icons/convert-font.js
@@ -116,7 +116,7 @@ async function processPerChunk(dest, iconEntries, rtlMetadata) {
 
   const indexPath = path.join(dest, 'index.tsx');
   // Finally add the interface definition and then write out the index.
-  indexContents.push("export { default as wrapIcon } from '../utils/wrapIcon'");
+  indexContents.push("export { wrapIcon } from '../utils/wrapIcon'");
   indexContents.push("export { bundleIcon } from '../utils/bundleIcon'");
   indexContents.push("export { createFluentIcon } from '../utils/createFluentIcon'");
   indexContents.push("export { createFluentFontIcon } from '../utils/fonts/createFluentFontIcon'");

--- a/packages/react-icons/convert.js
+++ b/packages/react-icons/convert.js
@@ -100,7 +100,7 @@ function processPerChunk(sourceFiles, dest, rtlMetadata) {
 
   const indexPath = path.join(dest, 'index.tsx');
   // Finally add the interface definition and then write out the index.
-  indexContents.push("export { default as wrapIcon } from './utils/wrapIcon'");
+  indexContents.push("export { wrapIcon } from './utils/wrapIcon'");
   indexContents.push("export { bundleIcon } from './utils/bundleIcon'");
   indexContents.push("export { createFluentIcon } from './utils/createFluentIcon'");
   indexContents.push("export * from './utils/useIconState'");

--- a/packages/react-icons/src/utils.ts
+++ b/packages/react-icons/src/utils.ts
@@ -1,4 +1,7 @@
 export { bundleIcon } from './utils/bundleIcon';
+export { wrapIcon } from './utils/wrapIcon';
+export { createFluentIcon } from './utils/createFluentIcon';
+export { useIconState } from './utils/useIconState';
 export {
   iconClassName,
   iconFilledClassName,

--- a/packages/react-icons/src/utils/bundleIcon.tsx
+++ b/packages/react-icons/src/utils/bundleIcon.tsx
@@ -5,6 +5,11 @@ import { iconFilledClassName, iconRegularClassName } from './constants';
 import type { FluentIcon } from './createFluentIcon';
 import { useBundledIconStyles } from './bundleIcon.styles';
 
+/**
+ *
+ * Combine the Regular and Filled versions of icons
+ * Could be used to toggle between them on hover.
+ */
 export const bundleIcon = (FilledIcon: FluentIcon, RegularIcon: FluentIcon): FluentIcon => {
   const Component: FluentIcon = (props) => {
     const { className, filled, ...rest } = props;

--- a/packages/react-icons/src/utils/wrapIcon.tsx
+++ b/packages/react-icons/src/utils/wrapIcon.tsx
@@ -3,7 +3,32 @@ import type { FluentIconsProps } from './FluentIconsProps.types';
 import { useIconState } from './useIconState';
 import type { CreateFluentIconOptions, FluentIcon } from './createFluentIcon';
 
-const wrapIcon = (
+/**
+ *
+ * Wraps custom Svg Component with Fluent Icon behaviour
+ *
+ * @example
+ * ```tsx
+ const CustomSvg = (iconProps: FluentIconsProps) =>
+  React.createElement(
+    'svg',
+    {
+      width: '20',
+      height: '20',
+      viewBox: '0 0 20 20',
+      xmlns: 'http://www.w3.org/2000/svg',
+      ...iconProps
+    },
+    React.createElement('path', {
+      fill: 'currentColor',
+      d: 'M10 2l6 16H4l6-16z'
+    })
+  );
+
+  const CustomIcon = wrapIcon(CustomSvg, 'CustomIcon');
+  ```
+ */
+export const wrapIcon = (
   Icon: (iconProps: FluentIconsProps) => React.ReactElement,
   displayName?: string,
   options?: CreateFluentIconOptions,
@@ -18,5 +43,3 @@ const wrapIcon = (
   WrappedIcon.displayName = displayName;
   return WrappedIcon;
 };
-
-export default wrapIcon;


### PR DESCRIPTION
Adds missing public apis to `/utils` endpoint to be able to fully use build transforms to consume only from atomic apis for better performance


- refactors  `wrapIcon` to use named export
- updates Atoms documentation