### PR TITLE
ci: support standalone project releases via separate release group and pipeline

### DIFF
--- a/.github/workflows/publish-standalone.yml
+++ b/.github/workflows/publish-standalone.yml
@@ -1,0 +1,159 @@
+name: Publish Standalone Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Run in dry-run mode (no publishing, no git commits)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  publish-standalone:
+    # Prevent infinite loops: skip if the commit was made by the build system itself
+    if: "!contains(github.event.head_commit.author.email, 'flubuild@microsoft.com')"
+    name: Publish standalone packages
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Validate branch
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "❌ ERROR: This workflow can only be run on the main branch" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Current ref: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GH_FLUENT_CI_APP_ID }}
+          private-key: ${{ secrets.GH_FLUENT_CI_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          filter: blob:none
+          fetch-depth: 50
+          fetch-tags: true
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Resolve standalone projects
+        id: projects
+        run: |
+          NX_NAMES=$(npx nx show projects -p "tag:npm:standalone" --sep ',')
+          echo "nx-names=$NX_NAMES" >> "$GITHUB_OUTPUT"
+          echo "### Standalone projects" >> $GITHUB_STEP_SUMMARY
+          echo "$NX_NAMES" | tr ',' '\n' | while read -r p; do echo "- $p" >> $GITHUB_STEP_SUMMARY; done
+
+      - name: Build packages
+        run: |
+          npx nx run-many -t build --projects=tag:npm:standalone
+
+      - name: Version packages (Nx Release)
+        run: |
+          npx nx release version --group=standalone --verbose
+
+      - name: Generate changelogs (Nx Release)
+        # --first-release: allows changelog generation when no prior git tag exists (first release).
+        # Safe to keep permanently — once per-package tags exist, they take priority and this flag becomes a no-op.
+        # Scoped here instead of global nx.json `automaticFromRef` to avoid masking tag-resolution failures in other release groups.
+        run: |
+          for pkg in $(echo "${{ steps.projects.outputs.nx-names }}" | tr ',' '\n'); do
+            VERSION=$(node -p "require('./packages/${pkg}/package.json').version")
+            echo "Generating changelog for ${pkg}@${VERSION}"
+            npx nx release changelog "$VERSION" --projects="$pkg" --first-release --no-git-tag --no-git-commit --verbose
+          done
+
+      - name: Update lockfile
+        run: npm install --package-lock-only
+
+      - name: Publish to npm (Nx Release)
+        if: ${{ !inputs.dry-run }}
+        run: |
+          npx nx release publish --projects=${{ steps.projects.outputs.nx-names }} --access public --verbose
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Config git credentials
+        run: git config user.email "flubuild@microsoft.com" && git config user.name "Fluent Build System"
+
+      - name: Commit version changes
+        if: ${{ !inputs.dry-run }}
+        run: |
+          git add -A
+          git commit -m "Release standalone packages [skip ci]"
+
+      - name: Tag releases
+        # Tags must be created manually after the final commit (which includes lockfile updates, changelogs, etc.)
+        # rather than by nx release (git.tag: false in nx.json) — nx would tag before the commit is finalized,
+        # causing tags to point to an intermediate state instead of the release commit.
+        if: ${{ !inputs.dry-run }}
+        run: |
+          for pkg in $(echo "${{ steps.projects.outputs.nx-names }}" | tr ',' '\n'); do
+            VERSION=$(node -p "require('./packages/${pkg}/package.json').version")
+            TAG="${pkg}@${VERSION}"
+            echo "Creating tag: $TAG"
+            git tag "$TAG"
+          done
+
+      - name: Push release
+        if: ${{ !inputs.dry-run }}
+        run: |
+          git push origin HEAD:main --follow-tags --tags
+
+      - name: Dry-run summary
+        if: ${{ inputs.dry-run }}
+        run: |
+          echo "## 🧪 Dry-run Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The following actions would have been performed:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 📦 Packages that would be published" >> $GITHUB_STEP_SUMMARY
+          for pkg in $(echo "${{ steps.projects.outputs.nx-names }}" | tr ',' '\n'); do
+            VERSION=$(node -p "require('./packages/${pkg}/package.json').version")
+            NAME=$(node -p "require('./packages/${pkg}/package.json').name")
+            echo "- \`${NAME}@${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          done
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 🏷️ Git operations that would be performed" >> $GITHUB_STEP_SUMMARY
+          echo "- Commit: \`Release standalone packages [skip ci]\`" >> $GITHUB_STEP_SUMMARY
+          for pkg in $(echo "${{ steps.projects.outputs.nx-names }}" | tr ',' '\n'); do
+            VERSION=$(node -p "require('./packages/${pkg}/package.json').version")
+            echo "- Tag: \`${pkg}@${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          done
+          echo "- Push to: \`origin/main\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 📝 Files modified (not committed)" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          git status --short >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Stage changed package files
+        if: ${{ inputs.dry-run }}
+        run: |
+          mkdir -p /tmp/changed-packages
+          git status --porcelain -- 'packages/' | awk '{print $NF}' | xargs -I{} cp --parents {} /tmp/changed-packages/ 2>/dev/null || true
+          cp package.json package-lock.json /tmp/changed-packages/
+
+      - name: Upload changed package files
+        if: ${{ inputs.dry-run }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: changed-packages-files
+          path: /tmp/changed-packages/
+          if-no-files-found: warn

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,7 +4,10 @@ This document describes the release process for Fluent UI System Icons across al
 
 ## Overview
 
-The entire repository is released together via the [`.github/workflows/publish.yml`](../.github/workflows/publish.yml) workflow. Releases are **manually triggered** and must be initiated from the `main` branch.
+The repository uses two separate release workflows:
+
+1. **[`.github/workflows/publish.yml`](../.github/workflows/publish.yml)** — Releases the core icon library packages (react, native, SVG) together. **Manually triggered** from the `main` branch.
+2. **[`.github/workflows/publish-standalone.yml`](../.github/workflows/publish-standalone.yml)** — Releases standalone tooling packages independently. **Manually triggered** from the `main` branch.
 
 ## Release Strategy
 
@@ -25,6 +28,13 @@ The following packages are published during each release:
 - `@fluentui/react-icons` - React Web SVG components inc font support
 - `@fluentui/react-icons-font-subsetting-webpack-plugin` - Webpack plugin for font subsetting
 - `@fluentui/react-native-icons` - React Native components
+
+#### Standalone npm Packages
+
+These packages are released independently via the `publish-standalone.yml` workflow and follow **zero-ver semver** (`0.x.y`):
+
+- `@fluentui/react-icons-atomic-webpack-loader` - Webpack loader for atomic icon imports
+- `@fluentui/react-icons-svg-sprite-subsetting-webpack-plugin` - Webpack plugin for SVG sprite subsetting
 
 #### Platform-Specific Packages
 
@@ -129,9 +139,10 @@ flowchart TD
 
 npm packages use **Nx Release** for version bumps and changelog generation:
 
-- Packages are organized into two **release groups** (configured in `nx.json`):
+- Packages are organized into release groups (configured in `nx.json`):
   - **`react`**: react-icons, webpack-plugin, react-native-icons → versioned with `REACT_VERSION`
   - **`native`**: svg-icons, svg-sprites → versioned with `NEW_VERSION`
+  - **`standalone`**: atomic-webpack-loader, svg-sprite-subsetting-webpack-plugin → versioned independently via conventional commits with zero-ver policy (`feat`/`fix` → patch, `feat!` → minor)
 - `skipLockFileUpdate` is enabled in nx config; the lockfile is updated explicitly after all version bumps via `npm install --package-lock-only`
 - Changelog is generated **per release group** (each with its respective version), based on **conventional commits** that modified `packages/{package-folder}/` only
 - Uses workspace-wide git tags (`1.1.{number}`) rather than package-specific tags

--- a/nx.json
+++ b/nx.json
@@ -24,6 +24,16 @@
       "native": {
         "projects": ["packages/svg-icons", "packages/svg-sprites"],
         "projectsRelationship": "independent"
+      },
+      "standalone": {
+        "projects": [
+          "packages/react-icons-atomic-webpack-loader",
+          "packages/react-icons-svg-sprite-subsetting-webpack-plugin"
+        ],
+        "projectsRelationship": "independent",
+        "version": {
+          "adjustSemverBumpsForZeroMajorVersion": true
+        }
       }
     },
     "version": {

--- a/packages/react-icons-atomic-webpack-loader/package.json
+++ b/packages/react-icons-atomic-webpack-loader/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluentui/react-icons-atomic-webpack-loader",
   "version": "0.0.0",
-  "private": true,
   "description": "Webpack loader that transforms barrel imports and re-exports from @fluentui/react-icons into atomic deep paths",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/react-icons-atomic-webpack-loader/project.json
+++ b/packages/react-icons-atomic-webpack-loader/project.json
@@ -3,7 +3,7 @@
   "name": "react-icons-atomic-webpack-loader",
   "projectType": "library",
   "sourceRoot": "packages/react-icons-atomic-webpack-loader/src",
-  "tags": [],
+  "tags": ["npm:standalone"],
   "targets": {
     "build": {
       "cache": true,

--- a/packages/react-icons-svg-sprite-subsetting-webpack-plugin/package.json
+++ b/packages/react-icons-svg-sprite-subsetting-webpack-plugin/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "description": "Webpack plugin to subset or merge SVG sprite assets used by @fluentui/react-icons svg-sprite APIs.",
   "main": "lib/index.js",
-  "private": true,
   "scripts": {
     "test": "npm run test:atomic && npm run test:merged && npm run test:manifest && npm run test:inline && npm run test:reference && npm run test:validation",
     "test:atomic": "webpack -c test/webpack.config.js",

--- a/packages/react-icons-svg-sprite-subsetting-webpack-plugin/project.json
+++ b/packages/react-icons-svg-sprite-subsetting-webpack-plugin/project.json
@@ -3,7 +3,7 @@
   "name": "react-icons-svg-sprite-subsetting-webpack-plugin",
   "projectType": "library",
   "sourceRoot": "packages/react-icons-svg-sprite-subsetting-webpack-plugin/src",
-  "tags": [],
+  "tags": ["npm:standalone"],
   "targets": {
     "build": {
       "cache": true,


### PR DESCRIPTION
> Needs https://github.com/microsoft/fluentui-system-icons/pull/1063

## Summary

Adds a new `standalone` release group and a dedicated publish workflow for independently-versioned npm packages that don't follow the main library's single-version policy.

The main goal behind this is to avoid "pre-release" publishing for packages that didnt have initial official version. Also this aligns with fluent publishing process where we embrace **zero major version** versioning by default when shipping new chunk of functionality (package) while validating it's stability against our user base.

### Changes

- **`nx.json`** — Added `standalone` release group with `projectsRelationship: "independent"` and `adjustSemverBumpsForZeroMajorVersion: true` (pending nx upgrade)
- **`packages/react-icons-atomic-webpack-loader`** — Removed `private: true`, added `npm:standalone` tag
- **`packages/react-icons-svg-sprite-subsetting-webpack-plugin`** — Removed `private: true`, added `npm:standalone` tag
- **`.github/workflows/publish-standalone.yml`** — New workflow:
  - Manually triggered from `main` only, with dry-run support
  - Resolves projects dynamically via `nx show projects -p "tag:npm:standalone"`
  - Uses conventional commits to determine version bumps (`nx release version`)
  - Generates per-project changelogs (`nx release changelog`)
  - Publishes via `nx release publish`
  - Creates per-package git tags (`{projectName}@{version}`) after commit for changelog range tracking
- **`docs/releases.md`** — Documented the standalone release group and new workflow

### How it works

- Version bumps are driven by conventional commits (inherited from shared nx config)
- Per-package git tags (`react-icons-atomic-webpack-loader@0.0.2`) enable nx to auto-resolve commit ranges for changelog and version calculation
- New packages can be added by setting the `npm:standalone` tag in their `project.json` and adding them to the `standalone` group in `nx.json`