### PR TITLE
feat(react-icons-atomic-webpack-loader): implement build-transform webpack loader

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -16,6 +16,7 @@
       "react": {
         "projects": [
           "packages/react-icons",
+          "packages/react-icons-atomic-webpack-loader",
           "packages/react-icons-font-subsetting-webpack-plugin",
           "packages/react-native-icons"
         ],

--- a/nx.json
+++ b/nx.json
@@ -16,7 +16,6 @@
       "react": {
         "projects": [
           "packages/react-icons",
-          "packages/react-icons-atomic-webpack-loader",
           "packages/react-icons-font-subsetting-webpack-plugin",
           "packages/react-native-icons"
         ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -29091,7 +29091,6 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.9.0",
         "acorn-typescript": "^1.4.13"
       },
       "devDependencies": {
@@ -29103,6 +29102,7 @@
         "node": ">=14.5.0"
       },
       "peerDependencies": {
+        "acorn": ">=8.9.0",
         "webpack": ">=5.0.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3682,6 +3682,10 @@
       "resolved": "packages/react-icons",
       "link": true
     },
+    "node_modules/@fluentui/react-icons-atomic-webpack-loader": {
+      "resolved": "packages/react-icons-atomic-webpack-loader",
+      "link": true
+    },
     "node_modules/@fluentui/react-icons-font-subsetting-webpack-plugin": {
       "resolved": "packages/react-icons-font-subsetting-webpack-plugin",
       "link": true
@@ -10268,7 +10272,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -10298,6 +10301,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-typescript": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/acorn-typescript/-/acorn-typescript-1.4.13.tgz",
+      "integrity": "sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": ">=8.9.0"
       }
     },
     "node_modules/address": {
@@ -29073,6 +29085,33 @@
       "peerDependencies": {
         "react": ">=16.8.0 <20.0.0"
       }
+    },
+    "packages/react-icons-atomic-webpack-loader": {
+      "name": "@fluentui/react-icons-atomic-webpack-loader",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-typescript": "^1.4.13"
+      },
+      "devDependencies": {
+        "@types/node": "14",
+        "typescript": "5.0.4",
+        "webpack": "^5.72.0"
+      },
+      "engines": {
+        "node": ">=14.5.0"
+      },
+      "peerDependencies": {
+        "webpack": ">=5.0.0"
+      }
+    },
+    "packages/react-icons-atomic-webpack-loader/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/react-icons-font-subsetting-webpack-plugin": {
       "name": "@fluentui/react-icons-font-subsetting-webpack-plugin",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18958,7 +18958,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -29088,18 +29087,20 @@
     },
     "packages/react-icons-atomic-webpack-loader": {
       "name": "@fluentui/react-icons-atomic-webpack-loader",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "acorn-typescript": "^1.4.13"
+        "acorn-typescript": "^1.4.13",
+        "magic-string": "^0.30.0"
       },
       "devDependencies": {
-        "@types/node": "14",
+        "@fluentui/react-icons": "*",
+        "@types/node": "22",
         "typescript": "5.0.4",
         "webpack": "^5.72.0"
       },
       "engines": {
-        "node": ">=14.5.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "acorn": ">=8.9.0",
@@ -29107,9 +29108,19 @@
       }
     },
     "packages/react-icons-atomic-webpack-loader/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "22.19.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
+      "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/react-icons-atomic-webpack-loader/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/react-icons-atomic-webpack-loader/README.md
+++ b/packages/react-icons-atomic-webpack-loader/README.md
@@ -1,6 +1,9 @@
 # @fluentui/react-icons-atomic-webpack-loader
 
-> ⚠️ This package is in early development. The API may change before the first stable release.
+> **⚠️ Alpha** — this package is available as an alpha prerelease only.
+> ⚠️ The API may change before the first stable release.
+
+> Install via `npm install @fluentui/react-icons-atomic-webpack-loader@alpha --save-dev`
 
 Webpack loader that transforms barrel imports and re-exports from `@fluentui/react-icons` into atomic deep paths for better tree-shaking and smaller bundles.
 
