### PR TITLE
feat(react-icons): add image (CSS mask / <img/>) icon API

### DIFF
--- a/packages/icon-app/package.json
+++ b/packages/icon-app/package.json
@@ -14,7 +14,9 @@
   "devDependencies": {
     "@types/react": "19.1.13",
     "@types/react-dom": "19.1.9",
+    "css-loader": "^7.1.4",
     "html-webpack-plugin": "^5.6.3",
+    "style-loader": "^3.3.4",
     "ts-loader": "9.5.4",
     "typescript": "5.0.4",
     "webpack": "^5.100.2",

--- a/packages/icon-app/src/app.tsx
+++ b/packages/icon-app/src/app.tsx
@@ -4,6 +4,7 @@ import { makeStyles } from '@griffel/react';
 const Atoms = React.lazy(() => import('./atoms').then((mod) => ({ default: mod.Atoms })));
 const Chunk = React.lazy(() => import('./chunk').then((mod) => ({ default: mod.Chunk })));
 const All = React.lazy(() => import('./all').then((mod) => ({ default: mod.All })));
+const Image = React.lazy(() => import('./image').then((mod) => ({ default: mod.Image })));
 
 const useRootStyles = makeStyles({
   root: {
@@ -15,7 +16,7 @@ const useRootStyles = makeStyles({
 
 export function App() {
   const styles = useRootStyles();
-  const [state, setState] = React.useState<'atoms' | 'all' | 'chunk' | null>(null);
+  const [state, setState] = React.useState<'atoms' | 'all' | 'chunk' | 'image' | null>(null);
 
   return (
     <main>
@@ -38,6 +39,10 @@ export function App() {
             <p>Demonstration of Atoms icons (import per icon)</p>
             <button onClick={() => setState('atoms')}>Atoms</button>
           </div>
+          <div>
+            <p>Demonstration of the Image API (CSS mask / &lt;img&gt;, zero icon rendering in JS)</p>
+            <button onClick={() => setState('image')}>Image</button>
+          </div>
         </div>
         <div>
           <h2>Icons</h2>
@@ -46,6 +51,7 @@ export function App() {
               {state === 'atoms' && <Atoms />}
               {state === 'all' && <All />}
               {state === 'chunk' && <Chunk />}
+              {state === 'image' && <Image />}
             </div>
           </React.Suspense>
         </div>

--- a/packages/icon-app/src/image.tsx
+++ b/packages/icon-app/src/image.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+import { makeStyles } from '@griffel/react';
+
+// Opt-in vanilla CSS: provides the mask, currentColor coloring, RTL flip, and HCM rules.
+import '@fluentui/react-icons/image/image.css';
+
+import { MeetNowFilled, MeetNowRegular } from '@fluentui/react-icons/image/meet-now';
+import { EmojiSmileSlightFilled } from '@fluentui/react-icons/image/emoji-smile-slight';
+import { AccessTimeRegular } from '@fluentui/react-icons/image/access-time';
+// Multicolor `*_color` icons render as <img> (cannot be recolored).
+import { AddCircleColor } from '@fluentui/react-icons/image/add-circle';
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '24px',
+    padding: '12px',
+  },
+  group: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '8px',
+  },
+  row: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    columnGap: '20px',
+    fontSize: '40px',
+  },
+  swatchRed: { color: '#c4314b' },
+  swatchBlue: { color: '#0f6cbd' },
+  swatchGreen: { color: '#107c10' },
+  caption: {
+    fontSize: '14px',
+    color: '#555',
+  },
+});
+
+export function Image() {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.group}>
+        <span className={styles.caption}>
+          Monochrome mask icons inherit the text <code>color</code> (via <code>currentColor</code>):
+        </span>
+        <div className={styles.row}>
+          <span className={styles.swatchRed}>
+            <MeetNowFilled />
+          </span>
+          <span className={styles.swatchBlue}>
+            <MeetNowRegular />
+          </span>
+          <span className={styles.swatchGreen}>
+            <EmojiSmileSlightFilled />
+          </span>
+          <AccessTimeRegular />
+        </div>
+      </div>
+
+      <div className={styles.group}>
+        <span className={styles.caption}>
+          …or via the <code>primaryFill</code> prop (overrides <code>color</code>):
+        </span>
+        <div className={styles.row}>
+          <MeetNowFilled primaryFill="#c4314b" />
+          <MeetNowFilled primaryFill="#0f6cbd" />
+          <MeetNowFilled primaryFill="#107c10" />
+        </div>
+      </div>
+
+      <div className={styles.group}>
+        <span className={styles.caption}>
+          Sized via <code>font-size</code> (icons are a <code>1em</code> box):
+        </span>
+        <div className={styles.row} style={{ fontSize: 'unset' }}>
+          <span style={{ fontSize: '16px' }}>
+            <AccessTimeRegular />
+          </span>
+          <span style={{ fontSize: '32px' }}>
+            <AccessTimeRegular />
+          </span>
+          <span style={{ fontSize: '64px' }}>
+            <AccessTimeRegular />
+          </span>
+        </div>
+      </div>
+
+      <div className={styles.group}>
+        <span className={styles.caption}>
+          Multicolor <code>*_color</code> icons render as <code>&lt;img&gt;</code> (not recolorable):
+        </span>
+        <div className={styles.row}>
+          <AddCircleColor />
+          {/* primaryFill is intentionally ignored by color icons */}
+          <span className={styles.swatchRed}>
+            <AddCircleColor />
+          </span>
+        </div>
+      </div>
+
+      <div className={styles.group}>
+        <span className={styles.caption}>Accessible label (renders aria-label / alt):</span>
+        <div className={styles.row}>
+          <AccessTimeRegular title="Access time" />
+          <AddCircleColor title="Add" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/icon-app/webpack.config.js
+++ b/packages/icon-app/webpack.config.js
@@ -20,8 +20,18 @@ module.exports = {
       // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
       { test: /\.tsx?$/, loader: 'ts-loader' },
       {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader'],
+      },
+      {
         test: /\.(ttf|woff2?)$/,
         type: 'asset',
+      },
+      // Image API icons import their SVG as a URL (mask / <img> source).
+      // `asset/resource` emits a separate hashed file (keeps the JS bundle tiny).
+      {
+        test: /\.svg$/,
+        type: 'asset/resource',
       },
     ],
   },

--- a/packages/react-icons/bundle-size/single-image.fixture.js
+++ b/packages/react-icons/bundle-size/single-image.fixture.js
@@ -1,0 +1,5 @@
+import { AirplaneRegular } from '@fluentui/react-icons/image/airplane';
+
+console.log(AirplaneRegular);
+
+export default { name: 'Single Image' };

--- a/packages/react-icons/bundle-size/single-svg-sprite.fixture.js
+++ b/packages/react-icons/bundle-size/single-svg-sprite.fixture.js
@@ -1,0 +1,5 @@
+import { AirplaneRegular } from '@fluentui/react-icons/svg-sprite/airplane';
+
+console.log(AirplaneRegular);
+
+export default { name: 'Single SVG Sprite' };

--- a/packages/react-icons/docs/preview-features/README.md
+++ b/packages/react-icons/docs/preview-features/README.md
@@ -11,3 +11,7 @@ SVG sprites offer smaller bundles, faster renders, and zero runtime overhead.
 ## [Headless API](./headless.md)
 
 A drop-in replacement for the standard API that removes the CSS-in-JS runtime — provides data-attribute selectors for styling behaviour with opt-in pre-defined vanilla CSS.
+
+## [Image API (CSS mask / `<img>`)](./image.md)
+
+Renders icons with zero icon rendering in JavaScript — monochrome icons via CSS `mask-image` (recolorable through `currentColor`) and multicolor icons via `<img>`, with per-icon hashed SVG files for strong caching.

--- a/packages/react-icons/docs/preview-features/image.md
+++ b/packages/react-icons/docs/preview-features/image.md
@@ -1,0 +1,133 @@
+# Image API (CSS mask / `<img>`)
+
+> **⚠️ Alpha** — this feature is available as an alpha prerelease only.
+>
+> Install via `npm i @fluentui/react-icons@prerelease`
+
+The Image API renders icons **without any icon rendering in JavaScript**. Instead of shipping SVG
+path data in your JS bundle, each icon component carries only a short hashed **URL** to its `.svg`
+file. Monochrome icons are drawn with CSS `mask-image` (so they recolor like text via
+`currentColor`), and the deprecated multicolor `*_color` icons are rendered as a native `<img>`.
+
+## Benefits
+
+- **Zero icon rendering in JS** — components render a `<span>` (mask) or `<img>` (color); no SVG path
+  data is included in the JavaScript bundle
+- **Smallest JS footprint** — each icon module is just a `createImageIcon('Name', url, width)` call;
+  under `asset/resource` the imported `.svg` compiles to a short hashed URL string (~30–50 bytes)
+- **CSS-driven coloring** — mask icons inherit `color` (`background-color: currentColor`), so they
+  recolor like text; an explicit `primaryFill` overrides it
+- **Strong caching** — every distinct icon is a content-hashed, immutably cacheable `.svg` file,
+  fetched lazily in parallel over HTTP/2 and shared across the app
+- **No CSS-in-JS runtime** — styling is a single opt-in vanilla CSS file (`image.css`)
+
+## How it works
+
+| Concern       | Mask icon (`<span>`)                                             | Color icon (`<img>`)                           |
+| ------------- | ---------------------------------------------------------------- | ---------------------------------------------- |
+| Element       | `<span class="fui-Icon-Image" style="--fui-img: url(...)">`      | `<img class="fui-Icon-Image-Color" src="...">` |
+| Color         | `background-color: currentColor` masked by the SVG shape         | fixed multicolor (not recolorable)             |
+| Sizing        | `1em` box scaled by `font-size` (sized variants pin `font-size`) | same                                           |
+| RTL flip      | `[data-fui-icon-rtl] { transform: scaleX(-1) }`                  | same                                           |
+| Accessibility | `title` → `aria-label` + `role="img"`, else `aria-hidden`        | `title` → `alt`, else `alt=""`                 |
+| High-contrast | `forced-colors` → `background-color: CanvasText` (stays visible) | system default                                 |
+
+> **Why two techniques?** CSS `mask-image` is the only one that can recolor a monochrome icon via
+> CSS. `<img>` content is isolated and cannot be recolored, so it is used only for the deprecated
+> multicolor `*_color` icons. Note that `mask-image` cannot reliably reference SVG `#fragment` ids
+> across browsers, so each icon is served as its own whole `.svg` file (not a `<use>` sprite).
+
+## CSS Setup
+
+You **must** import the image CSS file — it provides the mask, coloring, RTL, and high-contrast
+rules via class/attribute selectors:
+
+```ts
+import '@fluentui/react-icons/image/image.css';
+```
+
+## Bundler Setup
+
+Your bundler must emit imported `.svg` files as **assets** (a URL), not inline them into JS:
+
+- **webpack 5** — handled by default via [asset modules](https://webpack.js.org/guides/asset-modules/)
+  (`type: 'asset/resource'`). Avoid `asset/inline` / `url-loader`, which would embed large base64
+  strings into the JS bundle.
+- **Vite / Rollup** — handled by default (`.svg` imports resolve to a URL).
+
+## Usage
+
+Image icons are grouped by icon kind and exposed via `@fluentui/react-icons/image/{icon-group}`:
+
+```tsx
+import '@fluentui/react-icons/image/image.css';
+
+import { AccessTime20Filled, AccessTime24Regular } from '@fluentui/react-icons/image/access-time';
+import { Add20Filled } from '@fluentui/react-icons/image/add';
+
+function MyComponent() {
+  return (
+    <>
+      {/* inherits text color */}
+      <span style={{ color: 'rebeccapurple' }}>
+        <AccessTime24Regular />
+      </span>
+
+      {/* explicit color */}
+      <Add20Filled primaryFill="#0f6cbd" />
+
+      {/* accessible label */}
+      <AccessTime20Filled title="Access time" />
+    </>
+  );
+}
+```
+
+### Coloring
+
+Mask icons take their color from the surrounding text `color`:
+
+```tsx
+<span style={{ color: 'red' }}>
+  <Add20Filled />
+</span>
+```
+
+…or via the `primaryFill` prop, which overrides `color`:
+
+```tsx
+<Add20Filled primaryFill="red" />
+```
+
+### Sizing
+
+Image icons are a `1em` box scaled by `font-size` (matching the `"1em"` width convention of the
+other APIs). Resizable variants (e.g. `AddFilled`) inherit `font-size` from their context; sized
+variants (e.g. `Add24Filled`) pin themselves to that pixel size.
+
+```tsx
+{
+  /* 32px via font-size */
+}
+<span style={{ fontSize: 32 }}>
+  <AddFilled />
+</span>;
+```
+
+## API surface
+
+| Export                                     | Description                                              |
+| ------------------------------------------ | -------------------------------------------------------- |
+| `@fluentui/react-icons/image`              | Factories, types, and constants                          |
+| `@fluentui/react-icons/image/image.css`    | Opt-in vanilla CSS (mask, coloring, RTL, HCM)            |
+| `@fluentui/react-icons/image/{icon-group}` | Per-group icon components (e.g. `.../image/access-time`) |
+| `createImageIcon`                          | Factory for monochrome (CSS-mask) icons                  |
+| `createImageColorIcon`                     | Factory for multicolor (`<img>`) icons                   |
+
+## Notes & limitations
+
+- **Color icons cannot be recolored** and do not participate in CSS mask styling — they are served
+  as plain `<img>`. Color icons are deprecated.
+- **Each icon is one HTTP request** for its hashed `.svg` (cached immutably). For small, curated
+  icon sets a future build-time plugin may inline icons into a single CSS file (1 request) or a
+  `<style>` block (0 requests); per-icon files are the default strategy for the general case.

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@fluentui/react-icons",
   "version": "2.0.329",
-  "sideEffects": false,
+  "sideEffects": [
+    "**/headless/fonts/headless-fonts.css",
+    "**/headless/headless.css",
+    "**/image/image.css"
+  ],
   "main": "lib-cjs/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -14,8 +18,8 @@
   "scripts": {
     "clean": "git clean -fXd lib/ lib-cjs/ intermediate/ src/ tmp/",
     "generate:assets-to-svg": "node ../../importer/generate.js --source=../../assets --dest=./intermediate --extension=svg --target=react",
-    "convert:svg": "node scripts/convert.js --source=./intermediate --dest=./src --perIconDest=./src/atoms/svg --spriteDest=./src/atoms/svg-sprite --headlessPerIconDest=./src/atoms/headless-svg --headlessSpriteDest=./src/atoms/headless-svg-sprite --rtl=./intermediate/rtl.json --metadata=./tmp/metadata-svg.json",
-    "convert:fonts": "node scripts/convert-font.js --source=./src/utils/fonts --dest=./src/fonts --perIconDest=./src/atoms/fonts --headlessPerIconDest=./src/atoms/headless-fonts --codepointDest=./src/utils/fonts --rtl=./intermediate/rtl.json --metadata=./tmp/metadata-font.json",
+    "convert:svg": "node scripts/convert.js --source=./intermediate --dest=./src --perIconDest=./src/atoms/svg --spriteDest=./src/atoms/svg-sprite --headlessPerIconDest=./src/atoms/headless-svg --headlessSpriteDest=./src/atoms/headless-svg-sprite --imagePerIconDest=./src/atoms/image --rtl=./intermediate/rtl.json --metadata=./tmp/metadata-svg.json  --sprites --headless --image",
+    "convert:fonts": "node scripts/convert-font.js --source=./src/utils/fonts --dest=./src/fonts --perIconDest=./src/atoms/fonts --headlessPerIconDest=./src/atoms/headless-fonts --codepointDest=./src/utils/fonts --rtl=./intermediate/rtl.json --metadata=./tmp/metadata-font.json --headless",
     "convert:merge-metadata": "node scripts/merge-metadata.js --svgMetadata=./tmp/metadata-svg.json --fontMetadata=./tmp/metadata-font.json --output=./metadata.json",
     "generate:font-regular": "node ../../importer/generateFont.js --source=intermediate --dest=src/utils/fonts --iconType=Regular --codepoints=../../fonts/FluentSystemIcons-Regular.json",
     "generate:font-filled": "node ../../importer/generateFont.js --source=intermediate --dest=src/utils/fonts --iconType=Filled --codepoints=../../fonts/FluentSystemIcons-Filled.json",
@@ -129,6 +133,49 @@
       "types": "./lib/providers.d.ts",
       "import": "./lib/providers.js",
       "require": "./lib-cjs/providers.js"
+    },
+    "./svg-sprite/*": {
+      "types": "./lib/atoms/svg-sprite/*.d.ts",
+      "import": "./lib/atoms/svg-sprite/*.js",
+      "require": "./lib-cjs/atoms/svg-sprite/*.js"
+    },
+    "./headless": {
+      "types": "./lib/headless/index.d.ts",
+      "import": "./lib/headless/index.js",
+      "require": "./lib-cjs/headless/index.js"
+    },
+    "./headless/fonts": {
+      "types": "./lib/headless/fonts/index.d.ts",
+      "import": "./lib/headless/fonts/index.js",
+      "require": "./lib-cjs/headless/fonts/index.js"
+    },
+    "./headless/headless.css": "./lib/headless/headless.css",
+    "./headless/headless-fonts.css": "./lib/headless/fonts/headless-fonts.css",
+    "./headless/svg/*": {
+      "types": "./lib/atoms/headless-svg/*.d.ts",
+      "import": "./lib/atoms/headless-svg/*.js",
+      "require": "./lib-cjs/atoms/headless-svg/*.js"
+    },
+    "./headless/svg-sprite/*": {
+      "types": "./lib/atoms/headless-svg-sprite/*.d.ts",
+      "import": "./lib/atoms/headless-svg-sprite/*.js",
+      "require": "./lib-cjs/atoms/headless-svg-sprite/*.js"
+    },
+    "./headless/fonts/*": {
+      "types": "./lib/atoms/headless-fonts/*.d.ts",
+      "import": "./lib/atoms/headless-fonts/*.js",
+      "require": "./lib-cjs/atoms/headless-fonts/*.js"
+    },
+    "./image": {
+      "types": "./lib/image/index.d.ts",
+      "import": "./lib/image/index.js",
+      "require": "./lib-cjs/image/index.js"
+    },
+    "./image/image.css": "./lib/image/image.css",
+    "./image/*": {
+      "types": "./lib/atoms/image/*.d.ts",
+      "import": "./lib/atoms/image/*.js",
+      "require": "./lib-cjs/atoms/image/*.js"
     }
   }
 }

--- a/packages/react-icons/scripts/build.js
+++ b/packages/react-icons/scripts/build.js
@@ -54,6 +54,16 @@ function main(options) {
     addHeadlessExportMap(projectRoot);
   }
 
+  // Image assets: only copy when image generation was enabled
+  const imageSrcDir = join(projectRoot, 'src/atoms/image');
+  if (existsSync(imageSrcDir)) {
+    copyAssets('src/atoms/image/*.svg', './lib/atoms/image', projectRoot);
+    copyAssets('src/atoms/image/*.svg', './lib-cjs/atoms/image', projectRoot);
+    copyAssets('src/image/*.css', './lib/image', projectRoot);
+    copyAssets('src/image/*.css', './lib-cjs/image', projectRoot);
+    addImageExportMap(projectRoot);
+  }
+
   applyBabelTransform('lib', projectRoot);
   applyBabelTransform('lib-cjs', projectRoot);
 }
@@ -235,6 +245,46 @@ function addHeadlessExportMap(baseDir) {
   const headlessSideEffects = ['**/headless/fonts/headless-fonts.css', '**/headless/headless.css'];
   pkg.sideEffects = [...headlessSideEffects];
   console.log(`  ✓ [sideEffects] Added ${headlessSideEffects.join(', ')}`);
+
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+}
+
+/**
+ * Adds image (CSS-mask / `<img>`) export map entries to package.json when image generation is enabled.
+ *
+ * NOTE: will be part of package.json once image is stable. then we can remove this dynamic addition and the related build logic that copies image assets.
+ * @param {string} baseDir
+ */
+function addImageExportMap(baseDir) {
+  const pkgPath = join(baseDir, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+
+  /** @type {Record<string, string | {types: string; import: string; require: string}>} */
+  const imageExports = {
+    './image': {
+      types: './lib/image/index.d.ts',
+      import: './lib/image/index.js',
+      require: './lib-cjs/image/index.js',
+    },
+    './image/image.css': './lib/image/image.css',
+    './image/*': {
+      types: './lib/atoms/image/*.d.ts',
+      import: './lib/atoms/image/*.js',
+      require: './lib-cjs/atoms/image/*.js',
+    },
+  };
+
+  // Add image export maps
+  Object.assign(pkg.exports, imageExports);
+  console.log(`  ✓ [exports] Set ${Object.keys(imageExports).join(', ')}`);
+
+  // Append image CSS sideEffect (preserve existing sideEffects, e.g. headless)
+  const imageSideEffect = '**/image/image.css';
+  const existingSideEffects = Array.isArray(pkg.sideEffects) ? pkg.sideEffects : [];
+  if (!existingSideEffects.includes(imageSideEffect)) {
+    pkg.sideEffects = [...existingSideEffects, imageSideEffect];
+    console.log(`  ✓ [sideEffects] Added ${imageSideEffect}`);
+  }
 
   writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
 }

--- a/packages/react-icons/scripts/convert.js
+++ b/packages/react-icons/scripts/convert.js
@@ -13,6 +13,7 @@ const {
   getCreateFluentIconHeader,
   loadRtlMetadata,
   generatePerIconFiles,
+  generateImageFiles,
 } = require('./convert.utils');
 const {
   assertCompoundStyleVariantIssues,
@@ -39,6 +40,7 @@ async function main() {
     SPRITE_DEST,
     HEADLESS_PER_ICON_DEST,
     HEADLESS_SPRITE_DEST,
+    IMAGE_PER_ICON_DEST,
   } = parseArgs(process.argv.slice(2));
   const srcFiles = await processSourceDir(SRC_PATH);
   const rtlMetadata = loadRtlMetadata(RTL_FILE);
@@ -69,6 +71,11 @@ async function main() {
     });
   }
 
+  // 4. Generate image atom output (CSS-mask `<span>` / color `<img>`) - when --image is enabled
+  if (IMAGE_PER_ICON_DEST) {
+    await processImage(srcFiles, IMAGE_PER_ICON_DEST, rtlMetadata);
+  }
+
   writeMetadata(METADATA_PATH, chunkMetadata);
   writeMetadata(perIconMetadataPath, perIconMetadata);
 
@@ -85,6 +92,27 @@ async function main() {
   console.log(
     `[svg generation] Finished chunk + per-icon outputs. Chunk dest: ${DEST_PATH} | Per-icon dest: ${PER_ICON_DEST}${spriteSuffix}${headlessSuffix}`,
   );
+}
+
+/**
+ * Image atom generation (CSS-mask `<span>` / color `<img>`).
+ * Writes one `.tsx` module per icon group plus one standalone `.svg` per variant (mask/image source).
+ * @param {SourceFiles} sourceFiles
+ * @param {string} destPath
+ * @param {import('./convert-font.utils').RtlMetadata} rtlMetadata
+ */
+async function processImage(sourceFiles, destPath, rtlMetadata) {
+  if (fs.existsSync(destPath)) {
+    fs.rmSync(destPath, { recursive: true, force: true });
+  }
+  fs.mkdirSync(destPath, { recursive: true });
+
+  const { fileCount, svgFileCount } = await generateImageFiles(sourceFiles, destPath, rtlMetadata, {
+    iconImportPath: '../../image/createImageIcon',
+    colorImportPath: '../../image/createImageColorIcon',
+  });
+
+  console.log(`[image atoms] Wrote ${fileCount} icon module(s) and ${svgFileCount} svg source(s) to ${destPath}`);
 }
 
 /**
@@ -308,6 +336,8 @@ function parseArgs(argv) {
   const HEADLESS_ENABLED = Boolean(args.headless); // opt-in flag for headless component generation
   const HEADLESS_PER_ICON_DEST = HEADLESS_ENABLED ? /** @type {string} */ (args.headlessPerIconDest) : undefined; // headless per-icon output folder (only when --headless is set)
   const HEADLESS_SPRITE_DEST = HEADLESS_ENABLED ? /** @type {string|undefined} */ (args.headlessSpriteDest) : undefined; // headless svg sprite output folder (only when --headless is set)
+  const IMAGE_ENABLED = Boolean(args.image); // opt-in flag for image (CSS-mask / <img>) atom generation
+  const IMAGE_PER_ICON_DEST = IMAGE_ENABLED ? /** @type {string} */ (args.imagePerIconDest) : undefined; // image atoms output folder (only when --image is set)
 
   if (!SRC_PATH) {
     throw new Error('Icon source folder not specified by --source');
@@ -325,6 +355,9 @@ function parseArgs(argv) {
     throw new Error(
       'Headless per-icon output folder not specified by --headlessPerIconDest (required when --headless is set)',
     );
+  }
+  if (IMAGE_ENABLED && !IMAGE_PER_ICON_DEST) {
+    throw new Error('Image atoms output folder not specified by --imagePerIconDest (required when --image is set)');
   }
   if (!RTL_FILE) {
     throw new Error('RTL file not specified by --rtl');
@@ -353,6 +386,10 @@ function parseArgs(argv) {
     fs.mkdirSync(HEADLESS_SPRITE_DEST, { recursive: true });
   }
 
+  if (IMAGE_PER_ICON_DEST && !fs.existsSync(IMAGE_PER_ICON_DEST)) {
+    fs.mkdirSync(IMAGE_PER_ICON_DEST, { recursive: true });
+  }
+
   return {
     SRC_PATH,
     DEST_PATH,
@@ -362,6 +399,7 @@ function parseArgs(argv) {
     SPRITE_DEST,
     HEADLESS_PER_ICON_DEST,
     HEADLESS_SPRITE_DEST,
+    IMAGE_PER_ICON_DEST,
   };
 }
 

--- a/packages/react-icons/scripts/convert.utils.js
+++ b/packages/react-icons/scripts/convert.utils.js
@@ -8,6 +8,7 @@ const _ = require('lodash');
 
 const { writePerIconFiles } = require('./per-icon.writer');
 const { writeSpriteFiles } = require('./sprite.writer');
+const { writeImageFiles } = require('./image.writer');
 
 /** @typedef {{ [key: string]: 'mirror' | 'unique' }} RtlMetadata */
 
@@ -298,11 +299,78 @@ async function generatePerIconFiles(sourceFiles, dest, rtlMetadata, importConfig
   };
 }
 
+/**
+ * @typedef {{ iconImportPath: string; colorImportPath: string }} ImageImportConfig
+ */
+
+/**
+ * Generates image atom files (CSS-mask `<span>` / color `<img>`) for both resizable and sized
+ * variants in a single pass. Each icon group yields one `.tsx` module plus one standalone `.svg`
+ * per variant (the mask / image source), consumed via a bundler-resolved URL import.
+ *
+ * @param {Array<{file: string; srcFile: string}>} sourceFiles
+ * @param {string} destPath - image atoms output folder
+ * @param {RtlMetadata} rtlMetadata
+ * @param {ImageImportConfig} importConfig - import paths for the image factories
+ * @param {boolean} [groupByBase] - whether to group icons by base name (default: true)
+ * @returns {Promise<{ resizable: { iconNames: string[] }; sized: { iconNames: string[] }; fileCount: number; svgFileCount: number }>}
+ */
+async function generateImageFiles(sourceFiles, destPath, rtlMetadata, importConfig, groupByBase = true) {
+  /** @type {string[]} */
+  const resizableIconNames = [];
+  /** @type {ParsedIconSource[]} */
+  const resizableItems = [];
+
+  /** @type {string[]} */
+  const sizedIconNames = [];
+  /** @type {ParsedIconSource[]} */
+  const sizedItems = [];
+
+  for (const entry of sourceFiles) {
+    const sizedParsed = parseIconSource({
+      file: entry.file,
+      srcFile: entry.srcFile,
+      resizable: false,
+      metadata: rtlMetadata,
+    });
+    if (sizedParsed) {
+      sizedItems.push(sizedParsed);
+      sizedIconNames.push(sizedParsed.exportName);
+    }
+
+    if (entry.file.includes('20')) {
+      const resizableParsed = parseIconSource({
+        file: entry.file,
+        srcFile: entry.srcFile,
+        resizable: true,
+        metadata: rtlMetadata,
+      });
+      if (resizableParsed) {
+        resizableItems.push(resizableParsed);
+        resizableIconNames.push(resizableParsed.exportName);
+      }
+    }
+  }
+
+  const { fileCount, svgFileCount } = await writeImageFiles(destPath, [...resizableItems, ...sizedItems], {
+    groupByBase,
+    importConfig,
+  });
+
+  return {
+    resizable: { iconNames: resizableIconNames },
+    sized: { iconNames: sizedIconNames },
+    fileCount,
+    svgFileCount,
+  };
+}
+
 module.exports = {
   parseIconSource,
   buildIconExportCode,
   getCreateFluentIconHeader,
   loadRtlMetadata,
   generatePerIconFiles,
+  generateImageFiles,
   parseSvgToNodes,
 };

--- a/packages/react-icons/scripts/image.writer.js
+++ b/packages/react-icons/scripts/image.writer.js
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// @ts-check
+
+const fs = require('fs');
+const fsP = require('fs/promises');
+const path = require('path');
+
+const { groupItemsByBase } = require('./per-icon.writer');
+
+/** @typedef {{ groupByBase?: boolean }} WriteImageOptions */
+
+// ---------------
+// Private helpers
+// ---------------
+
+/**
+ * @param {string} width - Icon width string (e.g. "20", "1em")
+ * @returns {string} numeric viewBox width
+ */
+function viewBoxWidthFromIconWidth(width) {
+  if (width === '1em') {
+    return '20';
+  }
+  if (/^\d+$/.test(width)) {
+    return width;
+  }
+  return '20';
+}
+
+/**
+ * Escapes special characters for safe use inside XML/SVG attribute values.
+ *
+ * @param {string} value - The raw string to escape.
+ * @returns {string} The escaped string safe for XML attribute injection.
+ */
+function escapeAttr(value) {
+  return String(value).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Generate a standalone SVG document string for a single icon variant.
+ *
+ * - Mono icons emit `<path d="…"/>` entries with NO fill, so the default (black, full-alpha)
+ *   shape is a clean mask source for `mask-image` + `background-color: currentColor`.
+ * - Color icons emit their raw inner SVG content (fills preserved) for use as an `<img>` source.
+ *   No id namespacing is needed because each icon lives in its own file (no cross-icon collisions).
+ *
+ * @param {import('./convert.utils').ParsedIconSource} item
+ * @returns {string}
+ */
+function generateStandaloneSvg(item) {
+  const iconData = item.iconData;
+  const width = item.width || '20';
+  const viewBoxWidth = viewBoxWidthFromIconWidth(width);
+  const open = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${escapeAttr(viewBoxWidth)} ${escapeAttr(
+    viewBoxWidth,
+  )}">`;
+
+  // Color variants: keep the raw (filled) inner SVG content for <img> rendering.
+  if (iconData && 'rawSvg' in iconData) {
+    return `${open}${iconData.rawSvg}</svg>\n`;
+  }
+
+  // Mono variants: simple <path d="…"/> entries with no fill → pure-alpha mask source.
+  const paths = (iconData && 'paths' in iconData ? iconData.paths : [])
+    .map((d) => `<path d="${escapeAttr(d)}"/>`)
+    .join('');
+  return `${open}${paths}</svg>\n`;
+}
+
+/**
+ * Map a generated `.tsx` group file name to its co-located `.svg` variant file name.
+ * @param {string} fileName - e.g. "access-time-24-filled.tsx"
+ * @returns {string} e.g. "access-time-24-filled.svg"
+ */
+function svgFileNameFor(fileName) {
+  return fileName.replace(/\.tsx$/, '.svg');
+}
+
+/**
+ * Generate an image atom `.tsx` module that imports each co-located `.svg` (resolved to a URL by
+ * the consumer bundler) and wires it to the appropriate image factory.
+ *
+ * @param {Array<import('./convert.utils').ParsedIconSource>} items
+ * @param {{ iconImportPath: string; colorImportPath: string }} importConfig
+ * @returns {string}
+ */
+function generateImageModuleTsx(items, importConfig) {
+  const { iconImportPath, colorImportPath } = importConfig;
+  const hasMono = items.some((item) => !item.isColor);
+  const hasColor = items.some((item) => item.isColor);
+
+  /** @type {string[]} */
+  const header = ['"use client";', `import type { FluentImageIcon } from '${iconImportPath}';`];
+  if (hasMono) {
+    header.push(`import { createImageIcon } from '${iconImportPath}';`);
+  }
+  if (hasColor) {
+    header.push(`import { createImageColorIcon } from '${colorImportPath}';`);
+  }
+
+  for (const item of items) {
+    header.push(`import ${item.exportName}Url from './${svgFileNameFor(item.fileName)}';`);
+  }
+
+  const deprecatedPrefix =
+    '/** @deprecated Color icons are deprecated. [See User Guidance](https://microsoft.github.io/fluentui-system-icons/?path=/docs/icons-user-guidance--docs#color-variants-deprecated) */\n';
+
+  const body = items.map((item) => {
+    const widthStr = `"${item.width || '1em'}"`;
+    const options = item.flipInRtl ? ', { flipInRtl: true }' : '';
+    const factory = item.isColor ? 'createImageColorIcon' : 'createImageIcon';
+    return `${item.isColor ? deprecatedPrefix : ''}export const ${item.exportName}: FluentImageIcon = (/*#__PURE__*/${factory}('${item.exportName}', ${item.exportName}Url, ${widthStr}${options}));`;
+  });
+
+  return `${header.join('\n')}\n\n${body.join('\n')}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Write grouped image atom files (one `.tsx` per icon group + one standalone `.svg` per variant).
+ *
+ * @param {string} destPath - output directory for image atom files
+ * @param {import('./convert.utils').ParsedIconSource[]} items - icon items with enriched `iconData`, `width`, `isColor`
+ * @param {WriteImageOptions & { importConfig: { iconImportPath: string; colorImportPath: string } }} options
+ * @returns {Promise<{ fileCount: number; svgFileCount: number }>}
+ */
+async function writeImageFiles(destPath, items, options) {
+  const groups = groupItemsByBase(destPath, items, options);
+
+  if (!fs.existsSync(destPath)) {
+    fs.mkdirSync(destPath, { recursive: true });
+  }
+
+  let fileCount = 0;
+  let svgFileCount = 0;
+
+  for (const [base, groupItems] of groups) {
+    const typedItems = /** @type {import('./convert.utils').ParsedIconSource[]} */ (groupItems);
+
+    // 1. Write one standalone .svg per variant (the mask / image source).
+    for (const item of typedItems) {
+      const svgPath = path.join(destPath, svgFileNameFor(item.fileName));
+      await fsP.writeFile(svgPath, generateStandaloneSvg(item), 'utf8');
+      svgFileCount++;
+    }
+
+    // 2. Write the .tsx module that imports those .svg URLs and exports the components.
+    const moduleTsx = generateImageModuleTsx(typedItems, options.importConfig);
+    const tsxPath = path.join(destPath, `${base}.tsx`);
+    await fsP.writeFile(tsxPath, moduleTsx, 'utf8');
+    fileCount++;
+  }
+
+  return { fileCount, svgFileCount };
+}
+
+module.exports = { writeImageFiles };

--- a/packages/react-icons/src/image/createImageColorIcon.tsx
+++ b/packages/react-icons/src/image/createImageColorIcon.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+
+import { useIconContext } from '../contexts';
+import type { CreateImageIconOptions, FluentImageIcon, FluentImageIconsProps } from './shared';
+import { cx, DATA_FUI_ICON, DATA_FUI_ICON_RTL, fontSizeForWidth, imageColorIconClassName } from './shared';
+
+export type { CreateImageIconOptions, FluentImageIcon } from './shared';
+
+/**
+ * Image `createFluentIcon` for multicolor (`*_color`) icons, rendered as a native `<img>`.
+ *
+ * Multicolor icons cannot be recolored via CSS (the `<img>` content is isolated), so they cannot
+ * use the CSS-mask technique. They are served as a plain `<img src>` pointing at the icon SVG.
+ * Accessibility mirrors the other Fluent icon APIs, expressed via native `<img>` semantics:
+ * - `title` present → `alt={title}` (`role="img"` is implicit for `<img>`).
+ * - no `title` → `alt=""` (decorative; hidden from assistive tech, the `<img>` equivalent of
+ *   `aria-hidden`).
+ *
+ * @param displayName - The display name for the component (used in React DevTools).
+ * @param url - The bundler-resolved URL of the icon SVG (image source).
+ * @param width - The intrinsic width of the icon (`'1em'` for resizable, `'20'`/`'24'`/... for sized).
+ * @param options - Optional configuration.
+ *
+ * @access private
+ * @alpha
+ */
+export const createImageColorIcon = (
+  displayName: string,
+  url: string,
+  width: string = '1em',
+  options?: CreateImageIconOptions,
+): FluentImageIcon => {
+  const fontSize = fontSizeForWidth(width);
+
+  const Icon = React.forwardRef<HTMLElement, FluentImageIconsProps>((props, ref) => {
+    const {
+      className,
+      title,
+      // strip props that are not valid on an <img> element
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      primaryFill,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      filled,
+      style,
+      ...rest
+    } = props;
+
+    const iconContext = useIconContext();
+    const isRtlFlip = options?.flipInRtl && iconContext?.textDirection === 'rtl';
+
+    const mergedStyle = {
+      ...style,
+      ...(fontSize ? { fontSize } : null),
+    } as React.CSSProperties;
+
+    const state: Record<string, unknown> = {
+      ...rest,
+      ref,
+      src: url,
+      alt: title ?? '',
+      className: cx(imageColorIconClassName, className),
+      style: mergedStyle,
+      [DATA_FUI_ICON]: '',
+    };
+
+    if (isRtlFlip) {
+      state[DATA_FUI_ICON_RTL] = '';
+    }
+
+    return React.createElement('img', state);
+  }) as FluentImageIcon;
+
+  Icon.displayName = displayName;
+  return Icon;
+};

--- a/packages/react-icons/src/image/createImageIcon.tsx
+++ b/packages/react-icons/src/image/createImageIcon.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+
+import { useIconContext } from '../contexts';
+import type { CreateImageIconOptions, FluentImageIcon, FluentImageIconsProps } from './shared';
+import {
+  cx,
+  DATA_FUI_ICON,
+  DATA_FUI_ICON_RTL,
+  fontSizeForWidth,
+  imageIconClassName,
+  IMAGE_URL_CSS_VAR,
+} from './shared';
+
+export type { CreateImageIconOptions, FluentImageIcon } from './shared';
+
+/**
+ * Image `createFluentIcon` for monochrome, CSS-mask based icons (zero icon rendering in JS).
+ *
+ * Returns a React component that renders a `<span>` whose `mask-image` is the icon SVG referenced
+ * via a CSS custom property (`--fui-img`). Color comes from CSS `background-color: currentColor`
+ * (set in `image.css`), so the icon is recolorable like text via the `color` property or the
+ * `primaryFill` prop. No icon path data lives in the JS bundle — only a short hashed URL string.
+ *
+ * Styling is opt-in via the shipped `image.css` file (attribute/class selectors, no CSS-in-JS).
+ *
+ * @param displayName - The display name for the component (used in React DevTools).
+ * @param url - The bundler-resolved URL of the icon SVG (mask source).
+ * @param width - The intrinsic width of the icon (`'1em'` for resizable, `'20'`/`'24'`/... for sized).
+ * @param options - Optional configuration.
+ *
+ * @access private
+ * @alpha
+ */
+export const createImageIcon = (
+  displayName: string,
+  url: string,
+  width: string = '1em',
+  options?: CreateImageIconOptions,
+): FluentImageIcon => {
+  const fontSize = fontSizeForWidth(width);
+
+  const Icon = React.forwardRef<HTMLElement, FluentImageIconsProps>((props, ref) => {
+    const {
+      className,
+      primaryFill,
+      title,
+      // strip props that should not land on the DOM element
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      filled,
+      style,
+      ...rest
+    } = props;
+
+    const iconContext = useIconContext();
+    const isRtlFlip = options?.flipInRtl && iconContext?.textDirection === 'rtl';
+
+    const mergedStyle = {
+      ...style,
+      [IMAGE_URL_CSS_VAR]: `url("${url}")`,
+      ...(fontSize ? { fontSize } : null),
+      // `background-color: currentColor` in image.css colors the mask; overriding `color`
+      // recolors the icon when an explicit fill (other than currentColor) is requested.
+      ...(primaryFill && primaryFill.toLowerCase() !== 'currentcolor' ? { color: primaryFill } : null),
+    } as React.CSSProperties;
+
+    const state: Record<string, unknown> = {
+      ...rest,
+      ref,
+      className: cx(imageIconClassName, className),
+      style: mergedStyle,
+      [DATA_FUI_ICON]: '',
+    };
+
+    if (isRtlFlip) {
+      state[DATA_FUI_ICON_RTL] = '';
+    }
+
+    if (title) {
+      state['aria-label'] = title;
+    }
+
+    if (!state['aria-label'] && !state['aria-labelledby']) {
+      state['aria-hidden'] = true;
+    } else {
+      state['role'] = 'img';
+    }
+
+    return React.createElement('span', state);
+  }) as FluentImageIcon;
+
+  Icon.displayName = displayName;
+  return Icon;
+};

--- a/packages/react-icons/src/image/image.css
+++ b/packages/react-icons/src/image/image.css
@@ -1,0 +1,39 @@
+/* Image Fluent Icons — attribute/class-selector based styles (no CSS-in-JS runtime). */
+
+/* ===== Mask icon (monochrome, recolorable) ===== */
+.fui-Icon-Image {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  vertical-align: -0.125em;
+  /* Color is driven by `currentColor` so the icon recolors like text. */
+  background-color: currentColor;
+  /* `-webkit-` prefixed first for Safari < 15.4 (mask is Baseline 2023; prefix is the fallback). */
+  -webkit-mask: var(--fui-img) center / contain no-repeat;
+  mask: var(--fui-img) center / contain no-repeat;
+}
+
+/* ===== Color icon (multicolor <img>, not recolorable) ===== */
+.fui-Icon-Image-Color {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  vertical-align: -0.125em;
+}
+
+/* ===== RTL Directional Flip ===== */
+[data-fui-icon-rtl] {
+  transform: scaleX(-1);
+}
+
+/* ===== High Contrast Mode (a11y) =====
+ * SVG icons use `forced-color-adjust: auto` to let the system override `fill`. A mask icon gets
+ * its color from `background-color: currentColor`, which forced-colors would otherwise force to
+ * `Canvas` — making the icon invisible. Pin it to the `CanvasText` system color so the masked
+ * shape stays visible and adapts to the system theme.
+ */
+@media (forced-colors: active) {
+  .fui-Icon-Image {
+    background-color: CanvasText;
+  }
+}

--- a/packages/react-icons/src/image/image.test.tsx
+++ b/packages/react-icons/src/image/image.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { createImageIcon } from './createImageIcon';
+import { createImageColorIcon } from './createImageColorIcon';
+import { DATA_FUI_ICON, DATA_FUI_ICON_RTL, imageColorIconClassName, imageIconClassName } from './shared';
+import { IconDirectionContextProvider } from '../contexts';
+
+const URL = '/assets/access-time-regular.abc123.svg';
+
+describe('Image API — mask icons (createImageIcon)', () => {
+  test('creates a valid icon component', () => {
+    const AccessTimeRegular = createImageIcon('AccessTimeRegular', URL, '1em');
+
+    expect(AccessTimeRegular).toBeDefined();
+    expect(AccessTimeRegular.displayName).toBe('AccessTimeRegular');
+
+    const { container } = render(<AccessTimeRegular />);
+    const span = container.querySelector('span');
+
+    expect(span).not.toBeNull();
+    expect(span).toHaveClass(imageIconClassName);
+    expect(span).toHaveAttribute(DATA_FUI_ICON, '');
+    // aria-hidden by default (no title)
+    expect(span).toHaveAttribute('aria-hidden', 'true');
+    // the per-icon URL is carried via the --fui-img custom property
+    expect(span?.style.getPropertyValue('--fui-img')).toBe(`url("${URL}")`);
+  });
+
+  test('does not leak SVG path data into the DOM (zero JS rendering)', () => {
+    const Icon = createImageIcon('Icon', URL, '1em');
+    const { container } = render(<Icon />);
+
+    expect(container.querySelector('svg')).toBeNull();
+    expect(container.querySelector('path')).toBeNull();
+  });
+
+  test('title maps to aria-label + role="img"', () => {
+    const Icon = createImageIcon('Icon', URL, '1em');
+    const { container } = render(<Icon title="Access time" />);
+    const span = container.querySelector('span');
+
+    expect(span).toHaveAttribute('aria-label', 'Access time');
+    expect(span).toHaveAttribute('role', 'img');
+    expect(span).not.toHaveAttribute('aria-hidden');
+  });
+
+  test('primaryFill overrides color (recolor)', () => {
+    const Icon = createImageIcon('Icon', URL, '1em');
+    const { container } = render(<Icon primaryFill="red" />);
+    const span = container.querySelector('span');
+
+    expect(span?.style.color).toBe('red');
+  });
+
+  test('primaryFill="currentColor" does not set an explicit color', () => {
+    const Icon = createImageIcon('Icon', URL, '1em');
+    const { container } = render(<Icon primaryFill="currentColor" />);
+    const span = container.querySelector('span');
+
+    expect(span?.style.color).toBe('');
+  });
+
+  test('sized icons are pinned via font-size, resizable icons are not', () => {
+    const Sized = createImageIcon('Sized', URL, '24');
+    const { container: sizedContainer } = render(<Sized />);
+    expect(sizedContainer.querySelector('span')?.style.fontSize).toBe('24px');
+
+    const Resizable = createImageIcon('Resizable', URL, '1em');
+    const { container: resizableContainer } = render(<Resizable />);
+    expect(resizableContainer.querySelector('span')?.style.fontSize).toBe('');
+  });
+
+  test('flipInRtl sets the RTL data attribute only in an RTL context', () => {
+    const Icon = createImageIcon('Icon', URL, '1em', { flipInRtl: true });
+
+    const { container: ltr } = render(<Icon />);
+    expect(ltr.querySelector('span')).not.toHaveAttribute(DATA_FUI_ICON_RTL);
+
+    const { container: rtl } = render(
+      <IconDirectionContextProvider value={{ textDirection: 'rtl' }}>
+        <Icon />
+      </IconDirectionContextProvider>,
+    );
+    expect(rtl.querySelector('span')).toHaveAttribute(DATA_FUI_ICON_RTL, '');
+  });
+
+  test('forwards className and arbitrary props', () => {
+    const Icon = createImageIcon('Icon', URL, '1em');
+    const { container } = render(<Icon className="custom" data-testid="x" />);
+    const span = container.querySelector('span');
+
+    expect(span).toHaveClass(imageIconClassName);
+    expect(span).toHaveClass('custom');
+    expect(span).toHaveAttribute('data-testid', 'x');
+  });
+});
+
+describe('Image API — color icons (createImageColorIcon)', () => {
+  const COLOR_URL = '/assets/calendar-color.def456.svg';
+
+  test('renders an <img> with the icon source', () => {
+    const CalendarColor = createImageColorIcon('CalendarColor', COLOR_URL, '1em');
+    const { container } = render(<CalendarColor />);
+    const img = container.querySelector('img');
+
+    expect(img).not.toBeNull();
+    expect(img).toHaveClass(imageColorIconClassName);
+    expect(img).toHaveAttribute('src', COLOR_URL);
+    expect(img).toHaveAttribute(DATA_FUI_ICON, '');
+  });
+
+  test('no title renders alt="" (decorative)', () => {
+    const Icon = createImageColorIcon('Icon', COLOR_URL, '1em');
+    const { container } = render(<Icon />);
+    expect(container.querySelector('img')).toHaveAttribute('alt', '');
+  });
+
+  test('title maps to alt={title}', () => {
+    const Icon = createImageColorIcon('Icon', COLOR_URL, '1em');
+    const { container } = render(<Icon title="Calendar" />);
+    expect(container.querySelector('img')).toHaveAttribute('alt', 'Calendar');
+  });
+
+  test('sized color icons are pinned via font-size', () => {
+    const Icon = createImageColorIcon('Icon', COLOR_URL, '24');
+    const { container } = render(<Icon />);
+    expect(container.querySelector('img')?.style.fontSize).toBe('24px');
+  });
+});
+
+describe('Image API — image.css', () => {
+  const css = fs.readFileSync(path.join(__dirname, 'image.css'), 'utf-8');
+
+  test('mask icon uses currentColor and prefixed mask fallback', () => {
+    expect(css).toContain('background-color: currentColor');
+    expect(css).toContain('-webkit-mask: var(--fui-img)');
+    expect(css).toContain('mask: var(--fui-img)');
+  });
+
+  test('forced-colors keeps the mask visible via CanvasText (HCM)', () => {
+    expect(css).toMatch(/@media\s*\(forced-colors:\s*active\)/);
+    expect(css).toContain('background-color: CanvasText');
+  });
+});

--- a/packages/react-icons/src/image/index.ts
+++ b/packages/react-icons/src/image/index.ts
@@ -1,0 +1,21 @@
+// Image (CSS mask / <img>) Fluent Icons API
+// Import the shipped CSS file (image.css) for default styling via attribute/class selectors.
+
+// Types & constants
+export type { FluentIconsProps, FluentImageIconsProps, FluentImageIcon, CreateImageIconOptions } from './shared';
+export {
+  imageIconClassName,
+  imageColorIconClassName,
+  DATA_FUI_ICON,
+  DATA_FUI_ICON_RTL,
+  IMAGE_URL_CSS_VAR,
+  cx,
+} from './shared';
+
+// Context
+export { IconDirectionContextProvider, useIconContext } from '../contexts/index';
+export type { IconDirectionContextValue } from '../contexts/index';
+
+// Image icon factories
+export { createImageIcon } from './createImageIcon';
+export { createImageColorIcon } from './createImageColorIcon';

--- a/packages/react-icons/src/image/shared.ts
+++ b/packages/react-icons/src/image/shared.ts
@@ -1,0 +1,64 @@
+// Image (CSS mask / <img>) Fluent Icons API — shared types, constants, and helpers.
+// The shipped image.css file uses these data-attribute and class selectors for styling.
+
+import type * as React from 'react';
+
+/** Base data attribute applied to all image icons (mask `<span>` and color `<img>`). */
+export const DATA_FUI_ICON = 'data-fui-icon';
+
+/** Data attribute applied to icons that should flip in RTL text direction. */
+export const DATA_FUI_ICON_RTL = 'data-fui-icon-rtl';
+
+/** CSS class applied to the mask `<span>` icon (monochrome, recolorable). */
+export const imageIconClassName = 'fui-Icon-Image';
+
+/** CSS class applied to the color `<img>` icon (multicolor, not recolorable). */
+export const imageColorIconClassName = 'fui-Icon-Image-Color';
+
+/** CSS custom property carrying the per-icon mask source `url(...)`. */
+export const IMAGE_URL_CSS_VAR = '--fui-img';
+
+// Re-export the shared props contract so the image API stays consistent with the other APIs.
+export type { FluentIconsProps } from '../utils/FluentIconsProps.types';
+
+/**
+ * Props for image-based icons. Mask icons render a `<span>` and color icons render an `<img>`,
+ * so the base attribute type is the HTML element attribute set (not SVG).
+ */
+export type FluentImageIconsProps = import('../utils/FluentIconsProps.types').FluentIconsProps<
+  React.HTMLAttributes<HTMLElement>,
+  HTMLElement
+>;
+
+/** React component type produced by the image icon factories. */
+export type FluentImageIcon = React.FC<FluentImageIconsProps>;
+
+export type CreateImageIconOptions = {
+  flipInRtl?: boolean;
+};
+
+/**
+ * Joins class name strings, filtering out falsy values.
+ */
+export function cx(...classes: (string | false | undefined | null)[]): string | undefined {
+  const result = classes.filter(Boolean).join(' ');
+  return result || undefined;
+}
+
+/**
+ * Resolve the inline `font-size` used to size a non-resizable ("sized") icon.
+ *
+ * Image icons are a `1em` box scaled by `font-size` (matching the `"1em"` width convention used
+ * by the SVG/font APIs). Resizable icons (`width === '1em'`) inherit `font-size` from context and
+ * therefore receive no inline size. Sized icons (e.g. `width === '24'`) are pinned to that pixel
+ * size via `font-size`.
+ *
+ * @param width - The intrinsic width string of the icon (`'1em'`, `'20'`, `'24'`, ...).
+ * @returns A CSS `font-size` value (e.g. `'24px'`) or `undefined` for resizable icons.
+ */
+export function fontSizeForWidth(width: string): string | undefined {
+  if (width === '1em' || width === '') {
+    return undefined;
+  }
+  return /^\d+$/.test(width) ? `${width}px` : undefined;
+}


### PR DESCRIPTION
> **Draft / Alpha** — exploratory implementation of a new image-based icon API. Feedback welcome before stabilization.

## Summary

Adds a new **zero-JS-render** icon API under `@fluentui/react-icons/image`. Instead of shipping SVG path data in the JS bundle, each icon component carries only a short hashed **URL** to its `.svg`. Monochrome icons are drawn with CSS `mask-image` (recolorable via `currentColor`), and the deprecated multicolor `*_color` icons render as a native `<img>`.

## Motivation

- **Remove icon rendering from JavaScript** — components render a `<span>` (mask) or `<img>` (color); no SVG geometry in the JS bundle.
- **Smallest JS footprint** — under `asset/resource` the imported `.svg` compiles to a ~30–50 byte URL string per icon.
- **CSS-driven coloring** — mask icons inherit `color` (`background-color: currentColor`); `primaryFill` overrides it.
- **Strong caching** — each icon is a content-hashed, immutably cacheable `.svg`, fetched lazily in parallel over HTTP/2.
- **No CSS-in-JS runtime** — styling is a single opt-in vanilla CSS file (`image.css`).

## What's included

**Library (`packages/react-icons/src/image/`)**
- `createImageIcon` — monochrome mask `<span>` factory (`--fui-img` custom property + `currentColor`).
- `createImageColorIcon` — multicolor `<img>` factory (a11y via `alt`).
- `image.css` — opt-in vanilla CSS: `mask`/`-webkit-mask` fallback, `currentColor`, RTL flip, and a forced-colors `CanvasText` override so masks stay visible in High Contrast Mode.
- `index.ts` / `shared.ts` — `@fluentui/react-icons/image` entry, types, constants.

**Generation & build**
- `scripts/image.writer.js` + `convert.js --image` emit **atoms only** (no chunks): one `.tsx` module per icon group plus one standalone **unfilled** `.svg` mask source per variant (color icons keep fills for `<img>`).
- `build.js` copies image assets and registers the `./image` export map + `sideEffects`.

**Tests, docs, perf**
- `src/image/image.test.tsx` — render output, `--fui-img`, `currentColor`/`primaryFill`, no-SVG-in-DOM, sizing, RTL, color `<img>` + `alt`, and the HCM CSS rule.
- `docs/preview-features/image.md` (+ README entry), marked alpha.
- `bundle-size/single-image.fixture.js` (+ `single-svg-sprite.fixture.js`).

**Showcase**
- `packages/icon-app` Image demo (recolor, sizing, color `<img>`, a11y) + webpack `.css`/`.svg` loaders.

## Bundle size (single icon)

| API        | Minified | GZIP   |
| ---------- | -------- | ------ |
| **Image**  | 1.572 kB | 924 B  |
| SVG Sprite | 4.646 kB | 2.331 kB |
| Fonts      | 4.385 kB | 2.126 kB |
| SVG (JSX)  | 5.116 kB | 2.549 kB |

## Cross-browser / accessibility

- `mask-image` is Baseline 2023; `-webkit-mask` is shipped as the Safari < 15.4 fallback.
- `mask-image` cannot reliably reference SVG `#fragment` ids cross-browser, so each icon is served as its own whole `.svg` (not a `<use>` sprite).
- High Contrast Mode: masks pinned to `CanvasText` (would otherwise be forced to `Canvas` and become invisible).
- Color `<img>` a11y mirrors the existing APIs via native `alt` (`title` → `alt`, else `alt=""`).

## Notes / scope

- **Out of scope (future):** a build-time subsetting plugin that inlines used icons into one CSS file (1 request) / `<style>` (0 requests) — only beneficial for small curated sets; per-icon hashed files are the default.
- The committed `package.json` currently also carries headless/sprite build-mutation entries that ride along with the generation enablement; these will be tidied before this leaves draft.
- Generated `lib/` and `src/atoms/image/` outputs are gitignored and produced by the build.