### PR TITLE
feat(svg-icons): unify raw SVG processing with react-icons

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@ packages/react-icons @microsoft/cxe-prg @microsoft/cxe-red
 packages/react-icons-font-subsetting-webpack-plugin @MLoughry @microsoft/cxe-prg
 packages/react-icons-svg-sprite-subsetting-webpack-plugin @microsoft/cxe-prg
 packages/react-icons-atomic-webpack-loader @microsoft/cxe-prg
-packages/svg-icons
+packages/svg-icons @microsoft/cxe-prg
 packages/svg-sprites
 packages/react-native-icons @microsoft/react-native-sdk-admins
 

--- a/importer/svgo.config.shared.cjs
+++ b/importer/svgo.config.shared.cjs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// @ts-check
+
+// Shared SVGO optimization config used by both @fluentui/svg-icons and
+// @fluentui/react-icons so that raw-SVG processing is identical across packages.
+//
+// Keeping a single source of truth lets @fluentui/svg-icons serve as the
+// canonical optimized-SVG base that @fluentui/react-icons (and future consumers)
+// can build from. Precision is supplied per-package via the svgo CLI
+// (`--precision=2`); recursion/folder selection is also a CLI concern.
+//
+// Notes:
+// - `removeViewBox: false` keeps the viewBox so icons remain scalable.
+// - `mergePaths: false` preserves per-layer paths (required by color icons whose
+//   layers carry distinct fills/gradients).
+// - `prefixIds` namespaces ids (e.g. gradient ids) with the file's basename so
+//   color icons rendered together on a single page never collide.
+const nodePath = require('node:path');
+
+module.exports = {
+  plugins: [
+    {
+      name: 'preset-default',
+      params: {
+        overrides: {
+          removeViewBox: false,
+          mergePaths: false,
+        },
+      },
+    },
+    {
+      name: 'prefixIds',
+      params: {
+        prefix: (_, { path }) => {
+          // Generate a unique prefix based on file path or name
+          const filePath = path.filePath || path;
+          return nodePath.basename(filePath, '.svg');
+        },
+      },
+    },
+  ],
+};

--- a/packages/react-icons/svgo.config.js
+++ b/packages/react-icons/svgo.config.js
@@ -1,24 +1,3 @@
-const nodePath = require('path');
-module.exports = {
-  plugins: [
-    {
-      name: 'preset-default',
-      params: {
-        overrides: {
-          removeViewBox: false,
-          mergePaths: false,
-        },
-      },
-    },
-    {
-      name: 'prefixIds',
-      params: {
-        prefix: (_, { path }) => {
-          // Generate a unique prefix based on file path or name
-          const filePath = path.filePath || path;
-          return nodePath.basename(filePath, '.svg');
-        },
-      },
-    },
-  ],
-};
+// Re-exports the shared SVGO config so raw-SVG processing stays identical to
+// @fluentui/svg-icons. See importer/svgo.config.shared.cjs for details.
+module.exports = require('../../importer/svgo.config.shared.cjs');

--- a/packages/svg-icons/README.md
+++ b/packages/svg-icons/README.md
@@ -16,15 +16,44 @@ The library offers icons in SVG format; the icon names are structured as:
 
 - `name` - Name of the icon from [assets](../assets) that is all lowercased and underscore separated.
 - `size` - Size of the icon that is one of 16/20/24/28/48. Note that some icons do not have all sizes available yet. Our designers are working to add missing ones to complete the collection.
-- `style` - Style of the icon that is one of `regular`, `filled`. See the section below for details.
+- `style` - Style of the icon that is one of `regular`, `filled`, or `color`. See the section below for details.
 
 ### Icon styles
 
-The library offers icons in two styles, `regular` and `filled`
+The library offers icons in three styles, `regular`, `filled`, and `color`.
 
 | regular                                                  | filled                                                 |
 | -------------------------------------------------------- | ------------------------------------------------------ |
 | ![mail_24_regular](../../art/ic_fluent_mail_regular.png) | ![mail_24_filled](../../art/ic_fluent_mail_filled.png) |
