### PR TITLE
docs: update standalone packages docs — replace alpha prerelease with zero-based semver

### DIFF
--- a/packages/docsite/stories/Icons/IconsBuildTransforms.mdx
+++ b/packages/docsite/stories/Icons/IconsBuildTransforms.mdx
@@ -41,7 +41,7 @@ The examples below use `svg` as the target path. Replace it with the appropriate
 Add [@fluentui/react-icons-atomic-webpack-loader](https://www.npmjs.com/package/@fluentui/react-icons-atomic-webpack-loader) to your project:
 
 ```bash
-npm install --save-dev @fluentui/react-icons-atomic-webpack-loader@alpha
+npm install --save-dev @fluentui/react-icons-atomic-webpack-loader
 ```
 
 Then add it to your webpack config:

--- a/packages/react-icons-atomic-webpack-loader/README.md
+++ b/packages/react-icons-atomic-webpack-loader/README.md
@@ -1,9 +1,7 @@
 # @fluentui/react-icons-atomic-webpack-loader
 
-> **⚠️ Alpha** — this package is available as an alpha prerelease only.
-> ⚠️ The API may change before the first stable release.
-
-> Install via `npm install @fluentui/react-icons-atomic-webpack-loader@alpha --save-dev`
+> **⚠️ 0.x** — this package is in early development and follows [zero-based major semver](https://0ver.org/).
+> Breaking changes may occur in minor releases until 1.0.
 
 Webpack loader that transforms barrel imports and re-exports from `@fluentui/react-icons` into atomic deep paths for better tree-shaking and smaller bundles.
 

--- a/packages/react-icons-svg-sprite-subsetting-webpack-plugin/README.md
+++ b/packages/react-icons-svg-sprite-subsetting-webpack-plugin/README.md
@@ -1,8 +1,7 @@
 # @fluentui/react-icons-svg-sprite-subsetting-webpack-plugin
 
-> **⚠️ Alpha** — this package is available as an alpha prerelease only.
->
-> Install via `npm i @fluentui/react-icons-svg-sprite-subsetting-webpack-plugin@alpha`
+> **⚠️ 0.x** — this package is in early development and follows [zero-based major semver](https://0ver.org/).
+> Breaking changes may occur in minor releases until 1.0.
 
 Webpack plugin that optimizes the `@fluentui/react-icons/svg-sprite/*` entrypoints.
 

--- a/packages/react-icons/docs/build-transforms.md
+++ b/packages/react-icons/docs/build-transforms.md
@@ -146,7 +146,7 @@ Replace every `svg` segment in the target paths below with your chosen target (`
 Install [`@fluentui/react-icons-atomic-webpack-loader`](../../react-icons-atomic-webpack-loader/README.md):
 
 ```bash
-npm install @fluentui/react-icons-atomic-webpack-loader@alpha --save-dev
+npm install @fluentui/react-icons-atomic-webpack-loader --save-dev
 ```
 
 Add the loader as an `enforce: 'pre'` rule so it runs before other loaders:

--- a/packages/react-icons/docs/preview-features/svg-sprites.md
+++ b/packages/react-icons/docs/preview-features/svg-sprites.md
@@ -126,9 +126,8 @@ export default defineConfig({
 
 ### Webpack Plugin
 
-> **⚠️ Alpha** — this package is available as an alpha prerelease only.
->
-> Install via `npm i @fluentui/react-icons-svg-sprite-subsetting-webpack-plugin@prerelease`
+> **⚠️ 0.x** — this package is in early development and follows [zero-based major semver](https://0ver.org/).
+> Breaking changes may occur in minor releases until 1.0.
 
 To leverage performance benefits to the fullest, use the Webpack SvgSprite Subsetting Plugin. It analyzes your application's actual icon usage at build time and strips unused icon definitions from the sprite files — ensuring only icons your app references are shipped.
 


### PR DESCRIPTION
## Summary

Updates documentation across standalone packages (`react-icons-atomic-webpack-loader`, `react-icons-svg-sprite-subsetting-webpack-plugin`) and related docs/storybook stories to reflect that these packages now use **zero-based major semver** (`0.x`) instead of alpha prereleases.

## Changes

- **Package READMEs** — replaced `⚠️ Alpha` prerelease notices with `⚠️ 0.x zero-ver` messaging linking to [0ver.org](https://0ver.org/)
- **Docsite stories** (`IconsBuildTransforms.mdx`) — removed `@alpha` dist tag from install command
- **React-icons docs** (`build-transforms.md`) — removed `@alpha` dist tag from install command
- **React-icons docs** (`preview-features/svg-sprites.md`) — replaced alpha notice for the subsetting webpack plugin with 0.x zero-ver messaging

> `@fluentui/react-icons@alpha` references for react-icons preview features (headless, svg-sprites API) were intentionally left unchanged — those are a separate concern.