### PR TITLE
feat(react-icons-atomic-webpack-loader): support @fluentui/react-brand-icons

### DIFF
--- a/packages/react-icons-atomic-webpack-loader/README.md
+++ b/packages/react-icons-atomic-webpack-loader/README.md
@@ -3,19 +3,21 @@
 > **⚠️ 0.x** — this package is in early development and follows [zero-based major semver](https://0ver.org/).
 > Breaking changes may occur in minor releases until 1.0.
 
-Webpack loader that transforms barrel imports and re-exports from `@fluentui/react-icons` into atomic deep paths for better tree-shaking and smaller bundles.
+Webpack loader that transforms barrel imports and re-exports from `@fluentui/react-icons` and `@fluentui/react-brand-icons` into atomic deep paths for better tree-shaking and smaller bundles.
 
 ## Before / After
 
 ```js
 // Before — barrel import pulls in the entire icon set
 import { AddFilled, bundleIcon, useIconContext } from '@fluentui/react-icons';
+import { ProjectColor } from '@fluentui/react-brand-icons';
 export { ArrowLeftRegular } from '@fluentui/react-icons';
 
 // After — each reference resolves to a small, isolated module
 import { AddFilled } from '@fluentui/react-icons/svg/add';
 import { bundleIcon } from '@fluentui/react-icons/utils';
 import { useIconContext } from '@fluentui/react-icons/providers';
+import { ProjectColor } from '@fluentui/react-brand-icons/svg/project';
 export { ArrowLeftRegular } from '@fluentui/react-icons/svg/arrow-left';
 ```
 
@@ -23,7 +25,7 @@ export { ArrowLeftRegular } from '@fluentui/react-icons/svg/arrow-left';
 
 Add the loader to your webpack config as an [`enforce: 'pre'`](https://webpack.js.org/configuration/module/#ruleenforce) rule so it runs on the original source before any other loaders:
 
-NOTE: Unlike most loaders, this one should NOT exclude `node_modules`. It needs to process files inside `node_modules` as well to transform barrel imports from `@fluentui/react-icons` in your third-party dependencies. Files that don't reference `@fluentui/react-icons` are skipped via a fast regex pre-check, so there is no meaningful overhead.
+NOTE: Unlike most loaders, this one should NOT exclude `node_modules`. It needs to process files inside `node_modules` as well to transform barrel imports from `@fluentui/react-icons` and `@fluentui/react-brand-icons` in your third-party dependencies. Files that don't reference a supported module are skipped via a fast pre-check, so there is no meaningful overhead.
 
 ```js
 // webpack.config.js
@@ -59,11 +61,41 @@ module.exports = {
 };
 ```
 
+## Supported modules
+
+| Module                        | Variants                     | Notes                         |
+| ----------------------------- | ---------------------------- | ----------------------------- |
+| `@fluentui/react-icons`       | `svg`, `fonts`, `svg-sprite` | Has `/providers` and `/utils` |
+| `@fluentui/react-brand-icons` | `svg`                        | Has `/utils`; no `/providers` |
+
 ## Options
 
-| Option        | Type                                   | Default | Description                                                        |
-| ------------- | -------------------------------------- | ------- | ------------------------------------------------------------------ |
-| `iconVariant` | `'svg'` \| `'fonts'` \| `'svg-sprite'` | `'svg'` | Whether icons resolve to SVG, font-based, or SVG sprite components |
+| Option            | Type                                   | Default     | Description                                                                |
+| ----------------- | -------------------------------------- | ----------- | -------------------------------------------------------------------------- |
+| `iconVariant`     | `'svg'` \| `'fonts'` \| `'svg-sprite'` | `'svg'`     | Variant icons resolve to. Applied to every supported module.               |
+| `fallbackVariant` | `'svg'` \| `'fonts'` \| `'svg-sprite'` | `undefined` | Variant used for a module that does not support `iconVariant` (see below). |
+
+### Variant resolution & `fallbackVariant`
+
+`iconVariant` is applied to every supported module referenced in a file. Because not every module ships every variant (for example `@fluentui/react-brand-icons` only ships `svg`), the loader resolves the variant per module:
+
+1. If the module supports `iconVariant`, it is used.
+2. Otherwise, if `fallbackVariant` is set and supported by the module, it is used.
+3. Otherwise, if `fallbackVariant` is set but also unsupported, the loader emits a warning and falls back to `svg`.
+4. Otherwise (no `fallbackVariant`), the loader fails with a descriptive error.
+
+Resolution is lazy and per file: only modules actually imported in a given file are checked, so a file that imports only `@fluentui/react-icons` never errors about brand icons.
+
+```js
+// Resolve system icons to fonts, but keep brand icons on svg (their only variant).
+{
+  loader: '@fluentui/react-icons-atomic-webpack-loader',
+  options: {
+    iconVariant: 'fonts',
+    fallbackVariant: 'svg',
+  },
+}
+```
 
 ### Using font icons
 
@@ -105,7 +137,9 @@ This changes icon resolution from `@fluentui/react-icons/svg/*` to `@fluentui/re
 
 ## How it works
 
-The loader uses a Babel transform to rewrite import and re-export declarations that reference `@fluentui/react-icons`. Each named specifier is routed to an atomic subpath based on its name:
+The loader parses each module and rewrites import and re-export declarations that reference a supported module. Each named specifier is routed to an atomic subpath based on its name:
+
+### `@fluentui/react-icons`
 
 | Export type    | Example                                          | Resolved path                                                        |
 | -------------- | ------------------------------------------------ | -------------------------------------------------------------------- |
@@ -113,9 +147,17 @@ The loader uses a Babel transform to rewrite import and re-export declarations t
 | Context / hook | `useIconContext`, `IconDirectionContextProvider` | `@fluentui/react-icons/providers`                                    |
 | Utility        | `bundleIcon`, `createFluentIcon`                 | `@fluentui/react-icons/utils`                                        |
 
-Files that don't reference `@fluentui/react-icons` are passed through untouched (fast regex pre-check).
+### `@fluentui/react-brand-icons`
+
+| Export type    | Example                                   | Resolved path                             |
+| -------------- | ----------------------------------------- | ----------------------------------------- |
+| Icon component | `ProjectColor`, `CalendarTaskbar20Filled` | `@fluentui/react-brand-icons/svg/project` |
+| Utility        | `bundleIcon`, `createFluentIcon`          | `@fluentui/react-brand-icons/utils`       |
+
+Files that don't reference a supported module are passed through untouched (fast pre-check).
 
 ## Requirements
 
 - `webpack` >= 5
 - `@fluentui/react-icons` >= 2 (with atomic subpath exports)
+- `@fluentui/react-brand-icons` (with atomic subpath exports), if used

--- a/packages/react-icons-atomic-webpack-loader/src/index.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/index.ts
@@ -1,6 +1,6 @@
 import { transformSource } from './transform';
-import { DEFAULT_SAFETY_VARIANT, MODULES, SUPPORTED_MODULE_NAMES } from './modules';
-import type { IconVariant, ModuleDescriptor } from './modules';
+import { SUPPORTED_MODULE_NAMES } from './modules';
+import type { IconVariant } from './modules';
 import type { LoaderContext } from 'webpack';
 
 export type { IconVariant };
@@ -22,78 +22,41 @@ export interface FluentIconsAtomicImportLoaderOptions {
   fallbackVariant?: IconVariant;
 }
 
-interface ResolveVariantResult {
-  variant?: IconVariant;
-  error?: string;
-  warning?: string;
-}
-
-function resolveVariantForModule(
-  descriptor: ModuleDescriptor,
-  iconVariant: IconVariant,
-  fallbackVariant: IconVariant | undefined,
-): ResolveVariantResult {
-  if (descriptor.supportedVariants.includes(iconVariant)) {
-    return { variant: iconVariant };
-  }
-
-  const supported = descriptor.supportedVariants.join(', ');
-
-  if (fallbackVariant === undefined) {
-    return {
-      error:
-        `"${descriptor.name}" does not support iconVariant "${iconVariant}" ` +
-        `(supported: ${supported}). Provide a "fallbackVariant" option to resolve this.`,
-    };
-  }
-
-  if (descriptor.supportedVariants.includes(fallbackVariant)) {
-    return { variant: fallbackVariant };
-  }
-
-  return {
-    variant: DEFAULT_SAFETY_VARIANT,
-    warning:
-      `"${descriptor.name}" supports neither iconVariant "${iconVariant}" nor ` +
-      `fallbackVariant "${fallbackVariant}" (supported: ${supported}). ` +
-      `Falling back to "${DEFAULT_SAFETY_VARIANT}".`,
-  };
-}
-
 export default function fluentIconsAtomicImportLoader(
   this: LoaderContext<FluentIconsAtomicImportLoaderOptions>,
   sourceCode: string,
 ): void {
   const { resourcePath } = this;
 
+  // Cheap pre-skip only: a false positive here just means we parse the file and
+  // let the module record decide. Diagnostics are driven by actual imports.
   if (!SUPPORTED_MODULE_NAMES.some((name) => sourceCode.includes(name))) {
     return this.callback(null, sourceCode);
   }
 
   const { iconVariant = 'svg', fallbackVariant } = this.getOptions();
 
-  const variants: Record<string, IconVariant> = {};
-
-  for (const descriptor of MODULES) {
-    if (!sourceCode.includes(descriptor.name)) continue;
-
-    const resolved = resolveVariantForModule(descriptor, iconVariant, fallbackVariant);
-
-    if (resolved.error) {
-      return this.callback(new Error(`FluentIconsAtomicImportLoader: ${resolved.error}`));
-    }
-
-    if (resolved.warning) {
-      this.emitWarning(new Error(`FluentIconsAtomicImportLoader: ${resolved.warning}`));
-    }
-
-    variants[descriptor.name] = resolved.variant!;
-  }
+  let code: string;
+  let map: ReturnType<typeof transformSource>['map'];
+  let diagnostics: ReturnType<typeof transformSource>['diagnostics'];
 
   try {
-    const { code, map } = transformSource(sourceCode, { variants, path: resourcePath });
-    return this.callback(null, code, map);
-  } catch {
-    return this.callback(new Error(`FluentIconsAtomicImportLoader: Failed to transform "${resourcePath}"`));
+    ({ code, map, diagnostics } = transformSource(sourceCode, { iconVariant, fallbackVariant, path: resourcePath }));
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return this.callback(new Error(`FluentIconsAtomicImportLoader: Failed to transform "${resourcePath}": ${reason}`));
   }
+
+  for (const diagnostic of diagnostics) {
+    if (diagnostic.level === 'warning') {
+      this.emitWarning(new Error(`FluentIconsAtomicImportLoader: ${diagnostic.message}`));
+    }
+  }
+
+  const firstError = diagnostics.find((d) => d.level === 'error');
+  if (firstError) {
+    return this.callback(new Error(`FluentIconsAtomicImportLoader: ${firstError.message}`));
+  }
+
+  return this.callback(null, code, map);
 }

--- a/packages/react-icons-atomic-webpack-loader/src/index.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/index.ts
@@ -1,8 +1,63 @@
 import { transformSource } from './transform';
+import { DEFAULT_SAFETY_VARIANT, MODULES, SUPPORTED_MODULE_NAMES } from './modules';
+import type { IconVariant, ModuleDescriptor } from './modules';
 import type { LoaderContext } from 'webpack';
 
+export type { IconVariant };
+
 export interface FluentIconsAtomicImportLoaderOptions {
-  iconVariant?: 'svg' | 'fonts' | 'svg-sprite';
+  /**
+   * The icon variant to resolve atomic imports to. Defaults to `'svg'`.
+   *
+   * Not every module supports every variant (e.g. `@fluentui/react-brand-icons`
+   * only ships `svg`). When a referenced module does not support this variant,
+   * `fallbackVariant` is used instead.
+   */
+  iconVariant?: IconVariant;
+  /**
+   * The variant to use for a referenced module that does not support
+   * `iconVariant`. When omitted and a module cannot honor `iconVariant`, the
+   * loader fails with a descriptive error.
+   */
+  fallbackVariant?: IconVariant;
+}
+
+interface ResolveVariantResult {
+  variant?: IconVariant;
+  error?: string;
+  warning?: string;
+}
+
+function resolveVariantForModule(
+  descriptor: ModuleDescriptor,
+  iconVariant: IconVariant,
+  fallbackVariant: IconVariant | undefined,
+): ResolveVariantResult {
+  if (descriptor.supportedVariants.includes(iconVariant)) {
+    return { variant: iconVariant };
+  }
+
+  const supported = descriptor.supportedVariants.join(', ');
+
+  if (fallbackVariant === undefined) {
+    return {
+      error:
+        `"${descriptor.name}" does not support iconVariant "${iconVariant}" ` +
+        `(supported: ${supported}). Provide a "fallbackVariant" option to resolve this.`,
+    };
+  }
+
+  if (descriptor.supportedVariants.includes(fallbackVariant)) {
+    return { variant: fallbackVariant };
+  }
+
+  return {
+    variant: DEFAULT_SAFETY_VARIANT,
+    warning:
+      `"${descriptor.name}" supports neither iconVariant "${iconVariant}" nor ` +
+      `fallbackVariant "${fallbackVariant}" (supported: ${supported}). ` +
+      `Falling back to "${DEFAULT_SAFETY_VARIANT}".`,
+  };
 }
 
 export default function fluentIconsAtomicImportLoader(
@@ -11,14 +66,32 @@ export default function fluentIconsAtomicImportLoader(
 ): void {
   const { resourcePath } = this;
 
-  if (!sourceCode.includes('@fluentui/react-icons')) {
+  if (!SUPPORTED_MODULE_NAMES.some((name) => sourceCode.includes(name))) {
     return this.callback(null, sourceCode);
   }
 
-  const { iconVariant = 'svg' } = this.getOptions();
+  const { iconVariant = 'svg', fallbackVariant } = this.getOptions();
+
+  const variants: Record<string, IconVariant> = {};
+
+  for (const descriptor of MODULES) {
+    if (!sourceCode.includes(descriptor.name)) continue;
+
+    const resolved = resolveVariantForModule(descriptor, iconVariant, fallbackVariant);
+
+    if (resolved.error) {
+      return this.callback(new Error(`FluentIconsAtomicImportLoader: ${resolved.error}`));
+    }
+
+    if (resolved.warning) {
+      this.emitWarning(new Error(`FluentIconsAtomicImportLoader: ${resolved.warning}`));
+    }
+
+    variants[descriptor.name] = resolved.variant!;
+  }
 
   try {
-    const { code, map } = transformSource(sourceCode, { iconVariant, path: resourcePath });
+    const { code, map } = transformSource(sourceCode, { variants, path: resourcePath });
     return this.callback(null, code, map);
   } catch {
     return this.callback(new Error(`FluentIconsAtomicImportLoader: Failed to transform "${resourcePath}"`));

--- a/packages/react-icons-atomic-webpack-loader/src/modules.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/modules.ts
@@ -74,3 +74,55 @@ export const SUPPORTED_MODULE_NAMES: string[] = MODULES.map((m) => m.name);
 export function getModuleDescriptor(moduleName: string): ModuleDescriptor | undefined {
   return MODULES.find((m) => m.name === moduleName);
 }
+
+/**
+ * Outcome of resolving the effective variant for a single module given the
+ * requested `iconVariant` and optional `fallbackVariant`.
+ *
+ * - `variant` is the variant to rewrite with, when resolution succeeds.
+ * - `error` is set when the module cannot be satisfied and no fallback exists.
+ * - `warning` is set when the resolution succeeded only by degrading to the
+ *   safety variant.
+ */
+export interface VariantResolution {
+  variant?: IconVariant;
+  error?: string;
+  warning?: string;
+}
+
+/**
+ * Resolves the effective icon variant for a module, applying the
+ * `iconVariant` → `fallbackVariant` → safety-variant precedence. This is pure
+ * policy logic; callers decide how to surface `error`/`warning`.
+ */
+export function resolveModuleVariant(
+  descriptor: ModuleDescriptor,
+  iconVariant: IconVariant,
+  fallbackVariant: IconVariant | undefined,
+): VariantResolution {
+  if (descriptor.supportedVariants.includes(iconVariant)) {
+    return { variant: iconVariant };
+  }
+
+  const supported = descriptor.supportedVariants.join(', ');
+
+  if (fallbackVariant === undefined) {
+    return {
+      error:
+        `"${descriptor.name}" does not support iconVariant "${iconVariant}" ` +
+        `(supported: ${supported}). Provide a "fallbackVariant" option to resolve this.`,
+    };
+  }
+
+  if (descriptor.supportedVariants.includes(fallbackVariant)) {
+    return { variant: fallbackVariant };
+  }
+
+  return {
+    variant: DEFAULT_SAFETY_VARIANT,
+    warning:
+      `"${descriptor.name}" supports neither iconVariant "${iconVariant}" nor ` +
+      `fallbackVariant "${fallbackVariant}" (supported: ${supported}). ` +
+      `Falling back to "${DEFAULT_SAFETY_VARIANT}".`,
+  };
+}

--- a/packages/react-icons-atomic-webpack-loader/src/modules.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/modules.ts
@@ -1,0 +1,76 @@
+export type IconVariant = 'svg' | 'fonts' | 'svg-sprite';
+
+/**
+ * The variant used as the ultimate safety net when neither the requested
+ * `iconVariant` nor the configured `fallbackVariant` is supported by a module.
+ * Every module supports `svg`, so it is always a valid resolution target.
+ */
+export const DEFAULT_SAFETY_VARIANT: IconVariant = 'svg';
+
+const ICON_SUFFIX_REGEX = /(\d*)?(Regular|Filled|Light|Color)$/;
+
+function isIconName(importName: string): boolean {
+  return ICON_SUFFIX_REGEX.test(importName);
+}
+
+function toKebabCase(value: string): string {
+  return value.replace(/[a-z\d](?=[A-Z])|[a-zA-Z](?=\d)|[A-Z](?=[A-Z][a-z])/g, '$&-').toLowerCase();
+}
+
+function iconBaseName(importName: string): string {
+  return toKebabCase(importName.replace(ICON_SUFFIX_REGEX, ''));
+}
+
+/**
+ * Describes how a single supported module's barrel imports are rewritten into
+ * atomic deep paths.
+ */
+export interface ModuleDescriptor {
+  /** The bare module specifier this descriptor applies to. */
+  name: string;
+  /** Icon variants this module ships atomic entry points for. */
+  supportedVariants: IconVariant[];
+  /**
+   * Resolves the atomic subpath for a single named import.
+   *
+   * @param importName - The imported binding name (e.g. `AddFilled`, `bundleIcon`).
+   * @param variant - The already-resolved, supported icon variant for this module.
+   */
+  resolve(importName: string, variant: IconVariant): string;
+}
+
+const reactIcons: ModuleDescriptor = {
+  name: '@fluentui/react-icons',
+  supportedVariants: ['svg', 'fonts', 'svg-sprite'],
+  resolve(importName, variant) {
+    if (importName === 'useIconContext' || importName === 'IconDirectionContextProvider') {
+      return '@fluentui/react-icons/providers';
+    }
+
+    if (!isIconName(importName)) {
+      return '@fluentui/react-icons/utils';
+    }
+
+    return `@fluentui/react-icons/${variant}/${iconBaseName(importName)}`;
+  },
+};
+
+const reactBrandIcons: ModuleDescriptor = {
+  name: '@fluentui/react-brand-icons',
+  supportedVariants: ['svg'],
+  resolve(importName) {
+    if (!isIconName(importName)) {
+      return '@fluentui/react-brand-icons/utils';
+    }
+
+    return `@fluentui/react-brand-icons/svg/${iconBaseName(importName)}`;
+  },
+};
+
+export const MODULES: ModuleDescriptor[] = [reactIcons, reactBrandIcons];
+
+export const SUPPORTED_MODULE_NAMES: string[] = MODULES.map((m) => m.name);
+
+export function getModuleDescriptor(moduleName: string): ModuleDescriptor | undefined {
+  return MODULES.find((m) => m.name === moduleName);
+}

--- a/packages/react-icons-atomic-webpack-loader/src/transform.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/transform.ts
@@ -1,30 +1,16 @@
 import { parseSync } from 'oxc-parser';
-import type { StaticImport, StaticExport } from 'oxc-parser';
 import MagicString from 'magic-string';
 
-const MODULE_NAME = '@fluentui/react-icons';
-const ICON_SUFFIX_REGEX = /(\d*)?(Regular|Filled|Light|Color)$/;
+import { getModuleDescriptor } from './modules';
+import type { IconVariant } from './modules';
 
 interface TransformOptions {
-  iconVariant: 'svg' | 'fonts' | 'svg-sprite';
+  /**
+   * The resolved icon variant per module specifier. Only modules present in
+   * this map are rewritten; any other module is left untouched.
+   */
+  variants: Record<string, IconVariant>;
   path: string;
-}
-
-function getAtomicImportPath(importName: string, iconVariant: 'svg' | 'fonts' | 'svg-sprite'): string {
-  if (importName === 'useIconContext' || importName === 'IconDirectionContextProvider') {
-    return '@fluentui/react-icons/providers';
-  }
-
-  const isIcon = importName.match(ICON_SUFFIX_REGEX);
-
-  if (!isIcon) {
-    return '@fluentui/react-icons/utils';
-  }
-
-  const withoutSuffix = importName.replace(ICON_SUFFIX_REGEX, '');
-  const kebabCase = withoutSuffix.replace(/[a-z\d](?=[A-Z])|[a-zA-Z](?=\d)|[A-Z](?=[A-Z][a-z])/g, '$&-').toLowerCase();
-
-  return `@fluentui/react-icons/${iconVariant}/${kebabCase}`;
 }
 
 export interface TransformResult {
@@ -33,7 +19,7 @@ export interface TransformResult {
 }
 
 export function transformSource(source: string, options: TransformOptions): TransformResult {
-  const { iconVariant, path } = options;
+  const { variants, path } = options;
 
   const result = parseSync(path, source, {
     sourceType: 'module',
@@ -47,7 +33,12 @@ export function transformSource(source: string, options: TransformOptions): Tran
   const src = new MagicString(source);
 
   for (const imp of staticImports) {
-    if (imp.moduleRequest.value !== MODULE_NAME) continue;
+    const moduleName = imp.moduleRequest.value;
+    const descriptor = getModuleDescriptor(moduleName);
+    if (!descriptor) continue;
+
+    const variant = variants[moduleName];
+    if (!variant) continue;
 
     const namedEntries = imp.entries.filter((e) => e.importName.kind === 'Name');
     if (namedEntries.length === 0) continue;
@@ -59,13 +50,13 @@ export function transformSource(source: string, options: TransformOptions): Tran
       const names = otherEntries
         .map((e) => (e.importName.kind === 'Default' ? e.localName.value : `* as ${e.localName.value}`))
         .join(', ');
-      lines.push(`import ${names} from '${MODULE_NAME}';`);
+      lines.push(`import ${names} from '${moduleName}';`);
     }
 
     for (const entry of namedEntries) {
       const importedName = entry.importName.name!;
       const localName = entry.localName.value;
-      const newSource = getAtomicImportPath(importedName, iconVariant);
+      const newSource = descriptor.resolve(importedName, variant);
       const spec = importedName === localName ? importedName : `${importedName} as ${localName}`;
       lines.push(`import { ${spec} } from '${newSource}';`);
     }
@@ -75,7 +66,7 @@ export function transformSource(source: string, options: TransformOptions): Tran
 
   for (const exp of staticExports) {
     const relevantEntries = exp.entries.filter(
-      (e) => e.moduleRequest?.value === MODULE_NAME && e.exportName.kind === 'Name',
+      (e) => e.moduleRequest && getModuleDescriptor(e.moduleRequest.value) && e.exportName.kind === 'Name',
     );
     if (relevantEntries.length === 0) continue;
 
@@ -87,12 +78,19 @@ export function transformSource(source: string, options: TransformOptions): Tran
     const lines: string[] = [];
 
     for (const entry of relevantEntries) {
+      const moduleName = entry.moduleRequest!.value;
+      const descriptor = getModuleDescriptor(moduleName)!;
+      const variant = variants[moduleName];
+      if (!variant) continue;
+
       const importedName = entry.importName.name!;
       const exportedName = entry.exportName.name!;
-      const newSource = getAtomicImportPath(importedName, iconVariant);
+      const newSource = descriptor.resolve(importedName, variant);
       const spec = importedName === exportedName ? importedName : `${importedName} as ${exportedName}`;
       lines.push(`export { ${spec} } from '${newSource}';`);
     }
+
+    if (lines.length === 0) continue;
 
     src.overwrite(exp.start, exp.end, lines.join('\n'));
   }

--- a/packages/react-icons-atomic-webpack-loader/src/transform.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/transform.ts
@@ -1,25 +1,35 @@
 import { parseSync } from 'oxc-parser';
 import MagicString from 'magic-string';
 
-import { getModuleDescriptor } from './modules';
-import type { IconVariant } from './modules';
+import { getModuleDescriptor, resolveModuleVariant } from './modules';
+import type { IconVariant, ModuleDescriptor } from './modules';
 
 interface TransformOptions {
-  /**
-   * The resolved icon variant per module specifier. Only modules present in
-   * this map are rewritten; any other module is left untouched.
-   */
-  variants: Record<string, IconVariant>;
+  /** The requested icon variant. Applied to every supported module. */
+  iconVariant: IconVariant;
+  /** The variant to fall back to when a module does not support `iconVariant`. */
+  fallbackVariant?: IconVariant;
   path: string;
+}
+
+export interface Diagnostic {
+  level: 'error' | 'warning';
+  message: string;
 }
 
 export interface TransformResult {
   code: string;
   map: ReturnType<MagicString['generateMap']>;
+  /**
+   * Diagnostics gathered while rewriting. Only modules that are actually
+   * imported/re-exported (as reported by the parsed module record) contribute
+   * diagnostics, so mentions in comments or string literals never trigger one.
+   */
+  diagnostics: Diagnostic[];
 }
 
 export function transformSource(source: string, options: TransformOptions): TransformResult {
-  const { variants, path } = options;
+  const { iconVariant, fallbackVariant, path } = options;
 
   const result = parseSync(path, source, {
     sourceType: 'module',
@@ -32,12 +42,40 @@ export function transformSource(source: string, options: TransformOptions): Tran
   const { staticImports, staticExports } = result.module;
   const src = new MagicString(source);
 
+  const diagnostics: Diagnostic[] = [];
+  // Resolve (and diagnose) each referenced module at most once.
+  const resolvedVariants = new Map<string, IconVariant | null>();
+
+  /**
+   * Returns the variant to rewrite a referenced module with, or `null` when it
+   * could not be resolved (an error diagnostic has been recorded and the module
+   * should be left untouched).
+   */
+  const variantFor = (descriptor: ModuleDescriptor): IconVariant | null => {
+    if (resolvedVariants.has(descriptor.name)) {
+      return resolvedVariants.get(descriptor.name)!;
+    }
+
+    const resolution = resolveModuleVariant(descriptor, iconVariant, fallbackVariant);
+
+    if (resolution.warning) {
+      diagnostics.push({ level: 'warning', message: resolution.warning });
+    }
+    if (resolution.error) {
+      diagnostics.push({ level: 'error', message: resolution.error });
+    }
+
+    const variant = resolution.variant ?? null;
+    resolvedVariants.set(descriptor.name, variant);
+    return variant;
+  };
+
   for (const imp of staticImports) {
     const moduleName = imp.moduleRequest.value;
     const descriptor = getModuleDescriptor(moduleName);
     if (!descriptor) continue;
 
-    const variant = variants[moduleName];
+    const variant = variantFor(descriptor);
     if (!variant) continue;
 
     const namedEntries = imp.entries.filter((e) => e.importName.kind === 'Name');
@@ -80,7 +118,7 @@ export function transformSource(source: string, options: TransformOptions): Tran
     for (const entry of relevantEntries) {
       const moduleName = entry.moduleRequest!.value;
       const descriptor = getModuleDescriptor(moduleName)!;
-      const variant = variants[moduleName];
+      const variant = variantFor(descriptor);
       if (!variant) continue;
 
       const importedName = entry.importName.name!;
@@ -98,5 +136,6 @@ export function transformSource(source: string, options: TransformOptions): Tran
   return {
     code: src.toString(),
     map: src.generateMap({ hires: true }),
+    diagnostics,
   };
 }

--- a/packages/react-icons-atomic-webpack-loader/test/src/brand-icons-imports.js
+++ b/packages/react-icons-atomic-webpack-loader/test/src/brand-icons-imports.js
@@ -1,0 +1,5 @@
+import { CalendarTaskbarFilled } from '@fluentui/react-brand-icons';
+import { CalendarTaskbar20Filled, ProjectColor } from '@fluentui/react-brand-icons';
+import { bundleIcon } from '@fluentui/react-brand-icons';
+
+console.log(CalendarTaskbarFilled, CalendarTaskbar20Filled, ProjectColor, bundleIcon);

--- a/packages/react-icons-atomic-webpack-loader/test/src/mixed-modules-fonts.js
+++ b/packages/react-icons-atomic-webpack-loader/test/src/mixed-modules-fonts.js
@@ -1,0 +1,4 @@
+import { AddFilled } from '@fluentui/react-icons';
+import { ProjectColor } from '@fluentui/react-brand-icons';
+
+console.log(AddFilled, ProjectColor);

--- a/packages/react-icons-atomic-webpack-loader/test/transform.test.ts
+++ b/packages/react-icons-atomic-webpack-loader/test/transform.test.ts
@@ -2,15 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { transformSource } from '../src/transform';
 import type { IconVariant } from '../src/modules';
 
-const transform = (source: string, iconVariant: IconVariant = 'svg') =>
-  transformSource(source, {
-    variants: {
-      '@fluentui/react-icons': iconVariant,
-      // brand icons only ship svg
-      '@fluentui/react-brand-icons': 'svg',
-    },
-    path: 'input.js',
-  }).code;
+const transform = (source: string, iconVariant: IconVariant = 'svg', fallbackVariant?: IconVariant) =>
+  transformSource(source, { iconVariant, fallbackVariant, path: 'input.js' }).code;
 
 describe('transformSource', () => {
   describe('imports', () => {
@@ -211,7 +204,7 @@ describe('transformSource', () => {
     });
 
     it('always resolves brand icons to svg regardless of iconVariant', () => {
-      expect(transform(`import { ProjectColor } from '@fluentui/react-brand-icons';`, 'fonts')).toBe(
+      expect(transform(`import { ProjectColor } from '@fluentui/react-brand-icons';`, 'fonts', 'svg')).toBe(
         `import { ProjectColor } from '@fluentui/react-brand-icons/svg/project';`,
       );
     });
@@ -222,12 +215,88 @@ describe('transformSource', () => {
         `import { ProjectColor } from '@fluentui/react-brand-icons';`,
       ].join('\n');
 
-      expect(transform(source, 'fonts')).toBe(
+      expect(transform(source, 'fonts', 'svg')).toBe(
         [
           `import { AddFilled } from '@fluentui/react-icons/fonts/add';`,
           `import { ProjectColor } from '@fluentui/react-brand-icons/svg/project';`,
         ].join('\n'),
       );
+    });
+  });
+
+  describe('diagnostics', () => {
+    it('does not diagnose a module that only appears in a comment', () => {
+      const source = [
+        `// see @fluentui/react-brand-icons for product icons`,
+        `import { AddFilled } from '@fluentui/react-icons';`,
+      ].join('\n');
+
+      const { code, diagnostics } = transformSource(source, {
+        iconVariant: 'fonts',
+        path: 'input.js',
+      });
+
+      expect(diagnostics).toEqual([]);
+      expect(code).toBe(
+        [
+          `// see @fluentui/react-brand-icons for product icons`,
+          `import { AddFilled } from '@fluentui/react-icons/fonts/add';`,
+        ].join('\n'),
+      );
+    });
+
+    it('does not diagnose a module that only appears in a string literal', () => {
+      const source = [
+        `const docs = '@fluentui/react-brand-icons';`,
+        `import { AddFilled } from '@fluentui/react-icons';`,
+      ].join('\n');
+
+      const { diagnostics } = transformSource(source, { iconVariant: 'fonts', path: 'input.js' });
+
+      expect(diagnostics).toEqual([]);
+    });
+
+    it('emits an error diagnostic for a referenced module that cannot honor the variant', () => {
+      const { diagnostics } = transformSource(`import { ProjectColor } from '@fluentui/react-brand-icons';`, {
+        iconVariant: 'fonts',
+        path: 'input.js',
+      });
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0].level).toBe('error');
+      expect(diagnostics[0].message).toContain('@fluentui/react-brand-icons');
+      expect(diagnostics[0].message).toContain('fallbackVariant');
+    });
+
+    it('leaves a module untouched when it produces an error diagnostic', () => {
+      const source = `import { ProjectColor } from '@fluentui/react-brand-icons';`;
+
+      const { code } = transformSource(source, { iconVariant: 'fonts', path: 'input.js' });
+
+      expect(code).toBe(source);
+    });
+
+    it('emits a warning and degrades to svg when fallbackVariant is also unsupported', () => {
+      const { code, diagnostics } = transformSource(`import { ProjectColor } from '@fluentui/react-brand-icons';`, {
+        iconVariant: 'fonts',
+        fallbackVariant: 'svg-sprite',
+        path: 'input.js',
+      });
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0].level).toBe('warning');
+      expect(code).toBe(`import { ProjectColor } from '@fluentui/react-brand-icons/svg/project';`);
+    });
+
+    it('resolves and diagnoses each referenced module only once', () => {
+      const source = [
+        `import { ProjectColor } from '@fluentui/react-brand-icons';`,
+        `import { CalendarTaskbarFilled } from '@fluentui/react-brand-icons';`,
+      ].join('\n');
+
+      const { diagnostics } = transformSource(source, { iconVariant: 'fonts', path: 'input.js' });
+
+      expect(diagnostics).toHaveLength(1);
     });
   });
 });

