### PR TITLE
ci(standalone): exclude private packages from publish & join main-writer concurrency group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 /.github/workflows/pr.yml @microsoft/cxe-prg @microsoft/react-native-sdk-admins @spencer-nelson
 /.github/workflows/pr-summary-comment.yml @microsoft/cxe-prg
 /.github/workflows/publish.yml @microsoft/cxe-prg @microsoft/react-native-sdk-admins @spencer-nelson
+/.github/workflows/publish-standalone.yml @microsoft/cxe-prg
 /.github/workflows/publish-prerelease.yml @microsoft/cxe-prg
 /.github/workflows/bundle-size.baseline.yml @microsoft/cxe-prg
 /.github/workflows/deploy-docsite.yml @microsoft/cxe-prg

--- a/.github/workflows/publish-standalone.yml
+++ b/.github/workflows/publish-standalone.yml
@@ -9,6 +9,13 @@ on:
         default: false
         type: boolean
 
+# Serialize all automated writers to `main` (this workflow and publish.yml / bundle-size.baseline.yml
+# share the same group) so their pushes can never race and clobber each other.
+# `cancel-in-progress: false` queues runs instead of cancelling them.
+concurrency:
+  group: main-writer
+  cancel-in-progress: false
+
 jobs:
   publish-standalone:
     # Prevent infinite loops: skip if the commit was made by the build system itself
@@ -55,18 +62,22 @@ jobs:
       - name: Resolve standalone projects
         id: projects
         run: |
-          NX_NAMES=$(npx nx show projects -p "tag:npm:standalone" --sep ',')
+          # Intersect `npm:standalone` with the Nx-inferred `npm:public` tag (derived from each
+          # package.json `private` field) so private packages (e.g. react-icons-file-type) — which
+          # belong to the standalone release group only for pre-release versioning — are never
+          # versioned/changelogged/published/tagged by this public release workflow.
+          NX_NAMES=$(npx nx show projects -p "tag:npm:standalone" --exclude "tag:npm:private" --sep ',')
           echo "nx-names=$NX_NAMES" >> "$GITHUB_OUTPUT"
-          echo "### Standalone projects" >> $GITHUB_STEP_SUMMARY
+          echo "### Standalone projects (publishable)" >> $GITHUB_STEP_SUMMARY
           echo "$NX_NAMES" | tr ',' '\n' | while read -r p; do echo "- $p" >> $GITHUB_STEP_SUMMARY; done
 
       - name: Build packages
         run: |
-          npx nx run-many -t build --projects=tag:npm:standalone
+          npx nx run-many -t build --projects=${{ steps.projects.outputs.nx-names }}
 
       - name: Version packages (Nx Release)
         run: |
-          npx nx release version --group=standalone --verbose
+          npx nx release version --projects=${{ steps.projects.outputs.nx-names }} --verbose
 
       - name: Generate changelogs (Nx Release)
         # --first-release: allows changelog generation when no prior git tag exists (first release).


### PR DESCRIPTION
## Summary

Two fixes to the standalone publish workflow (`.github/workflows/publish-standalone.yml`):

1. **Don't publish private packages.** The `Resolve standalone projects` step previously selected every project tagged `npm:standalone`, which included the **private** `@fluentui/react-icons-file-type` (it lives in the `standalone` release group only for pre-release versioning). It is now filtered out by intersecting with the Nx-inferred `npm:private` tag (derived from each `package.json` `private` field — the same mechanism `publish.yml` relies on via `npm:public`):

   ```bash
   npx nx show projects -p "tag:npm:standalone" --exclude "tag:npm:private" --sep ','
   ```

   The resolved list is the single source of truth used by build, version, changelog, publish, tag, and the dry-run summary, so the private package is excluded from the entire public release flow. The version step was also switched from `--group=standalone` to `--projects=<resolved list>` for consistency.

2. **Prevent race conditions with other `main` writers.** Added the shared `concurrency` group so this workflow queues behind `publish.yml` / `bundle-size.baseline.yml` instead of racing their pushes to `main`:

   ```yaml
   concurrency:
     group: main-writer
     cancel-in-progress: false
   ```

## Notes

- Verified locally that `--exclude "tag:npm:private"` returns only the two publishable standalone packages (`react-icons-atomic-webpack-loader`, `react-icons-svg-sprite-subsetting-webpack-plugin`).
- The comma form `tag:npm:standalone,tag:npm:public` is a **union** (returns all projects), so it is not usable here — exclusion is required.