### PR TITLE
ci: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,11 @@
+/.github/CODEOWNERS @microsoft/cxe-prg @react-native-sdk-admins
 /.github/ISSUE_TEMPLATE/01-react-icons-bug-report.yml @microsoft/cxe-prg
 /.github/ISSUE_TEMPLATE/02-react-icons-feature-request.yml @microsoft/cxe-prg
 /.github/react-icons.instructions.md @microsoft/cxe-prg
 /.github/workflows/copilot-setup-steps.yml @microsoft/cxe-prg
-/.github/workflows/pr.yml @microsoft/cxe-prg @spencer-nelson
+/.github/workflows/pr.yml @microsoft/cxe-prg @react-native-sdk-admins @spencer-nelson
 /.github/workflows/pr-summary-comment.yml @microsoft/cxe-prg
-/.github/workflows/publish.yml @microsoft/cxe-prg @spencer-nelson
+/.github/workflows/publish.yml @microsoft/cxe-prg @react-native-sdk-admins @spencer-nelson
 /.github/workflows/publish-prerelease.yml @microsoft/cxe-prg
 /.github/workflows/bundle-size.baseline.yml @microsoft/cxe-prg
 /.github/workflows/deploy-docsite.yml @microsoft/cxe-prg
@@ -16,13 +17,15 @@ packages/docsite @microsoft/cxe-prg
 packages/icon-app @microsoft/cxe-prg
 packages/react-icons @microsoft/cxe-prg @microsoft/cxe-red
 packages/react-icons-font-subsetting-webpack-plugin @MLoughry @microsoft/cxe-prg
-packages/svg-icons @tomi-msft
-packages/svg-sprites @tomi-msft
-packages/react-native-icons @praveen970
+packages/react-icons-svg-sprite-subsetting-webpack-plugin @microsoft/cxe-prg
+packages/react-icons-atomic-webpack-loader @microsoft/cxe-prg
+packages/svg-icons
+packages/svg-sprites
+packages/react-native-icons @react-native-sdk-admins
 
 
 ## Build Systems
-android/ @praveen970
+android/ @react-native-sdk-admins
 flutter/ @nickromano
 ios/ @nickromano
 package-lock.json @microsoft/cxe-prg

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,11 @@
-/.github/CODEOWNERS @microsoft/cxe-prg @react-native-sdk-admins
+/.github/CODEOWNERS @microsoft/cxe-prg @microsoft/react-native-sdk-admins
 /.github/ISSUE_TEMPLATE/01-react-icons-bug-report.yml @microsoft/cxe-prg
 /.github/ISSUE_TEMPLATE/02-react-icons-feature-request.yml @microsoft/cxe-prg
 /.github/react-icons.instructions.md @microsoft/cxe-prg
 /.github/workflows/copilot-setup-steps.yml @microsoft/cxe-prg
-/.github/workflows/pr.yml @microsoft/cxe-prg @react-native-sdk-admins @spencer-nelson
+/.github/workflows/pr.yml @microsoft/cxe-prg @microsoft/react-native-sdk-admins @spencer-nelson
 /.github/workflows/pr-summary-comment.yml @microsoft/cxe-prg
-/.github/workflows/publish.yml @microsoft/cxe-prg @react-native-sdk-admins @spencer-nelson
+/.github/workflows/publish.yml @microsoft/cxe-prg @microsoft/react-native-sdk-admins @spencer-nelson
 /.github/workflows/publish-prerelease.yml @microsoft/cxe-prg
 /.github/workflows/bundle-size.baseline.yml @microsoft/cxe-prg
 /.github/workflows/deploy-docsite.yml @microsoft/cxe-prg
@@ -21,11 +21,11 @@ packages/react-icons-svg-sprite-subsetting-webpack-plugin @microsoft/cxe-prg
 packages/react-icons-atomic-webpack-loader @microsoft/cxe-prg
 packages/svg-icons
 packages/svg-sprites
-packages/react-native-icons @react-native-sdk-admins
+packages/react-native-icons @microsoft/react-native-sdk-admins
 
 
 ## Build Systems
-android/ @react-native-sdk-admins
+android/ @microsoft/react-native-sdk-admins
 flutter/ @nickromano
 ios/ @nickromano
 package-lock.json @microsoft/cxe-prg


### PR DESCRIPTION
Update CODEOWNERS to:

- Replace individual user `@praveen970` with `@react-native-sdk-admins` team for react-native-icons and android paths
- Add `@react-native-sdk-admins` as co-owner of `pr.yml` and `publish.yml` workflows
- Add ownership entries for new packages (`react-icons-svg-sprite-subsetting-webpack-plugin`, `react-icons-atomic-webpack-loader`)
- Remove stale individual ownership from `svg-icons` and `svg-sprites`