### PR TITLE
ci: serialize main writers with shared concurrency group

### DIFF
--- a/.github/workflows/bundle-size.baseline.yml
+++ b/.github/workflows/bundle-size.baseline.yml
@@ -9,6 +9,13 @@ on:
       # Icons changes can affect the bundle size so we wanna run the baseline update here as well
       - 'assets/**'
 
+# Serialize all automated writers to `main` (this workflow and publish.yml share the
+# same group) so their pushes can never race and clobber each other.
+# `cancel-in-progress: false` queues runs instead of cancelling them.
+concurrency:
+  group: main-writer
+  cancel-in-progress: false
+
 jobs:
   bundle-size-baseline:
     if: ${{ github.repository_owner == 'microsoft' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,13 @@ on:
         default: false
         type: boolean
 
+# Serialize all automated writers to `main` (this workflow and bundle-size.baseline.yml
+# share the same group) so their pushes can never race and clobber each other.
+# `cancel-in-progress: false` queues runs instead of cancelling them.
+concurrency:
+  group: main-writer
+  cancel-in-progress: false
+
 env:
   LIBRARY_VERSION: 1.1.${{ github.run_number }}
 


### PR DESCRIPTION
## Problem

Two workflows push to `main` with no coordination:

- [`publish.yml`](.github/workflows/publish.yml) — manual release; pushes the *"Release X.Y.Z"* commit + tag at the end.
- [`bundle-size.baseline.yml`](.github/workflows/bundle-size.baseline.yml) — triggers on `push` to `main` touching `assets/**` or `packages/react-icons/**`; commits the baseline and pushes.

When both run around the same time they race on the `main` ref. [This recently caused the **Release 1.1.330** commit to be silently dropped](https://github.com/microsoft/fluentui-system-icons/pull/1107): the bundle-size baseline push landed first, so the release's final `git push origin HEAD:main` became a non-fast-forward and was lost (npm packages were already published, leaving an inconsistent state that had to be restored by hand).

## Fix

Add a **shared `concurrency` group** (`main-writer`) to both workflows:

```yaml
concurrency:
  group: main-writer
  cancel-in-progress: false
```

Because both workflows share the same group string, GitHub Actions will **queue** them instead of running them concurrently. `cancel-in-progress: false` ensures a queued run waits rather than being cancelled, so neither writer's push is ever clobbered by the other.

This closes the race at its source with no changes to the push/tag logic.

## Scope

- Minimal, defensive change — only adds the concurrency block to the two files.
- Does not touch the npm-publish-before-git-push ordering or reduce the number of writers — those are possible follow-ups, intentionally out of scope here.

## Related 

- https://github.com/microsoft/fluentui-system-icons/pull/1107
