### PR TITLE
chore: replace renamer dependency with importer/rename-strip-prefix.js

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,7 @@ packages/react-icons-atomic-webpack-loader @microsoft/cxe-prg
 packages/svg-icons @microsoft/cxe-prg
 packages/svg-sprites
 packages/react-native-icons @microsoft/react-native-sdk-admins
+importer/ @microsoft/cxe-prg
 
 
 ## Build Systems

--- a/importer/rename-strip-prefix.js
+++ b/importer/rename-strip-prefix.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// @ts-check
+'use strict';
+
+/**
+ * Strip a filename prefix from every file within a directory tree.
+ *
+ * Replacement for `renamer --find <prefix> ...`, which logs one line per file
+ * (20k+ lines for the icon packages) and floods CI logs. This script is silent
+ * by default and prints a single summary line, while still failing the build
+ * (non-zero exit code) on real errors.
+ *
+ * Usage:
+ *   node ../../importer/rename-strip-prefix.js --dir ./icons --prefix ic_fluent_
+ *
+ * Options:
+ *   --dir <path>        Directory to scan (required).
+ *   --prefix <string>   Filename prefix to strip (required).
+ *   --flat              Only rename files directly inside --dir (default: recursive).
+ *   --verbose           Print every rename instead of just a summary.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { parseArgs } = require('node:util');
+
+const USAGE = `Usage: rename-strip-prefix.js --dir <path> --prefix <string> [options]
+
+Strip a filename prefix from every file within a directory tree.
+
+Options:
+  --dir <path>      Directory to scan (required).
+  --prefix <string> Filename prefix to strip (required).
+  --flat            Only rename files directly inside --dir (default: recursive).
+  --verbose         Print every rename instead of just a summary.
+  -h, --help        Print this help and exit.`;
+
+function getOptions() {
+  const { values } = parseArgs({
+    options: {
+      dir: { type: 'string' },
+      prefix: { type: 'string' },
+      flat: { type: 'boolean', default: false },
+      verbose: { type: 'boolean', default: false },
+      help: { type: 'boolean', short: 'h', default: false },
+    },
+  });
+
+  if (values.help) {
+    console.log(USAGE);
+    process.exit(0);
+  }
+
+  if (!values.dir) throw new Error('Missing required option: --dir');
+  if (!values.prefix) throw new Error('Missing required option: --prefix');
+
+  return {
+    dir: values.dir,
+    prefix: values.prefix,
+    recursive: !values.flat,
+    verbose: values.verbose,
+  };
+}
+
+/**
+ * @param {string} dir
+ * @param {boolean} recursive
+ * @returns {string[]} absolute file paths
+ */
+function collectFiles(dir, recursive) {
+  /** @type {string[]} */
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (recursive) files.push(...collectFiles(fullPath, recursive));
+    } else if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function main() {
+  const options = getOptions();
+
+  if (!fs.existsSync(options.dir)) {
+    throw new Error(`Directory does not exist: ${options.dir}`);
+  }
+
+  const files = collectFiles(options.dir, options.recursive);
+
+  let renamed = 0;
+  for (const filePath of files) {
+    const dir = path.dirname(filePath);
+    const base = path.basename(filePath);
+    if (!base.startsWith(options.prefix)) continue;
+
+    const target = path.join(dir, base.slice(options.prefix.length));
+    if (fs.existsSync(target)) {
+      throw new Error(`Target already exists, refusing to overwrite: ${target}`);
+    }
+
+    fs.renameSync(filePath, target);
+    renamed++;
+    if (options.verbose) console.log(`${base} \u2192 ${path.basename(target)}`);
+  }
+
+  console.log(`rename-strip-prefix: stripped "${options.prefix}" from ${renamed} file(s) in ${options.dir}`);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`rename-strip-prefix: ${err instanceof Error ? err.message : err}`);
+  process.exitCode = 1;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10586,16 +10586,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/array-back": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -12412,146 +12402,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/command-line-args": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
-      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^3.1.0",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/command-line-args/node_modules/array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/command-line-args/node_modules/typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/command-line-usage": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
-      "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.2",
-        "chalk": "^2.4.2",
-        "table-layout": "^1.0.2",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/command-line-usage/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/commander": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -13255,16 +13105,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -14700,13 +14540,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
-    "node_modules/fast-diff": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -14981,29 +14814,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/find-replace/node_modules/array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -15660,47 +15470,6 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true,
       "license": "BSD-2-Clause"
-    },
-    "node_modules/global-modules": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "global-prefix": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/global-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ini": "^1.3.5",
-        "kind-of": "^6.0.2",
-        "which": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/global-prefix/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
     },
     "node_modules/globals": {
       "version": "13.24.0",
@@ -16641,13 +16410,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
     },
