### PR TITLE
fix(react-icons-atomic-webpack-loader): skip indirect re-exports to avoid duplicate-export build failures

### DIFF
--- a/packages/react-icons-atomic-webpack-loader/package.json
+++ b/packages/react-icons-atomic-webpack-loader/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "tsc -p .",
-    "test": "webpack -c test/webpack.config.js"
+    "test": "vitest run && webpack -c test/webpack.config.js"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/react-icons-atomic-webpack-loader/src/transform.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/transform.ts
@@ -75,14 +75,11 @@ export function transformSource(source: string, options: TransformOptions): Tran
 
   for (const exp of staticExports) {
     const relevantEntries = exp.entries.filter(
-      (e) =>
-        e.moduleRequest?.value === MODULE_NAME &&
-        e.exportName.kind === 'Name' &&
-        e.start >= exp.start &&
-        e.end <= exp.end,
+      (e) => e.moduleRequest?.value === MODULE_NAME && e.exportName.kind === 'Name',
     );
-
     if (relevantEntries.length === 0) continue;
+
+    if (source.startsWith('import', exp.start)) continue;
 
     const lines: string[] = [];
 

--- a/packages/react-icons-atomic-webpack-loader/src/transform.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/transform.ts
@@ -79,6 +79,9 @@ export function transformSource(source: string, options: TransformOptions): Tran
     );
     if (relevantEntries.length === 0) continue;
 
+    // Skip indirect re-exports (`import { X } from '...'; export { X };`): oxc reports these as static
+    // exports anchored at the originating `import` statement. The import loop above has already
+    // rewritten that range, so emitting again here would produce duplicate declarations.
     if (source.startsWith('import', exp.start)) continue;
 
     const lines: string[] = [];

