### PR TITLE
feat(importer): detect duplicate destination filenames in generate.js

### DIFF
--- a/importer/generate.js
+++ b/importer/generate.js
@@ -42,6 +42,12 @@ const parseArgs = (args=process.argv.slice(2)) => {
       describe: 'Keep original directories in output',
       default: false,
     })
+    .option('on-duplicate', {
+      type: 'string',
+      choices: ['fail', 'warn', 'ignore'],
+      describe: 'How to handle two source folders producing the same destination filename',
+      default: 'fail',
+    })
     .help()
     .wrap(Math.min(120, process.stdout.columns || 120))
     .argv;
@@ -49,6 +55,7 @@ const parseArgs = (args=process.argv.slice(2)) => {
   /**
    * @typedef {'react'|'android'|'ios'|'flutter'} TargetType
    * @typedef {'svg'|'xml'|'pdf'|'tsx'} ExtensionType
+   * @typedef {'fail'|'warn'|'ignore'} OnDuplicate
    *
    * @typedef {{
    *   SRC_PATH: string,
@@ -56,7 +63,8 @@ const parseArgs = (args=process.argv.slice(2)) => {
    *   EXTENSION: ExtensionType,
    *   TARGET: TargetType,
    *   SELECTOR: boolean,
-   *   KEEP_DIRS: boolean
+   *   KEEP_DIRS: boolean,
+   *   ON_DUPLICATE: OnDuplicate,
    * }} ParseResult
    */
 
@@ -67,10 +75,30 @@ const parseArgs = (args=process.argv.slice(2)) => {
     TARGET: /** @type {TargetType} */ (argv.target),
     SELECTOR: Boolean(argv.selector),
     KEEP_DIRS: Boolean(argv.keepdirs),
+    ON_DUPLICATE: /** @type {OnDuplicate} */ (argv['on-duplicate']),
   });
 };
 
-const { SRC_PATH, DEST_PATH, EXTENSION, TARGET, SELECTOR, KEEP_DIRS } = parseArgs();
+const { SRC_PATH, DEST_PATH, EXTENSION, TARGET, SELECTOR, KEEP_DIRS, ON_DUPLICATE } = parseArgs();
+
+/**
+ * Source folders known to collide with canonical asset folders today.
+ * These folders appear to be staging artifacts (no metadata.json, contain SVG
+ * files named after the OPPOSITE icon, e.g. `Arrow Undo Temp RTL/SVG/ic_fluent_arrow_redo_*.svg`).
+ * They cause non-deterministic atom output because multiple source folders
+ * write to the same intermediate filename — see issue tracker for cleanup.
+ * Until they are removed from `assets/`, collisions involving these folders
+ * are downgraded to warnings so the build does not fail today.
+ *
+ * TODO: remove this allowlist once the `* Temp (LTR|RTL)` folders are deleted
+ * from `assets/`.
+ */
+const KNOWN_DUPLICATE_SOURCE = / Temp (LTR|RTL)(\/|\\|$)/;
+
+/** @type {Map<string, string>} destFile -> first srcFile that wrote it */
+const writtenFiles = new Map();
+/** @type {Array<{ destFile: string, previousSrc: string, conflictingSrc: string, allowlisted: boolean }>} */
+const duplicateCollisions = [];
 const ICON_OUTLINE_STYLE = '_regular'
 const ICON_FILLED_STYLE = '_filled'
 const ICON_LIGHT_STYLE = '_light'
@@ -166,6 +194,14 @@ function processFolder(srcPath, destPath, folderDepth) {
         if (!fs.existsSync(destPath)) {
           fs.mkdirSync(destPath)
         }
+        const previousSrc = writtenFiles.get(destFile);
+        if (previousSrc && previousSrc !== srcFile) {
+          const allowlisted =
+            KNOWN_DUPLICATE_SOURCE.test(previousSrc) || KNOWN_DUPLICATE_SOURCE.test(srcFile);
+          duplicateCollisions.push({ destFile, previousSrc, conflictingSrc: srcFile, allowlisted });
+        } else {
+          writtenFiles.set(destFile, srcFile);
+        }
         fs.copyFileSync(srcFile, destFile);
         // Generate selector if both filled/regular styles are available
         if (SELECTOR && file.endsWith(SVG_EXTENSION)) {
@@ -240,3 +276,52 @@ export default ${iconName + REACT_SUFFIX};
     if (err) throw err;
   });
 }