@@ -18,15 +21,11 @@ import { useIconContext } from '@fluentui/react-icons/providers';
 export { ArrowLeftRegular } from '@fluentui/react-icons/svg/arrow-left';
 ```
 
-## Install
-
-```bash
-npm install @fluentui/react-icons-atomic-webpack-loader --save-dev
-```
-
 ## Usage
 
-Add the loader to your webpack config. It should run on both your source files and any `node_modules` that re-export from `@fluentui/react-icons`.
+Add the loader to your webpack config as an [`enforce: 'pre'`](https://webpack.js.org/configuration/module/#ruleenforce) rule so it runs on the original source before any other loaders:
+
+NOTE: Unlike most loaders, this one should NOT exclude `node_modules`. It needs to process files inside `node_modules` as well to transform barrel imports from `@fluentui/react-icons` in your third-party dependencies. Files that don't reference `@fluentui/react-icons` are skipped via a fast regex pre-check, so there is no meaningful overhead.
 
 ```js
 // webpack.config.js
@@ -35,23 +34,32 @@ module.exports = {
     rules: [
       {
         test: /\.[mc]?[jt]sx?$/,
-        exclude: /node_modules/,
-        use: [
-          'your-existing-loader', // e.g. babel-loader, ts-loader, swc-loader
-          '@fluentui/react-icons-atomic-webpack-loader',
-        ],
-      },
-      {
-        test: /\.m?js$/,
-        include: /node_modules/,
+        enforce: 'pre',
         use: ['@fluentui/react-icons-atomic-webpack-loader'],
       },
+      // … your other rules (babel-loader, ts-loader, etc.)
     ],
   },
 };
 ```
 
-> **Note:** Webpack loaders run bottom-to-top. Place the atomic import loader **below** your transpilation loader so it runs first on the original source.
+If your existing rules exclude `node_modules`, add a separate rule to cover dependencies:
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.[mc]?[jt]sx?$/,
+        include: /[\\/]node_modules[\\/]/,
+        enforce: 'pre',
+        use: ['@fluentui/react-icons-atomic-webpack-loader'],
+      },
+      // … your other rules (babel-loader, ts-loader, etc.)
+    ],
+  },
+};
+```
 
 ## Options
 