@@ -17964,19 +17726,6 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "node_modules/load-module": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/load-module/-/load-module-3.0.0.tgz",
-      "integrity": "sha512-ZqprfrTx4vfH5+1mgpspPh5JYsNyA193NkMUdb3GwpmVqMczOh8cUDJgZBmEZVlSR42JBGYTUxlBAX9LHIBtIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/loader-runner": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
@@ -18011,13 +17760,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -20524,20 +20266,6 @@
         "url": "https://github.com/sponsors/antelle"
       }
     },
-    "node_modules/node-version-matches": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/node-version-matches/-/node-version-matches-2.0.1.tgz",
-      "integrity": "sha512-oqk6+05FC0dNVY5NuXuhPEMq+m1b9ZjS9SIhVE9EjwCHZspnmjSO8npbKAEieinR8GeEgbecoQcYIvI/Kwcf6Q==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nopt": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
@@ -21888,19 +21616,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/printj": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/printj/-/printj-1.3.1.tgz",
-      "integrity": "sha512-GA3TdL8szPK4AQ2YnOe/b+Y1jUFwmmGMMK/qbY7VcE3Z7FU8JstbKiKRzO6CIiAKPhTO8m01NoQ0V5f3jc4OGg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "printj": "bin/printj.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -22601,26 +22316,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/reduce-flatten": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-3.0.1.tgz",
-      "integrity": "sha512-bYo+97BmUUOzg09XwfkwALt4PQH1M5L0wzKerBt6WLm3Fhdd43mMS89HiT1B9pJIqko/6lWx3OnV4J9f2Kqp5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/reduce-unique": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-2.0.1.tgz",
-      "integrity": "sha512-x4jH/8L1eyZGR785WY+ePtyMNhycl1N2XOLxhCbzZFaqF4AXjLzqSxa2UHgJ2ZVR/HHyPOvl1L7xRnW8ye5MdA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -22797,81 +22492,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/renamer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/renamer/-/renamer-2.0.1.tgz",
-      "integrity": "sha512-Cx4rMQx2sjuH8CNDbv50YMpkLaROVHros4owSzuLeiCbmZZTGeh6pZO7tkvJE7NT2ls8byBfBldNFLsoX7XUkg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.1",
-        "chalk": "^4.0.0",
-        "command-line-args": "^5.1.1",
-        "command-line-usage": "^6.1.0",
-        "fast-diff": "^1.2.0",
-        "glob": "^7.1.6",
-        "global-modules": "^2.0.0",
-        "load-module": "^3.0.0",
-        "node-version-matches": "^2.0.1",
-        "printj": "^1.2.2",
-        "reduce-flatten": "^3.0.0",
-        "reduce-unique": "^2.0.1",
-        "stream-read-all": "^3.0.0",
-        "typical": "^6.0.1"
-      },
-      "bin": {
-        "renamer": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/renamer/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/renamer/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/renamer/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/renderkid": {
@@ -24335,16 +23955,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/stream-read-all": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/stream-read-all/-/stream-read-all-3.0.1.tgz",
-      "integrity": "sha512-EWZT9XOceBPlVJRrYcykW8jyRSZYbkb/0ZK36uLEmoWVO5gxBOnntNTseNzfREsqxqdfEGQrD8SXQ3QWbBmq8A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/strict-url-sanitise": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/strict-url-sanitise/-/strict-url-sanitise-0.0.1.tgz",
@@ -24964,32 +24574,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/table-layout": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
-      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.1",
-        "deep-extend": "~0.6.0",
-        "typical": "^5.2.0",
-        "wordwrapjs": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/table-layout/node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/tabster": {
       "version": "8.7.0",
@@ -25808,16 +25392,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/typical": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-6.0.1.tgz",
-      "integrity": "sha512-+g3NEp7fJLe9DPa1TArHm9QAA7YciZmWnfAqEaFrBihQ7epOv9i99rjtgb6Iz0wh3WuQDjsCTDfgRoGnmHN81A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/uglify-js": {
@@ -27757,40 +27331,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/wordwrapjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
-      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "reduce-flatten": "^2.0.0",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/wordwrapjs/node_modules/reduce-flatten": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
-      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/wordwrapjs/node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -28236,7 +27776,6 @@
         "glob": "^7.2.0",
         "lodash": "4.18.1",
         "mkdirp": "^1.0.4",
-        "renamer": "^2.0.1",
         "svgo": "2.8.2",
         "typescript": "4.1.6",
         "typescript-eslint": "7.18.0",
@@ -28536,7 +28075,6 @@
         "react": "19.2.3",
         "react-native": "^0.85.0",
         "react-native-svg": "^15.15.3",
-        "renamer": "^2.0.1",
         "svgo": "2.8.2",
         "typescript": "5.0.4",
         "yargs": "^14.0.0"
@@ -28869,7 +28407,6 @@
       "version": "1.1.330",
       "license": "MIT",
       "devDependencies": {
-        "renamer": "^2.0.1",
         "svgo": "2.8.2"
       }
     },
@@ -28878,7 +28415,6 @@
       "version": "1.1.330",
       "license": "MIT",
       "devDependencies": {
-        "renamer": "^2.0.1",
         "svgo": "2.8.2",
         "svgstore": "^3.0.1",
         "yargs": "^14.0.0"

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -48,7 +48,6 @@
     "glob": "^7.2.0",
     "lodash": "4.18.1",
     "mkdirp": "^1.0.4",
-    "renamer": "^2.0.1",
     "svgo": "2.8.2",
     "typescript": "4.1.6",
     "typescript-eslint": "7.18.0",

--- a/packages/react-native-icons/package.json
+++ b/packages/react-native-icons/package.json
@@ -42,7 +42,6 @@
     "react": "19.2.3",
     "react-native": "^0.85.0",
     "react-native-svg": "^15.15.3",
-    "renamer": "^2.0.1",
     "svgo": "2.8.2",
     "typescript": "5.0.4",
     "yargs": "^14.0.0"

--- a/packages/svg-icons/package.json
+++ b/packages/svg-icons/package.json
@@ -11,7 +11,7 @@
     "clean": "git clean -fXd ./icons",
     "copy": "node ../../importer/generate.js --source=../../assets --dest=./icons --extension=svg",
     "copywithdirs": "node ../../importer/generate.js --source=../../assets --dest=./icons --extension=svg --keepdirs=true",
-    "rename": "renamer --find 'ic_fluent_' '**'",
+    "rename": "node ../../importer/rename-strip-prefix.js --dir ./icons --prefix ic_fluent_",
     "optimize": "svgo --config svgo.config.js --folder=./icons --recursive --precision=2",
     "unfill": "node unfill.js --path=./icons/",
     "build": "npm run copy && npm run rename && npm run optimize && npm run unfill",
@@ -19,7 +19,6 @@
     "build-verify": "vitest run build-verify.test.js"
   },
   "devDependencies": {
-    "renamer": "^2.0.1",
     "svgo": "2.8.2"
   },
   "files": [

--- a/packages/svg-sprites/package.json
+++ b/packages/svg-sprites/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "clean": "git clean -fXd ./icons ./sprites",
     "copy": "node ../../importer/generate.js --source=../../assets --dest=./icons --extension=svg",
-    "rename": "renamer --find ic_fluent_ './icons/*'",
+    "rename": "node ../../importer/rename-strip-prefix.js --dir ./icons --prefix ic_fluent_ --flat",
     "optimize": "svgo --config svgo.config.js --folder=./icons --precision=2",
     "unfill": "node unfill.js --path=./icons/",
     "sprites": "node generate-sprites.js",
@@ -22,7 +22,6 @@
     "build-verify": "vitest run build-verify.test.js"
   },
   "devDependencies": {
-    "renamer": "^2.0.1",
     "svgo": "2.8.2",
     "svgstore": "^3.0.1",
     "yargs": "^14.0.0"


### PR DESCRIPTION
## Problem

The `rename` build step uses the `renamer` CLI, which logs **one line per file**. For `@fluentui/svg-icons` that's ~20,000 lines per build (and `svg-sprites` does the same), flooding CI logs on GitHub and making them hard to read. `renamer@2.0.1` offers no `--quiet`/`--silent` flag — its only output options (`--verbose`, `--view`) *add* output, and even error messages go to `stdout`.

## Solution

Replace `renamer` with a small, dependency-free Node script that strips a filename prefix from a directory tree:

- **Silent by default** — prints a single summary line (e.g. `stripped "ic_fluent_" from 20382 file(s)`).
- **Still fails the build** — sets a non-zero exit code on real errors (errors go to `stderr`), so the `&&` build chain breaks as before.
- Refuses to overwrite an existing target file.
- Uses `node:util` `parseArgs`; supports `--dir`, `--prefix`, `--flat` (non-recursive), `--verbose`, and `-h/--help`.

## Changes

- Add `importer/rename-strip-prefix.js` alongside the other importer generators.
- Wire `svg-icons` and `svg-sprites` `rename` scripts to the new script (`--flat` for sprites to match the original top-level-only behavior).
- Drop the now-unused `renamer` devDependency from all four packages that declared it (`svg-icons`, `svg-sprites`, `react-icons`, `react-native-icons` — the latter two never used it in scripts).
- Update `package-lock.json` accordingly.
- Add `importer/` to CODEOWNERS.

## Testing

- Verified prefix stripping, recursive vs `--flat`, `--verbose`, `--help`/`-h` (exit 0), collision detection (exit 1), and missing-arg errors (exit 1) against temp fixtures.