### PR TITLE
docs: included Fluent Design Calendar link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Pull request titles must follow the [Conventional Commits](https://www.conventio
 - `fix(svg-sprites): correct sprite generation for RTL icons`
 - `docs: update installation instructions`
 - `chore(deps): update dependencies`
-- `feat(assets): add new icons
+- `feat(assets): add new icons`
 
 **Common types**:
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -34,8 +34,8 @@ The following packages are published during each release:
 
 ## Release cadence
 
-- Releases are scheduled for every 2nd week by Design Team
-- Releases can be triggered at any time in between if there is a high priority NPM package change that needs to be published (eg.: security vulnerability mitigation, critical fix etc)
+- Releases are scheduled on a bi-weekly cadence by the Fluent Design Team. For details, refer to [Fluent Design Calendar](https://aka.ms/fluentdesigncalendar)
+- Releases can be triggered at any time in between if there is a high priority NPM package change that needs to be published (e.g.: security vulnerability mitigation, critical fix etc.)
 
 ## Release Process
 


### PR DESCRIPTION
This pull request makes minor documentation improvements to clarify contribution guidelines and release processes. The changes correct formatting and provide more precise information about release scheduling.

- Documentation formatting and clarity:
  * Fixed a formatting issue in the example commit message for new icons in `CONTRIBUTING.md`.
  * Updated the release cadence section in `docs/releases.md` to specify a bi-weekly schedule by the Fluent Design Team and added a link to the Fluent Design Calendar. Also improved the explanation about triggering releases for high-priority changes.