@@ -63,10 +71,16 @@ module.exports = {
 
 ```js
 {
-  loader: '@fluentui/react-icons-atomic-webpack-loader',
-  options: {
-    iconVariant: 'fonts',
-  },
+  test: /\.[mc]?[jt]sx?$/,
+  enforce: 'pre',
+  use: [
+    {
+      loader: '@fluentui/react-icons-atomic-webpack-loader',
+      options: {
+        iconVariant: 'fonts',
+      },
+    },
+  ],
 }
 ```
 

--- a/packages/react-icons-atomic-webpack-loader/README.md
+++ b/packages/react-icons-atomic-webpack-loader/README.md
@@ -1,0 +1,90 @@
+# @fluentui/react-icons-atomic-webpack-loader
+
+> ⚠️ This package is in early development. The API may change before the first stable release.
+
+Webpack loader that transforms barrel imports and re-exports from `@fluentui/react-icons` into atomic deep paths for better tree-shaking and smaller bundles.
+
+## Before / After
+
+```js
+// Before — barrel import pulls in the entire icon set
+import { AddFilled, bundleIcon, useIconContext } from '@fluentui/react-icons';
+export { ArrowLeftRegular } from '@fluentui/react-icons';
+
+// After — each reference resolves to a small, isolated module
+import { AddFilled } from '@fluentui/react-icons/svg/add';
+import { bundleIcon } from '@fluentui/react-icons/utils';
+import { useIconContext } from '@fluentui/react-icons/providers';
+export { ArrowLeftRegular } from '@fluentui/react-icons/svg/arrow-left';
+```
+
+## Install
+
+```bash
+npm install @fluentui/react-icons-atomic-webpack-loader --save-dev
+```
+
+## Usage
+
+Add the loader to your webpack config. It should run on both your source files and any `node_modules` that re-export from `@fluentui/react-icons`.
+
+```js
+// webpack.config.js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.[mc]?[jt]sx?$/,
+        exclude: /node_modules/,
+        use: [
+          'your-existing-loader', // e.g. babel-loader, ts-loader, swc-loader
+          '@fluentui/react-icons-atomic-webpack-loader',
+        ],
+      },
+      {
+        test: /\.m?js$/,
+        include: /node_modules/,
+        use: ['@fluentui/react-icons-atomic-webpack-loader'],
+      },
+    ],
+  },
+};
+```
+
+> **Note:** Webpack loaders run bottom-to-top. Place the atomic import loader **below** your transpilation loader so it runs first on the original source.
+
+## Options
+
+| Option        | Type                 | Default | Description                                           |
+| ------------- | -------------------- | ------- | ----------------------------------------------------- |
+| `iconVariant` | `'svg'` \| `'fonts'` | `'svg'` | Whether icons resolve to SVG or font-based components |
+
+### Using font icons
+
+```js
+{
+  loader: '@fluentui/react-icons-atomic-webpack-loader',
+  options: {
+    iconVariant: 'fonts',
+  },
+}
+```
+
+This changes icon resolution from `@fluentui/react-icons/svg/*` to `@fluentui/react-icons/fonts/*`. Non-icon exports (`utils`, `providers`) are unaffected.
+
+## How it works
+
+The loader uses a Babel transform to rewrite import and re-export declarations that reference `@fluentui/react-icons`. Each named specifier is routed to an atomic subpath based on its name:
+
+| Export type    | Example                                          | Resolved path                                     |
+| -------------- | ------------------------------------------------ | ------------------------------------------------- |
+| Icon component | `AddFilled`, `ArrowLeftRegular`                  | `@fluentui/react-icons/svg/add` (or `/fonts/add`) |
+| Context / hook | `useIconContext`, `IconDirectionContextProvider` | `@fluentui/react-icons/providers`                 |
+| Utility        | `bundleIcon`, `createFluentIcon`                 | `@fluentui/react-icons/utils`                     |
+
+Files that don't reference `@fluentui/react-icons` are passed through untouched (fast regex pre-check).
+
+## Requirements
+
+- `webpack` >= 5
+- `@fluentui/react-icons` >= 2 (with atomic subpath exports)

--- a/packages/react-icons-atomic-webpack-loader/package.json
+++ b/packages/react-icons-atomic-webpack-loader/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluentui/react-icons-atomic-webpack-loader",
-  "version": "0.1.0",
+  "version": "0.0.0",
+  "private": true,
   "description": "Webpack loader that transforms barrel imports and re-exports from @fluentui/react-icons into atomic deep paths",
   "main": "lib/index.js",
   "scripts": {
@@ -8,7 +9,7 @@
     "test": "webpack -c test/webpack.config.js"
   },
   "engines": {
-    "node": ">=14.5.0"
+    "node": ">=20.0.0"
   },
   "repository": {
     "type": "git",
@@ -20,12 +21,14 @@
     "url": "https://github.com/microsoft/fluentui-system-icons/issues"
   },
   "dependencies": {
-    "acorn-typescript": "^1.4.13"
+    "acorn-typescript": "^1.4.13",
+    "magic-string": "^0.30.0"
   },
   "devDependencies": {
+    "@fluentui/react-icons": "*",
     "typescript": "5.0.4",
     "webpack": "^5.72.0",
-    "@types/node": "14"
+    "@types/node": "22"
   },
   "peerDependencies": {
     "acorn": ">=8.9.0",

--- a/packages/react-icons-atomic-webpack-loader/package.json
+++ b/packages/react-icons-atomic-webpack-loader/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@fluentui/react-icons-atomic-webpack-loader",
+  "version": "0.1.0",
+  "description": "Webpack loader that transforms barrel imports and re-exports from @fluentui/react-icons into atomic deep paths",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "tsc -p .",
+    "test": "webpack -c test/webpack.config.js"
+  },
+  "engines": {
+    "node": ">=14.5.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/microsoft/fluentui-system-icons.git",
+    "directory": "packages/react-icons-atomic-webpack-loader"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/microsoft/fluentui-system-icons/issues"
+  },
+  "dependencies": {
+    "acorn": "^8.9.0",
+    "acorn-typescript": "^1.4.13"
+  },
+  "devDependencies": {
+    "typescript": "5.0.4",
+    "webpack": "^5.72.0",
+    "@types/node": "14"
+  },
+  "peerDependencies": {
+    "webpack": ">=5.0.0"
+  },
+  "files": [
+    "lib/*"
+  ]
+}