--- a/packages/react-icons-atomic-webpack-loader/src/transform.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/transform.ts
@@ -75,8 +75,13 @@ export function transformSource(source: string, options: TransformOptions): Tran
 
   for (const exp of staticExports) {
     const relevantEntries = exp.entries.filter(
-      (e) => e.moduleRequest?.value === MODULE_NAME && e.exportName.kind === 'Name',
+      (e) =>
+        e.moduleRequest?.value === MODULE_NAME &&
+        e.exportName.kind === 'Name' &&
+        e.start >= exp.start &&
+        e.end <= exp.end,
     );
+
     if (relevantEntries.length === 0) continue;
 
     const lines: string[] = [];

--- a/packages/react-icons-atomic-webpack-loader/test/src/aliased-indirect-reexports.js
+++ b/packages/react-icons-atomic-webpack-loader/test/src/aliased-indirect-reexports.js
@@ -1,0 +1,3 @@
+import { AddFilled as MyAdd, ArrowLeftRegular as MyArrow } from '@fluentui/react-icons';
+
+export { MyAdd, MyArrow };

--- a/packages/react-icons-atomic-webpack-loader/test/src/indirect-reexports.js
+++ b/packages/react-icons-atomic-webpack-loader/test/src/indirect-reexports.js
@@ -1,0 +1,3 @@
+import { AddFilled, ArrowLeftRegular, iconFilledClassName } from '@fluentui/react-icons';
+
+export { AddFilled, ArrowLeftRegular, iconFilledClassName };

--- a/packages/react-icons-atomic-webpack-loader/test/src/mixed-reexports.js
+++ b/packages/react-icons-atomic-webpack-loader/test/src/mixed-reexports.js
@@ -1,0 +1,4 @@
+import { AddFilled, bundleIcon } from '@fluentui/react-icons';
+
+export { AddFilled, bundleIcon };
+export { ArrowLeftRegular } from '@fluentui/react-icons';

--- a/packages/react-icons-atomic-webpack-loader/test/src/renamed-indirect-reexports.js
+++ b/packages/react-icons-atomic-webpack-loader/test/src/renamed-indirect-reexports.js
@@ -1,0 +1,3 @@
+import { AddFilled, ArrowLeftRegular } from '@fluentui/react-icons';
+
+export { AddFilled as MyAdd, ArrowLeftRegular as MyArrow };

--- a/packages/react-icons-atomic-webpack-loader/test/transform.test.ts
+++ b/packages/react-icons-atomic-webpack-loader/test/transform.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { transformSource } from '../src/transform';
+
+const transform = (source: string, iconVariant: 'svg' | 'fonts' | 'svg-sprite' = 'svg') =>
+  transformSource(source, { iconVariant, path: 'input.js' }).code;
+
+describe('transformSource', () => {
+  describe('imports', () => {
+    it('rewrites a single named icon import to its atomic path', () => {
+      expect(transform(`import { AddFilled } from '@fluentui/react-icons';`)).toBe(
+        `import { AddFilled } from '@fluentui/react-icons/svg/add';`,
+      );
+    });
+
+    it('splits a multi-binding import into one statement per atomic path', () => {
+      expect(transform(`import { AddFilled, ArrowLeftRegular } from '@fluentui/react-icons';`)).toBe(
+        [
+          `import { AddFilled } from '@fluentui/react-icons/svg/add';`,
+          `import { ArrowLeftRegular } from '@fluentui/react-icons/svg/arrow-left';`,
+        ].join('\n'),
+      );
+    });
+
+    it('routes utility bindings to /utils', () => {
+      expect(transform(`import { bundleIcon, iconFilledClassName } from '@fluentui/react-icons';`)).toBe(
+        [
+          `import { bundleIcon } from '@fluentui/react-icons/utils';`,
+          `import { iconFilledClassName } from '@fluentui/react-icons/utils';`,
+        ].join('\n'),
+      );
+    });
+
+    it('routes provider bindings to /providers', () => {
+      expect(transform(`import { useIconContext, IconDirectionContextProvider } from '@fluentui/react-icons';`)).toBe(
+        [
+          `import { useIconContext } from '@fluentui/react-icons/providers';`,
+          `import { IconDirectionContextProvider } from '@fluentui/react-icons/providers';`,
+        ].join('\n'),
+      );
+    });
+
+    it('preserves local aliases on icon imports', () => {
+      expect(transform(`import { AddFilled as MyAdd } from '@fluentui/react-icons';`)).toBe(
+        `import { AddFilled as MyAdd } from '@fluentui/react-icons/svg/add';`,
+      );
+    });
+
+    it('honors the iconVariant option for fonts', () => {
+      expect(transform(`import { AddFilled } from '@fluentui/react-icons';`, 'fonts')).toBe(
+        `import { AddFilled } from '@fluentui/react-icons/fonts/add';`,
+      );
+    });
+
+    it('honors the iconVariant option for svg-sprite', () => {
+      expect(transform(`import { AddFilled } from '@fluentui/react-icons';`, 'svg-sprite')).toBe(
+        `import { AddFilled } from '@fluentui/react-icons/svg-sprite/add';`,
+      );
+    });
+
+    it('leaves imports from other modules untouched', () => {
+      const source = `import React from 'react';\nimport { something } from 'other-mod';`;
+      expect(transform(source)).toBe(source);
+    });
+  });
+
+  describe('direct re-exports', () => {
+    it('rewrites `export { X } from "@fluentui/react-icons"` to the atomic path', () => {
+      expect(transform(`export { AddFilled } from '@fluentui/react-icons';`)).toBe(
+        `export { AddFilled } from '@fluentui/react-icons/svg/add';`,
+      );
+    });
+
+    it('splits multi-name direct re-exports into one statement per atomic path', () => {
+      expect(transform(`export { AddFilled, ArrowLeftRegular } from '@fluentui/react-icons';`)).toBe(
+        [
+          `export { AddFilled } from '@fluentui/react-icons/svg/add';`,
+          `export { ArrowLeftRegular } from '@fluentui/react-icons/svg/arrow-left';`,
+        ].join('\n'),
+      );
+    });
+
+    it('preserves renames on direct re-exports', () => {
+      expect(transform(`export { AddFilled as MyAdd } from '@fluentui/react-icons';`)).toBe(
+        `export { AddFilled as MyAdd } from '@fluentui/react-icons/svg/add';`,
+      );
+    });
+  });
+
+  describe('indirect re-exports (regression)', () => {
+    it('rewrites only the import for `import { X }; export { X };`', () => {
+      const source = `import { AddFilled } from '@fluentui/react-icons';\nexport { AddFilled };`;
+
+      expect(transform(source)).toMatchInlineSnapshot(`
+        "import { AddFilled } from '@fluentui/react-icons/svg/add';
+        export { AddFilled };"
+      `);
+    });
+
+    it('does not emit a duplicate export for multi-binding indirect re-exports', () => {
+      const source = [
+        `import { AddFilled, ArrowLeftRegular, iconFilledClassName } from '@fluentui/react-icons';`,
+        ``,
+        `export { AddFilled, ArrowLeftRegular, iconFilledClassName };`,
+      ].join('\n');
+
+      expect(transform(source)).toMatchInlineSnapshot(`
+        "import { AddFilled } from '@fluentui/react-icons/svg/add';
+        import { ArrowLeftRegular } from '@fluentui/react-icons/svg/arrow-left';
+        import { iconFilledClassName } from '@fluentui/react-icons/utils';
+
+        export { AddFilled, ArrowLeftRegular, iconFilledClassName };"
+      `);
+    });
+
+    it('handles aliased import + plain export (`import { X as Y }; export { Y };`)', () => {
+      const source = [
+        `import { AddFilled as MyAdd, ArrowLeftRegular as MyArrow } from '@fluentui/react-icons';`,
+        ``,
+        `export { MyAdd, MyArrow };`,
+      ].join('\n');
+
+      expect(transform(source)).toMatchInlineSnapshot(`
+        "import { AddFilled as MyAdd } from '@fluentui/react-icons/svg/add';
+        import { ArrowLeftRegular as MyArrow } from '@fluentui/react-icons/svg/arrow-left';
+
+        export { MyAdd, MyArrow };"
+      `);
+    });
+
+    it('handles plain import + renamed export (`import { X }; export { X as Y };`)', () => {
+      const source = [
+        `import { AddFilled, ArrowLeftRegular } from '@fluentui/react-icons';`,
+        ``,
+        `export { AddFilled as MyAdd, ArrowLeftRegular as MyArrow };`,
+      ].join('\n');
+
+      expect(transform(source)).toMatchInlineSnapshot(`
+        "import { AddFilled } from '@fluentui/react-icons/svg/add';
+        import { ArrowLeftRegular } from '@fluentui/react-icons/svg/arrow-left';
+
+        export { AddFilled as MyAdd, ArrowLeftRegular as MyArrow };"
+      `);
+    });
+  });
+
+  describe('mixed indirect + direct re-exports', () => {
+    it('rewrites the direct branch and leaves the indirect branch intact', () => {
+      const source = [
+        `import { AddFilled, bundleIcon } from '@fluentui/react-icons';`,
+        ``,
+        `export { AddFilled, bundleIcon };`,
+        `export { ArrowLeftRegular } from '@fluentui/react-icons';`,
+      ].join('\n');
+
+      expect(transform(source)).toMatchInlineSnapshot(`
+        "import { AddFilled } from '@fluentui/react-icons/svg/add';
+        import { bundleIcon } from '@fluentui/react-icons/utils';
+
+        export { AddFilled, bundleIcon };
+        export { ArrowLeftRegular } from '@fluentui/react-icons/svg/arrow-left';"
+      `);
+    });
+  });
+});

--- a/packages/react-icons-atomic-webpack-loader/test/webpack.config.js
+++ b/packages/react-icons-atomic-webpack-loader/test/webpack.config.js
@@ -39,6 +39,28 @@ const entries = {
     ],
     mustExclude: ['"@fluentui/react-icons"'],
   },