+
+#### `regular` and `filled`
+
+Monochrome icons. The single design fill is stripped during build so the icon
+inherits `currentColor` (or whatever `fill` you set on the element), making them
+fully themeable.
+
+```ts
+import MailIcon from '@fluentui/svg-icons/icons/mail_24_regular.svg';
+```
+
+#### `color` (deprecated)
+
+Multi-color icons (gradients, multiple fills) intended to be used as-is. Unlike
+`regular`/`filled`, their fills are preserved and **not** themeable, and each
+file's gradient/clip ids are namespaced with the file name (e.g.
+`#mail_24_color__a`) so multiple color icons can be inlined on the same page
+without id collisions.
+
+```ts
+import MailColorIcon from '@fluentui/svg-icons/icons/mail_24_color.svg';
+```
+
+> **Deprecated:** color icons are deprecated and may be removed in a future
+> release. Prefer `regular`/`filled` for new work. See the
+> [color variants guidance](https://microsoft.github.io/fluentui-system-icons/?path=/docs/icons-user-guidance--docs#color-variants-deprecated).
+>
+> Note: color icons cover only a subset of the icon set (and not every
+> size is available for each icon).
 
 ## Implementation
 

--- a/packages/svg-icons/package.json
+++ b/packages/svg-icons/package.json
@@ -21,5 +21,10 @@
   "devDependencies": {
     "renamer": "^2.0.1",
     "svgo": "2.8.2"
-  }
+  },
+  "files": [
+    "icons/",
+    "README.md",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/svg-icons/svgo.config.js
+++ b/packages/svg-icons/svgo.config.js
@@ -1,14 +1,4 @@
-module.exports = {
-  plugins: [
-    {
-      name: 'preset-default',
-      params: {
-        overrides: {
-          removeViewBox: false,
-          mergePaths: false,
-          cleanupIds: false,
-        },
-      },
-    },
-  ],
-};
+// Re-exports the shared SVGO config so raw-SVG processing stays identical to
+// @fluentui/react-icons, letting this package serve as the optimized-SVG base.
+// See importer/svgo.config.shared.cjs for details.
+module.exports = require('../../importer/svgo.config.shared.cjs');

--- a/packages/svg-icons/unfill.js
+++ b/packages/svg-icons/unfill.js
@@ -13,5 +13,8 @@ replaceInFiles({
   paths: [values.path],
   recursive: true,
   include: '*.svg',
+  // Color icons rely on their fills (incl. #212121 base layers) for correct
+  // rendering and gradient fallbacks, so they are excluded from unfill.
+  exclude: '*_color.svg',
   quiet: true,
 });


### PR DESCRIPTION
## Summary

Unifies raw‑SVG asset processing between `@fluentui/svg-icons` and `@fluentui/react-icons` so both packages optimize assets identically, enabling **`svg-icons` to serve as the canonical optimized‑SVG base** for `react-icons` (and future consumers) in a later PR.

This PR is intentionally **atomic** — it only unifies the processing + cleans up the published surface. Re‑pointing `react-icons` to consume `svg-icons` as a build dependency is a planned follow‑up.

## Changes

- **New shared SVGO config** — `importer/svgo.config.shared.cjs` is the single source of truth (`preset-default` with `removeViewBox:false`, `mergePaths:false`, plus `prefixIds` for id namespacing). Both `packages/react-icons/svgo.config.js` and `packages/svg-icons/svgo.config.js` now re‑export it.
- **`unfill` alignment (svg-icons)** — color icons (`*_color.svg`) are now excluded from `unfill`, matching `react-icons`. Monochrome icons are unchanged (fills still stripped for theming).
- **README** — documents the previously‑undocumented `color` style (multi‑color/gradient, non‑themeable, file‑namespaced ids, deprecated).
- **`files` field (svg-icons)** — publishes only icon assets + docs, dropping build cruft (`build-verify.test.js`, `svgo.config.js`, `unfill.js`).

## Behavioral impact on `svg-icons` output

> Flagged as **feat** because the published `svg-icons` output changes. Note: repo releases force a single assets‑driven version bump across all packages, so the bump type cannot be controlled per package — calling this out for changelog clarity.

1. **Unique gradient ids** — color icons now get file‑prefixed ids (e.g. `molecule_24_color__a`) instead of colliding short ids (`a`, `b`). Fixes id collisions when multiple color icons are inlined on one page.
2. **Preserved color artwork** — `unfill` no longer strips fills from color icons, restoring `#212121` base layers and keeping gradient fallbacks intact. (Verified: all 27 `#212121` color layers were occluded, so no visible change — this is a fidelity/correctness fix.)

## Verification

- `svg-icons:build` ✅ — `unfill` now processes 20,402 / 21,292 files (890 color files correctly excluded).
- `svg-icons:build-verify` ✅ — 4 passed / 1 skipped.
- `react-icons:build` ✅ (clean build) + verify (build-verify + transforms + **color-render**) ✅ — **127 passed, 15 skipped, 0 failed**. color-render passing confirms prefixed ids render correctly.
- Published tarball: 21,298 → 21,295 files (cruft removed).

## Follow‑ups (separate PRs)

- Re‑point `react-icons` geometry source to consume `@fluentui/svg-icons` + add the Nx graph edge.
- Optionally add an `exports` map to formalize the `./icons/*` contract (needs cross‑bundler verification).