### PR TITLE
fix(release): prevent cross-group version cascade to standalone packages

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -38,6 +38,7 @@
     },
     "version": {
       "conventionalCommits": true,
+      "updateDependents": "auto",
       "preserveMatchingDependencyRanges": ["devDependencies"],
       "fallbackCurrentVersionResolver": "disk",
       "git": {

--- a/packages/react-icons-atomic-webpack-loader/CHANGELOG.md
+++ b/packages/react-icons-atomic-webpack-loader/CHANGELOG.md
@@ -1,10 +1,3 @@
-## 2.0.325 (2026-04-24)
-
-### 🚀 Features
-
-- **react-icons-atomic-webpack-loader:** replace acorn parser with oxc-parser ([#1061](https://github.com/microsoft/fluentui-system-icons/pull/1061))
-- **react-icons-atomic-webpack-loader:** add svg-sprite variant support & fix acorn-ts invocation ([#1059](https://github.com/microsoft/fluentui-system-icons/pull/1059))
-
 ## 0.0.1 (2026-04-17)
 
 ### 🚀 Features

--- a/packages/react-icons-atomic-webpack-loader/package.json
+++ b/packages/react-icons-atomic-webpack-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-icons-atomic-webpack-loader",
-  "version": "2.0.325",
+  "version": "0.0.1",
   "description": "Webpack loader that transforms barrel imports and re-exports from @fluentui/react-icons into atomic deep paths",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/react-icons-svg-sprite-subsetting-webpack-plugin/CHANGELOG.md
+++ b/packages/react-icons-svg-sprite-subsetting-webpack-plugin/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 2.0.325 (2026-04-24)
-
-This release contains icon updates
-
 ## 0.0.1 (2026-04-17)
 
 ### 🚀 Features

--- a/packages/react-icons-svg-sprite-subsetting-webpack-plugin/package.json
+++ b/packages/react-icons-svg-sprite-subsetting-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-icons-svg-sprite-subsetting-webpack-plugin",
-  "version": "2.0.325",
+  "version": "0.0.1",
   "description": "Webpack plugin to subset or merge SVG sprite assets used by @fluentui/react-icons svg-sprite APIs.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
## Problem

The [publish workflow run](https://github.com/microsoft/fluentui-system-icons/actions/runs/24906607811/job/72937464208) incorrectly bumped standalone group packages (`react-icons-atomic-webpack-loader`, `react-icons-svg-sprite-subsetting-webpack-plugin`) to the monorepo version `2.0.325`.

These packages are in the `standalone` release group and should NOT be versioned when the `react` or `native` groups are released.

## Root Cause

Nx v22 changed the default `version.updateDependents` from `"auto"` to `"always"`. With `"always"`, running `nx release version --group=react` cascades version bumps to **all** dependents of `react-icons` across release group boundaries — including standalone packages that have `@fluentui/react-icons` as a devDependency.

## Fix

- Set `updateDependents: "auto"` in `nx.json` to restore the pre-v22 behavior where cascading only applies within the same release group when filtered by `--group`.
- Reverted package versions back to `0.0.1`.
- Removed erroneous `2.0.325` changelog entries.

## Affected Packages

- `@fluentui/react-icons-atomic-webpack-loader`
- `@fluentui/react-icons-svg-sprite-subsetting-webpack-plugin`