+  'aliased-indirect-reexports': {
+    src: './src/aliased-indirect-reexports.js',
+    loaderOptions: {},
+    mustInclude: ['@fluentui/react-icons/svg/add', '@fluentui/react-icons/svg/arrow-left'],
+    mustExclude: ['"@fluentui/react-icons"'],
+  },
+  'renamed-indirect-reexports': {
+    src: './src/renamed-indirect-reexports.js',
+    loaderOptions: {},
+    mustInclude: ['@fluentui/react-icons/svg/add', '@fluentui/react-icons/svg/arrow-left'],
+    mustExclude: ['"@fluentui/react-icons"'],
+  },
+  'mixed-reexports': {
+    src: './src/mixed-reexports.js',
+    loaderOptions: {},
+    mustInclude: [
+      '@fluentui/react-icons/svg/add',
+      '@fluentui/react-icons/svg/arrow-left',
+      '@fluentui/react-icons/utils',
+    ],
+    mustExclude: ['"@fluentui/react-icons"'],
+  },
   'fonts-imports': {
     src: './src/fonts-imports.js',
     loaderOptions: { iconVariant: 'fonts' },

--- a/packages/react-icons-atomic-webpack-loader/test/webpack.config.js
+++ b/packages/react-icons-atomic-webpack-loader/test/webpack.config.js
@@ -29,6 +29,16 @@ const entries = {
     ],
     mustExclude: ['"@fluentui/react-icons"'],
   },