+
+/**
+ * Report any duplicate-destination collisions detected during the walk.
+ *
+ * The walker is async-callback based and has no explicit completion signal,
+ * so we hook `process.on('exit')` which fires after all queued callbacks drain
+ * and Node would otherwise exit naturally.
+ *
+ * Behaviour per `--on-duplicate`:
+ *   - fail    (default): non-zero exit if any non-allowlisted collision occurred
+ *   - warn             : prints all collisions but keeps exit code 0
+ *   - ignore           : prints nothing
+ *
+ * Collisions where either side matches `KNOWN_DUPLICATE_SOURCE` are downgraded
+ * to a warning even under `--on-duplicate=fail`.
+ */
+process.on('exit', () => {
+  if (ON_DUPLICATE === 'ignore' || duplicateCollisions.length === 0) {
+    return;
+  }
+  const blocking = duplicateCollisions.filter((c) => !c.allowlisted);
+  const allowlisted = duplicateCollisions.filter((c) => c.allowlisted);
+  /** @param {typeof duplicateCollisions} list */
+  const formatList = (list) =>
+    list
+      .map(
+        (c) =>
+          `  - ${c.destFile}\n      first : ${c.previousSrc}\n      collide: ${c.conflictingSrc}`
+      )
+      .join('\n');
+  if (allowlisted.length > 0) {
+    console.warn(
+      `\n[generate.js] ${allowlisted.length} known duplicate destination(s) ` +
+        `(allowlisted via KNOWN_DUPLICATE_SOURCE):\n${formatList(allowlisted)}\n`
+    );
+  }
+  if (blocking.length > 0) {
+    const message =
+      `\n[generate.js] ${blocking.length} duplicate destination(s) detected. ` +
+      `Two source folders produced the same output filename; output is non-deterministic. ` +
+      `Rename one of the source folders or remove the duplicate asset.\n${formatList(blocking)}\n`;
+    if (ON_DUPLICATE === 'fail') {
+      console.error(message);
+      process.exitCode = 1;
+    } else {
+      console.warn(message);
+    }
+  }
+});


### PR DESCRIPTION
### Summary

`importer/generate.js` recursively walks `assets/` and copies each SVG into a flat `intermediate/` directory using only the source filename. When two different source folders contain SVGs with the same filename, both files write to the same destination — and because the walker uses `fs.readdir` + async `fs.stat` + `fs.copyFileSync`, the byte content of the destination is non-deterministic between builds.

This change adds a small detector that records the first source folder to claim each destination filename. When a second source folder tries to write the same destination, the collision is recorded and reported at process exit. Behaviour is configurable via a new `--on-duplicate=fail|warn|ignore` flag (default **fail**), so future PRs that add a colliding asset folder will fail in CI instead of silently producing different output on each run.

Refs #1009 (similar duplicate-asset issue previously fixed by hand).

### Why this matters

Two clean builds of `@fluentui/react-icons` from the same source code produce **different bytes** for ~4 atom files + several barrel chunks + all 3 font binaries on each run. Investigation traced this to `assets/` containing duplicate source folders whose SVG filenames collide on copy. The runtime output (which path data ends up in `lib/atoms/svg/<icon>.js`) depends on which `fs.copyFileSync` finishes last.

### What the detector does