--- a/packages/react-icons-atomic-webpack-loader/package.json
+++ b/packages/react-icons-atomic-webpack-loader/package.json
@@ -20,7 +20,6 @@
     "url": "https://github.com/microsoft/fluentui-system-icons/issues"
   },
   "dependencies": {
-    "acorn": "^8.9.0",
     "acorn-typescript": "^1.4.13"
   },
   "devDependencies": {
@@ -29,6 +28,7 @@
     "@types/node": "14"
   },
   "peerDependencies": {
+    "acorn": ">=8.9.0",
     "webpack": ">=5.0.0"
   },
   "files": [

--- a/packages/react-icons-atomic-webpack-loader/project.json
+++ b/packages/react-icons-atomic-webpack-loader/project.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "react-icons-atomic-webpack-loader",
+  "projectType": "library",
+  "sourceRoot": "packages/react-icons-atomic-webpack-loader/src",
+  "tags": [],
+  "targets": {
+    "build": {
+      "cache": true,
+      "inputs": ["default", "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)", "!{projectRoot}/test/**"],
+      "outputs": ["{projectRoot}/lib"]
+    },
+    "test": {
+      "dependsOn": ["build"]
+    }
+  }
+}

--- a/packages/react-icons-atomic-webpack-loader/src/index.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/index.ts
@@ -1,0 +1,29 @@
+import { transformSource } from './transform';
+import type { LoaderContext } from 'webpack';
+
+const REACT_ICONS_IMPORT_REGEX = /['"]@fluentui\/react-icons['";\s]/;
+
+export interface FluentIconsAtomicImportLoaderOptions {
+  iconVariant?: 'svg' | 'fonts';
+}
+
+export default function fluentIconsAtomicImportLoader(
+  this: LoaderContext<FluentIconsAtomicImportLoaderOptions>,
+  sourceCode: string,
+): string {
+  if (!REACT_ICONS_IMPORT_REGEX.test(sourceCode)) {
+    return sourceCode;
+  }
+
+  const options = this.getOptions();
+  const iconVariant = options.iconVariant ?? 'svg';
+  const isTsx = this.resourcePath.endsWith('.tsx');
+  const isTypescript = /\.[mc]?tsx?$/.test(this.resourcePath);
+
+  try {
+    return transformSource(sourceCode, { iconVariant, isTypescript, isTsx });
+  } catch {
+    this.emitWarning(new Error(`FluentIconsAtomicImportLoader: Failed to transform "${this.resourcePath}"`));
+    return sourceCode;
+  }
+}

--- a/packages/react-icons-atomic-webpack-loader/src/index.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/index.ts
@@ -10,9 +10,10 @@ export interface FluentIconsAtomicImportLoaderOptions {
 export default function fluentIconsAtomicImportLoader(
   this: LoaderContext<FluentIconsAtomicImportLoaderOptions>,
   sourceCode: string,
-): string {
+): void {
   if (!REACT_ICONS_IMPORT_REGEX.test(sourceCode)) {
-    return sourceCode;
+    this.callback(null, sourceCode);
+    return;
   }
 
   const options = this.getOptions();
@@ -21,9 +22,10 @@ export default function fluentIconsAtomicImportLoader(
   const isTypescript = /\.[mc]?tsx?$/.test(this.resourcePath);
 
   try {
-    return transformSource(sourceCode, { iconVariant, isTypescript, isTsx });
+    const { code, map } = transformSource(sourceCode, { iconVariant, isTypescript, isTsx });
+    this.callback(null, code, map);
   } catch {
     this.emitWarning(new Error(`FluentIconsAtomicImportLoader: Failed to transform "${this.resourcePath}"`));
-    return sourceCode;
+    this.callback(null, sourceCode);
   }
 }

--- a/packages/react-icons-atomic-webpack-loader/src/transform.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/transform.ts
@@ -1,6 +1,7 @@
 import * as acorn from 'acorn';
 import tsPlugin from 'acorn-typescript';
-import type { ImportDeclaration, ExportNamedDeclaration, ImportSpecifier, ExportSpecifier, Identifier } from 'estree';
+import MagicString from 'magic-string';
+import type { ImportDeclaration, ExportNamedDeclaration, ImportSpecifier, ExportSpecifier } from 'estree';
 
 type AcornPlugin = (BaseParser: typeof acorn.Parser) => typeof acorn.Parser;
 
@@ -43,7 +44,12 @@ function getParser(options: TransformOptions) {
   return acorn.Parser.extend(plugin);
 }
 
-export function transformSource(source: string, options: TransformOptions): string {
+export interface TransformResult {
+  code: string;
+  map: ReturnType<MagicString['generateMap']>;
+}
+
+export function transformSource(source: string, options: TransformOptions): TransformResult {
   const parser = getParser(options);
 
   const ast = parser.parse(source, {
@@ -52,7 +58,7 @@ export function transformSource(source: string, options: TransformOptions): stri
     locations: false,
   });
 
-  const replacements: { start: number; end: number; text: string }[] = [];
+  const src = new MagicString(source);
 
   for (const node of ast.body) {
     if (node.type === 'ImportDeclaration') {
@@ -86,7 +92,7 @@ export function transformSource(source: string, options: TransformOptions): stri
         lines.push(`import { ${spec} } from '${newSource}';`);
       }
 
-      replacements.push({ start: n.start, end: n.end, text: lines.join('\n') });
+      src.overwrite(n.start, n.end, lines.join('\n'));
     }
 
     if (node.type === 'ExportNamedDeclaration') {
@@ -112,16 +118,12 @@ export function transformSource(source: string, options: TransformOptions): stri
         lines.push(`export { ${spec} } from '${newSource}';`);
       }
 
-      replacements.push({ start: n.start, end: n.end, text: lines.join('\n') });
+      src.overwrite(n.start, n.end, lines.join('\n'));
     }
   }
 
-  // Apply in reverse to preserve character offsets
-  let result = source;
-  for (let i = replacements.length - 1; i >= 0; i--) {
-    const { start, end, text } = replacements[i];
-    result = result.slice(0, start) + text + result.slice(end);
-  }
-
-  return result;
+  return {
+    code: src.toString(),
+    map: src.generateMap({ hires: true }),
+  };
 }

--- a/packages/react-icons-atomic-webpack-loader/src/transform.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/transform.ts
@@ -1,0 +1,127 @@
+import * as acorn from 'acorn';
+import tsPlugin from 'acorn-typescript';
+import type { ImportDeclaration, ExportNamedDeclaration, ImportSpecifier, ExportSpecifier, Identifier } from 'estree';
+
+type AcornPlugin = (BaseParser: typeof acorn.Parser) => typeof acorn.Parser;
+
+const MODULE_NAME = '@fluentui/react-icons';
+const ICON_SUFFIX_REGEX = /(\d*)?(Regular|Filled|Light|Color)$/;
+
+interface TransformOptions {
+  iconVariant: 'svg' | 'fonts';
+  isTypescript: boolean;
+  isTsx: boolean;
+}
+
+function getAtomicImportPath(importName: string, iconVariant: 'svg' | 'fonts'): string {
+  if (importName === 'useIconContext' || importName === 'IconDirectionContextProvider') {
+    return '@fluentui/react-icons/providers';
+  }
+
+  const isIcon = importName.match(ICON_SUFFIX_REGEX);
+
+  if (!isIcon) {
+    return '@fluentui/react-icons/utils';
+  }
+
+  const withoutSuffix = importName.replace(ICON_SUFFIX_REGEX, '');
+  const kebabCase = withoutSuffix.replace(/[a-z\d](?=[A-Z])|[a-zA-Z](?=\d)|[A-Z](?=[A-Z][a-z])/g, '$&-').toLowerCase();
+
+  return `@fluentui/react-icons/${iconVariant}/${kebabCase}`;
+}
+
+function getName(node: { type: string; name?: string; value?: unknown }): string {
+  return (node.name ?? String(node.value))!;
+}
+
+function getParser(options: TransformOptions) {
+  if (!options.isTypescript) {
+    return acorn.Parser;
+  }
+
+  const plugin = tsPlugin(options.isTsx ? { jsx: {} } : undefined) as unknown as AcornPlugin;
+  return acorn.Parser.extend(plugin);
+}
+
+export function transformSource(source: string, options: TransformOptions): string {
+  const parser = getParser(options);
+
+  const ast = parser.parse(source, {
+    sourceType: 'module',
+    ecmaVersion: 'latest',
+    locations: false,
+  });
+
+  const replacements: { start: number; end: number; text: string }[] = [];
+
+  for (const node of ast.body) {
+    if (node.type === 'ImportDeclaration') {
+      const n = node as unknown as ImportDeclaration & { start: number; end: number };
+
+      if (n.source.value !== MODULE_NAME) {
+        continue;
+      }
+
+      const memberImports = n.specifiers.filter((s): s is ImportSpecifier => s.type === 'ImportSpecifier');
+
+      if (memberImports.length === 0) {
+        continue;
+      }
+
+      const fullImports = n.specifiers.filter((s) => s.type !== 'ImportSpecifier');
+      const lines: string[] = [];
+
+      if (fullImports.length > 0) {
+        const names = fullImports
+          .map((s) => (s.type === 'ImportDefaultSpecifier' ? s.local.name : `* as ${s.local.name}`))
+          .join(', ');
+        lines.push(`import ${names} from '${MODULE_NAME}';`);
+      }
+
+      for (const specifier of memberImports) {
+        const importedName = getName(specifier.imported);
+        const localName = specifier.local.name;
+        const newSource = getAtomicImportPath(importedName, options.iconVariant);
+        const spec = importedName === localName ? importedName : `${importedName} as ${localName}`;
+        lines.push(`import { ${spec} } from '${newSource}';`);
+      }
+
+      replacements.push({ start: n.start, end: n.end, text: lines.join('\n') });
+    }
+
+    if (node.type === 'ExportNamedDeclaration') {
+      const n = node as unknown as ExportNamedDeclaration & { start: number; end: number };
+
+      if (!n.source || n.source.value !== MODULE_NAME) {
+        continue;
+      }
+
+      const specifiers = n.specifiers.filter((s): s is ExportSpecifier => s.type === 'ExportSpecifier');
+
+      if (specifiers.length === 0) {
+        continue;
+      }
+
+      const lines: string[] = [];
+
+      for (const specifier of specifiers) {
+        const localName = getName(specifier.local);
+        const exportedName = getName(specifier.exported);
+        const newSource = getAtomicImportPath(localName, options.iconVariant);
+        const spec = localName === exportedName ? localName : `${localName} as ${exportedName}`;
+        lines.push(`export { ${spec} } from '${newSource}';`);
+      }
+
+      replacements.push({ start: n.start, end: n.end, text: lines.join('\n') });
+    }
+  }
+
+  // Apply in reverse to preserve character offsets
+  let result = source;
+  for (let i = replacements.length - 1; i >= 0; i--) {
+    const { start, end, text } = replacements[i];
+    result = result.slice(0, start) + text + result.slice(end);
+  }
+
+  return result;
+}

--- a/packages/react-icons-atomic-webpack-loader/test/src/fonts-imports.js
+++ b/packages/react-icons-atomic-webpack-loader/test/src/fonts-imports.js
@@ -1,0 +1,4 @@
+import { AddFilled } from '@fluentui/react-icons';
+import { ArrowLeftRegular, bundleIcon } from '@fluentui/react-icons';
+
+console.log(AddFilled, ArrowLeftRegular, bundleIcon);

--- a/packages/react-icons-atomic-webpack-loader/test/src/svg-imports.js
+++ b/packages/react-icons-atomic-webpack-loader/test/src/svg-imports.js
@@ -1,0 +1,6 @@
+import { AddFilled } from '@fluentui/react-icons';
+import { ArrowLeftRegular, ArrowCircleDownFilled } from '@fluentui/react-icons';
+import { useIconContext, bundleIcon, PeopleColor } from '@fluentui/react-icons';
+import { useState } from 'react';
+
+console.log(AddFilled, ArrowLeftRegular, ArrowCircleDownFilled, useIconContext, bundleIcon, PeopleColor, useState);

--- a/packages/react-icons-atomic-webpack-loader/test/src/svg-reexports.js
+++ b/packages/react-icons-atomic-webpack-loader/test/src/svg-reexports.js
@@ -1,0 +1,5 @@
+export { AddFilled } from '@fluentui/react-icons';
+export { ArrowLeftRegular, ArrowCircleDownFilled } from '@fluentui/react-icons';
+export { useIconContext, bundleIcon } from '@fluentui/react-icons';
+export { AddCircleFilled as MyAdd } from '@fluentui/react-icons';
+export { Something } from 'other-package';

--- a/packages/react-icons-atomic-webpack-loader/test/src/svg-reexports.js
+++ b/packages/react-icons-atomic-webpack-loader/test/src/svg-reexports.js
@@ -2,4 +2,3 @@ export { AddFilled } from '@fluentui/react-icons';
 export { ArrowLeftRegular, ArrowCircleDownFilled } from '@fluentui/react-icons';
 export { useIconContext, bundleIcon } from '@fluentui/react-icons';
 export { AddCircleFilled as MyAdd } from '@fluentui/react-icons';
-export { Something } from 'other-package';

--- a/packages/react-icons-atomic-webpack-loader/test/webpack.config.js
+++ b/packages/react-icons-atomic-webpack-loader/test/webpack.config.js
@@ -53,16 +53,18 @@ function createConfig(name, entry) {
     mode: 'production',
     optimization: { minimize: false },
     entry: { [name]: entry.src },
+    experiments: { outputModule: true },
     output: {
       path: resolve(__dirname, 'dist', name),
       filename: '[name].js',
-      libraryTarget: 'commonjs2',
+      library: { type: 'module' },
     },
-    externals: [/^@fluentui\/react-icons/, /^react$/, /^other-package$/],
+    externals: [/^@fluentui\/react-icons/, /^react$/],
     module: {
       rules: [
         {
           test: /\.js$/,
+          enforce: 'pre',
           use: [
             {
               loader: resolve(__dirname, '../lib/index.js'),

--- a/packages/react-icons-atomic-webpack-loader/test/webpack.config.js
+++ b/packages/react-icons-atomic-webpack-loader/test/webpack.config.js
@@ -1,0 +1,104 @@
+// @ts-check
+const { resolve } = require('path');
+const { readFileSync } = require('fs');
+
+const entries = {
+  'svg-imports': {
+    src: './src/svg-imports.js',
+    loaderOptions: {},
+    mustInclude: [
+      '@fluentui/react-icons/svg/add',
+      '@fluentui/react-icons/svg/arrow-left',
+      '@fluentui/react-icons/svg/arrow-circle-down',
+      '@fluentui/react-icons/svg/people',
+      '@fluentui/react-icons/providers',
+      '@fluentui/react-icons/utils',
+    ],
+    mustExclude: ['"@fluentui/react-icons"'],
+  },
+  'svg-reexports': {
+    src: './src/svg-reexports.js',
+    loaderOptions: {},
+    mustInclude: [
+      '@fluentui/react-icons/svg/add',
+      '@fluentui/react-icons/svg/arrow-left',
+      '@fluentui/react-icons/svg/arrow-circle-down',
+      '@fluentui/react-icons/svg/add-circle',
+      '@fluentui/react-icons/providers',
+      '@fluentui/react-icons/utils',
+    ],
+    mustExclude: ['"@fluentui/react-icons"'],
+  },
+  'fonts-imports': {
+    src: './src/fonts-imports.js',
+    loaderOptions: { iconVariant: 'fonts' },
+    mustInclude: [
+      '@fluentui/react-icons/fonts/add',
+      '@fluentui/react-icons/fonts/arrow-left',
+      '@fluentui/react-icons/utils',
+    ],
+    mustExclude: ['"@fluentui/react-icons"', '@fluentui/react-icons/svg/'],
+  },
+};
+
+/**
+ * @param {string} name
+ * @param {typeof entries[keyof typeof entries]} entry
+ * @returns {import('webpack').Configuration}
+ */
+function createConfig(name, entry) {
+  return {
+    name,
+    context: __dirname,
+    mode: 'production',
+    optimization: { minimize: false },
+    entry: { [name]: entry.src },
+    output: {
+      path: resolve(__dirname, 'dist', name),
+      filename: '[name].js',
+      libraryTarget: 'commonjs2',
+    },
+    externals: [/^@fluentui\/react-icons/, /^react$/, /^other-package$/],
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          use: [
+            {
+              loader: resolve(__dirname, '../lib/index.js'),
+              options: entry.loaderOptions,
+            },
+          ],
+        },
+      ],
+    },
+    plugins: [
+      {
+        apply(compiler) {
+          compiler.hooks.afterEmit.tap('verify-transforms', () => {
+            const outputPath = resolve(__dirname, 'dist', name, `${name}.js`);
+            const output = readFileSync(outputPath, 'utf8');
+
+            for (const pattern of entry.mustInclude) {
+              if (!output.includes(pattern)) {
+                throw new Error(`[${name}] Expected output to contain "${pattern}" but it was not found.`);
+              }
+            }
+
+            for (const pattern of entry.mustExclude) {
+              if (output.includes(pattern)) {
+                throw new Error(`[${name}] Expected output NOT to contain "${pattern}" but it was found.`);
+              }
+            }
+
+            console.log(`  ✓ ${name}: all assertions passed`);
+          });
+        },
+      },
+    ],
+  };
+}
+
+const testConfigs = Object.entries(entries).map(([name, entry]) => createConfig(name, entry));
+
+module.exports = testConfigs;

--- a/packages/react-icons-atomic-webpack-loader/tsconfig.json
+++ b/packages/react-icons-atomic-webpack-loader/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "types": ["node"],
+    "target": "es2020",
+    "module": "commonjs",
+    "rootDir": "./src",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./lib",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
The idea of adding that plugin is a result of explorations in user land code with adding build transforms to support react-icons atomic API. 

This should help users migrate to atomic API in a more convenient way. 

The loader respects atomic API routing for svg / font icons and applies on both imports and reexports. 