+  'indirect-reexports': {
+    src: './src/indirect-reexports.js',
+    loaderOptions: {},
+    mustInclude: [
+      '@fluentui/react-icons/svg/add',
+      '@fluentui/react-icons/svg/arrow-left',
+      '@fluentui/react-icons/utils',
+    ],
+    mustExclude: ['"@fluentui/react-icons"'],
+  },
   'fonts-imports': {
     src: './src/fonts-imports.js',
     loaderOptions: { iconVariant: 'fonts' },


### PR DESCRIPTION
## Problem

The atomic webpack loader produces a duplicate export when a module re-exports a barrel-imported icon binding indirectly:

input:

```js
import { X } from '@fluentui/react-icons';
export { X };
```

output:

```js
export { X } from '@fluentui/react-icons/x';
export { X };
```

`oxc-parser` anchors the `StaticExport.{start,end}` of an indirect re-export to the originating `import` statement (not the `export` line), so the loader's `src.overwrite(exp.start, exp.end, …)` lands on the import range that the import-rewrite loop has already overwritten, while the original `export { X };` line is left untouched. Webpack then dies with:

```
Module parse failed: Duplicate export 'X'
```

This is reproducible against `@1js/fluent-icons-web/lib/types.js` (and other published packages — `@editor/settings`, `@office-iss/canvas-contextual-pal`) in OWA.

## Fix

Direct (`export { X } from 'mod';`) and indirect (`import { X } from 'mod'; export { X };`) re-exports are indistinguishable at the entry level — same `moduleRequest`, same `importName`/`exportName`/`localName` kinds. They differ only in where `oxc-parser` anchors the outer `StaticExport` record:

| Pattern | Outer record anchored at | Entry position |
|---|---|---|
| direct | the `export … from` statement | inside outer range |
| indirect | the originating `import` statement | outside outer range (points at the actual `export { X };` line) |

Add two clauses to the export-entry filter so we only rewrite entries whose own `[start, end]` falls inside their enclosing record's `[start, end]`:

```ts
e.start >= exp.start &&
e.end <= exp.end,
```

The import-rewrite loop already redirects the local binding to the atomic path, so the original `export { X };` continues to resolve correctly with zero extra code emitted.

## Test

Four fixtures exercise the indirect pattern and its variants; all fail pre-fix with `Module parse failed: Duplicate export …` and build cleanly post-fix:

- `test/src/indirect-reexports.js` — `export { AddFilled, ArrowLeftRegular, iconFilledClassName };`
- `test/src/aliased-indirect-reexports.js` — aliased import + plain export (`import { AddFilled as MyAdd … }; export { MyAdd, … };`)
- `test/src/renamed-indirect-reexports.js` — plain import + renamed export (`export { AddFilled as MyAdd, … };`)
- `test/src/mixed-reexports.js` — both indirect and direct re-exports in the same module

The `verify-transforms` plugin asserts the expected atomic paths (`@fluentui/react-icons/svg/add`, `…/svg/arrow-left`, `…/utils`) appear in each bundle and the barrel name (`"@fluentui/react-icons"`) does not.