- **Tracks**: a `Map<destFile, srcFile>` populated on every copy
- **Reports**: a `process.on('exit')` hook that fires after the async walker drains, groups collisions into _blocking_ and _allowlisted_
- **`--on-duplicate=fail`** (default): non-zero exit if any non-allowlisted collision was recorded
- **`--on-duplicate=warn`**: prints the same report, keeps exit 0
- **`--on-duplicate=ignore`**: silent
- **Allowlist** (`KNOWN_DUPLICATE_SOURCE` regex matching `/ Temp (LTR|RTL)$/`): downgrades collisions involving today's known-dirty folders to warnings so this PR does not break the build. The allowlist has a `TODO` pointing to the asset-cleanup task below.

### Known duplicate sources — needs design-team action

Today's run reports **136 colliding writes** affecting **74 unique intermediate filenames**, all originating from **20 asset folders** matching `* Temp (LTR|RTL)`. These look like staging artifacts (no `metadata.json`, contain SVGs named after the OPPOSITE icon — e.g. `assets/Arrow Undo Temp RTL/SVG/ic_fluent_arrow_redo_*.svg`):

| Icon family | Folders to remove |
| --- | --- |
| Arrow Redo | `assets/Arrow Redo Temp LTR/`, `assets/Arrow Redo Temp RTL/` |
| Arrow Undo | `assets/Arrow Undo Temp LTR/`, `assets/Arrow Undo Temp RTL/` |
| Table Freeze Column | `assets/Table Freeze Column Temp LTR/`, `assets/Table Freeze Column Temp RTL/` |
| Table Freeze Column And Row | `assets/Table Freeze Column And Row Temp LTR/`, `assets/Table Freeze Column And Row Temp RTL/` |
| Text Align Left | `assets/Text Align Left Temp LTR/`, `assets/Text Align Left Temp RTL/` |
| Text First Line | `assets/Text First Line Temp LTR/`, `assets/Text First Line Temp RTL/` |
| Text Grammar Arrow Left | `assets/Text Grammar Arrow Left Temp LTR/`, `assets/Text Grammar Arrow Left Temp RTL/` |
| Text Grammar Arrow Right | `assets/Text Grammar Arrow Right Temp LTR/`, `assets/Text Grammar Arrow Right Temp RTL/` |
| Text Hanging | `assets/Text Hanging Temp LTR/`, `assets/Text Hanging Temp RTL/` |
| Text Paragraph | `assets/Text Paragraph Temp LTR/`, `assets/Text Paragraph Temp RTL/` |

**Requested action from the design / icon-asset team**: confirm these 20 folders are no longer needed and remove them in a follow-up PR. Once they are gone, the `KNOWN_DUPLICATE_SOURCE` allowlist + its TODO can be deleted, and React atom / font output will become byte-deterministic across runs.

Before merging that follow-up please also confirm with the iOS/Android/Flutter pipeline owners that these `Temp` folders are not consumed by any non-React generator.

### Verification

| Test | Result |
| --- | --- |
| `node importer/generate.js … --target=react` on full `assets/` (default `fail`) | 136 collisions, all allowlisted → exit 0 |
| Synthetic two-folder collision (default `fail`) | Reports + exit 1 |
| Same fixture with `--on-duplicate=warn` | Reports + exit 0 |
| Same fixture with `--on-duplicate=ignore` | Silent + exit 0 |

### Sample report output

```
[generate.js] 136 known duplicate destination(s) (allowlisted via KNOWN_DUPLICATE_SOURCE):
  - intermediate/ic_fluent_arrow_undo_24_regular.svg
      first : ../../assets/Arrow Undo/SVG/ic_fluent_arrow_undo_24_regular.svg
      collide: ../../assets/Arrow Undo Temp LTR/SVG/ic_fluent_arrow_undo_24_regular.svg
  - intermediate/ic_fluent_arrow_undo_24_regular.svg
      first : ../../assets/Arrow Undo/SVG/ic_fluent_arrow_undo_24_regular.svg
      collide: ../../assets/Arrow Redo Temp RTL/SVG/ic_fluent_arrow_undo_24_regular.svg
  …
```

### Out of scope

- Removal of the 20 Temp folders (separate PR, needs design-team sign-off)
- Making the walker synchronous (orthogonal; current change is sufficient since detection is order-independent)
- Replacing the existing fix from #1009 — left untouched