--- a/packages/react-icons-atomic-webpack-loader/test/transform.test.ts
+++ b/packages/react-icons-atomic-webpack-loader/test/transform.test.ts
@@ -1,8 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { transformSource } from '../src/transform';
+import type { IconVariant } from '../src/modules';
 
-const transform = (source: string, iconVariant: 'svg' | 'fonts' | 'svg-sprite' = 'svg') =>
-  transformSource(source, { iconVariant, path: 'input.js' }).code;
+const transform = (source: string, iconVariant: IconVariant = 'svg') =>
+  transformSource(source, {
+    variants: {
+      '@fluentui/react-icons': iconVariant,
+      // brand icons only ship svg
+      '@fluentui/react-brand-icons': 'svg',
+    },
+    path: 'input.js',
+  }).code;
 
 describe('transformSource', () => {
   describe('imports', () => {
@@ -159,6 +167,67 @@ describe('transformSource', () => {
         export { AddFilled, bundleIcon };
         export { ArrowLeftRegular } from '@fluentui/react-icons/svg/arrow-left';"
       `);
+    });
+  });
+
+  describe('@fluentui/react-brand-icons', () => {
+    it('rewrites an unsized brand icon import to its atomic svg path', () => {
+      expect(transform(`import { CalendarTaskbarFilled } from '@fluentui/react-brand-icons';`)).toBe(
+        `import { CalendarTaskbarFilled } from '@fluentui/react-brand-icons/svg/calendar-taskbar';`,
+      );
+    });
+
+    it('rewrites a sized brand icon import to its atomic svg path', () => {
+      expect(transform(`import { CalendarTaskbar20Filled } from '@fluentui/react-brand-icons';`)).toBe(
+        `import { CalendarTaskbar20Filled } from '@fluentui/react-brand-icons/svg/calendar-taskbar';`,
+      );
+    });
+
+    it('rewrites a color brand icon import to its atomic svg path', () => {
+      expect(transform(`import { ProjectColor } from '@fluentui/react-brand-icons';`)).toBe(
+        `import { ProjectColor } from '@fluentui/react-brand-icons/svg/project';`,
+      );
+    });
+
+    it('routes brand utility bindings to /utils', () => {
+      expect(transform(`import { bundleIcon, createFluentIcon } from '@fluentui/react-brand-icons';`)).toBe(
+        [
+          `import { bundleIcon } from '@fluentui/react-brand-icons/utils';`,
+          `import { createFluentIcon } from '@fluentui/react-brand-icons/utils';`,
+        ].join('\n'),
+      );
+    });
+
+    it('preserves local aliases on brand icon imports', () => {
+      expect(transform(`import { ProjectColor as MyProject } from '@fluentui/react-brand-icons';`)).toBe(
+        `import { ProjectColor as MyProject } from '@fluentui/react-brand-icons/svg/project';`,
+      );
+    });
+
+    it('rewrites direct brand re-exports', () => {
+      expect(transform(`export { ProjectColor } from '@fluentui/react-brand-icons';`)).toBe(
+        `export { ProjectColor } from '@fluentui/react-brand-icons/svg/project';`,
+      );
+    });
+
+    it('always resolves brand icons to svg regardless of iconVariant', () => {
+      expect(transform(`import { ProjectColor } from '@fluentui/react-brand-icons';`, 'fonts')).toBe(
+        `import { ProjectColor } from '@fluentui/react-brand-icons/svg/project';`,
+      );
+    });
+
+    it('rewrites system and brand icons in the same module independently', () => {
+      const source = [
+        `import { AddFilled } from '@fluentui/react-icons';`,
+        `import { ProjectColor } from '@fluentui/react-brand-icons';`,
+      ].join('\n');
+
+      expect(transform(source, 'fonts')).toBe(
+        [
+          `import { AddFilled } from '@fluentui/react-icons/fonts/add';`,
+          `import { ProjectColor } from '@fluentui/react-brand-icons/svg/project';`,
+        ].join('\n'),
+      );
     });
   });
 });

--- a/packages/react-icons-atomic-webpack-loader/test/webpack.config.js
+++ b/packages/react-icons-atomic-webpack-loader/test/webpack.config.js
@@ -82,6 +82,26 @@ const entries = {
     mustExclude: ['"@fluentui/react-icons"', '@fluentui/react-icons/svg/', '@fluentui/react-icons/fonts/'],
   },
 
+  'brand-icons-imports': {
+    src: './src/brand-icons-imports.js',
+    loaderOptions: {},
+    mustInclude: [
+      '@fluentui/react-brand-icons/svg/calendar-taskbar',
+      '@fluentui/react-brand-icons/svg/project',
+      '@fluentui/react-brand-icons/utils',
+    ],
+    mustExclude: ['"@fluentui/react-brand-icons"'],
+  },
+
+  'mixed-modules-fonts': {
+    src: './src/mixed-modules-fonts.js',
+    // react-icons honors 'fonts'; react-brand-icons only ships 'svg', so it
+    // falls back via the explicit fallbackVariant without erroring.
+    loaderOptions: { iconVariant: 'fonts', fallbackVariant: 'svg' },
+    mustInclude: ['@fluentui/react-icons/fonts/add', '@fluentui/react-brand-icons/svg/project'],
+    mustExclude: ['"@fluentui/react-icons"', '"@fluentui/react-brand-icons"', '@fluentui/react-brand-icons/fonts/'],
+  },
+
   'jsx-component': {
     src: './src/jsx-component.jsx',
     loaderOptions: {},
@@ -117,7 +137,7 @@ function createConfig(name, entry) {
     resolve: {
       extensions: ['.tsx', '.ts', '.jsx', '.js'],
     },
-    externals: [/^@fluentui\/react-icons/, /^react$/],
+    externals: [/^@fluentui\/react-icons/, /^@fluentui\/react-brand-icons/, /^react$/],
     module: {
       rules: [
         {


### PR DESCRIPTION
## Summary

Generalizes `@fluentui/react-icons-atomic-webpack-loader` to rewrite barrel imports/re-exports for **multiple modules** via an internal module registry, and adds support for **`@fluentui/react-brand-icons`** alongside `@fluentui/react-icons`.

## What changed

- **New `src/modules.ts`** — internal module registry. Each `ModuleDescriptor` declares its `name`, `supportedVariants`, and atomic-path `resolve()`:
  - `@fluentui/react-icons` → `svg` / `fonts` / `svg-sprite`; providers → `/providers`, icons → `/{variant}/{kebab}`, else → `/utils`
  - `@fluentui/react-brand-icons` → `svg` only; icons → `/svg/{kebab}`, else → `/utils` (no `/providers`)
  - Also hosts the pure variant-resolution policy (`resolveModuleVariant`).
- **`src/transform.ts`** — module-agnostic rewriter. Resolves the effective variant per module **from the parsed import/export record** (oxc `staticImports`/`staticExports`), so only modules actually imported/re-exported are considered. Returns structured `diagnostics` alongside `{ code, map }`; modules that fail resolution are left untouched. Indirect re-export dedupe guard preserved.
- **`src/index.ts`** — new `fallbackVariant` option. Per referenced module:
  1. supports `iconVariant` → use it
  2. else `fallbackVariant` supported → use it
  3. else `fallbackVariant` set but unsupported → warn + fall back to `svg`
  4. else (no `fallbackVariant`) → descriptive error

  The loader emits the transform's diagnostics (warnings via `emitWarning`, errors via the loader callback) and preserves the underlying error message on transform failure.

## API

```js
{
  loader: '@fluentui/react-icons-atomic-webpack-loader',
  options: {
    iconVariant: 'fonts',     // svg | fonts | svg-sprite (default svg)
    fallbackVariant: 'svg',   // used when a module can't honor iconVariant
  },
}
```

`iconVariant: 'svg'` (default) is backward compatible and never errors.

## Diagnostics

Diagnostics are driven by the parsed **module record**, not by substring-matching the source. A module name appearing only in a comment or string literal never triggers an error/warning; a file importing only `@fluentui/react-icons` never errors about brand icons.

## Notes

- No public/user-extensible rule API — module resolution is hardcoded internally.
- No runtime dependency on the private `@fluentui/react-brand-icons` package (externalized in tests).

## Testing

- `npm test` — 30 unit tests + 12 webpack integration entries (incl. new `brand-icons-imports` and `mixed-modules-fonts`) pass.
- `npm run build` — clean.
