### PR TITLE
refactor(react-icons): extract shared icon core for griffel + headless

### DIFF
--- a/packages/react-icons/build-verify.test.js
+++ b/packages/react-icons/build-verify.test.js
@@ -2498,6 +2498,34 @@ describe('Build Verification', () => {
 
       expect(packageJson.sideEffects).toEqual(['**/headless/fonts/styles.css', '**/headless/styles.css']);
     });
+
+    // Tree-shaking guardrail: the headless API and its atoms must never pull in
+    // Griffel. The shared core/ modules are styling-agnostic, so any Griffel
+    // reference here means a regression leaked the CSS-in-JS runtime into headless.
+    it('headless output must be Griffel-free (tree-shaking guardrail)', () => {
+      const targets = [
+        path.join(__dirname, 'lib', 'headless'),
+        path.join(__dirname, 'lib', 'atoms', 'headless-svg'),
+        path.join(__dirname, 'lib', 'atoms', 'headless-fonts'),
+        path.join(__dirname, 'lib-cjs', 'headless'),
+        path.join(__dirname, 'lib-cjs', 'atoms', 'headless-svg'),
+        path.join(__dirname, 'lib-cjs', 'atoms', 'headless-fonts'),
+      ];
+      /** @type {string[]} */
+      const offenders = [];
+      for (const dir of targets) {
+        if (!fs.existsSync(dir)) continue;
+        for (const entry of fs.readdirSync(dir, { recursive: true })) {
+          const rel = String(entry);
+          if (!rel.endsWith('.js')) continue;
+          const full = path.join(dir, rel);
+          if (/@griffel/.test(fs.readFileSync(full, 'utf-8'))) {
+            offenders.push(path.relative(__dirname, full));
+          }
+        }
+      }
+      expect(offenders).toEqual([]);
+    });
   });
 
   describe('Metadata Validation', () => {

--- a/packages/react-icons/src/core/fontIcon.ts
+++ b/packages/react-icons/src/core/fontIcon.ts
@@ -1,0 +1,35 @@
+import * as React from 'react';
+
+/**
+ * Applies the inline styles shared by both font-icon factories:
+ * - maps `primaryFill` -> `color` (unless `currentColor`)
+ * - applies an explicit `fontSize`
+ *
+ * Mutates `state.style` in place to match the existing factory behaviour.
+ */
+export const applyFontStyle = (
+  state: { style?: React.CSSProperties },
+  primaryFill: string | undefined,
+  fontSize: number | undefined,
+): void => {
+  if (primaryFill && primaryFill.toLowerCase() !== 'currentcolor') {
+    state.style = {
+      ...state.style,
+      color: primaryFill,
+    };
+  }
+
+  if (fontSize) {
+    state.style = {
+      ...state.style,
+      fontSize,
+    };
+  }
+};
+
+/**
+ * Renders the `<i>` element body for a font icon. `state` must already carry
+ * className/style/a11y; the glyph `codepoint` is the element's text content.
+ */
+export const renderFontBody = <TState extends object>(state: TState, codepoint: string): React.ReactElement =>
+  React.createElement('i', state, codepoint);

--- a/packages/react-icons/src/core/svg.ts
+++ b/packages/react-icons/src/core/svg.ts
@@ -1,0 +1,76 @@
+import * as React from 'react';
+
+/**
+ * Structured SVG element tree used for color icons (CSP-safe alternative to
+ * raw innerHTML strings).
+ */
+export type SvgNode = [
+  tag: string,
+  attrs: Record<string, string | Record<string, string>> | null,
+  ...children: SvgNode[],
+];
+
+/** Recursively renders an {@link SvgNode} tree into React elements. */
+export const renderSvgNode = (node: SvgNode, key: number): React.ReactElement => {
+  const [tag, attrs, ...children] = node;
+  return React.createElement(tag, { ...attrs, key }, ...children.map(renderSvgNode));
+};
+
+/** Normalizes the icon width into a square viewBox dimension. */
+export const computeViewBox = (width: string): string => (width === '1em' ? '20' : width);
+
+/**
+ * Pre-renders color SVG node trees once (outside React render) so the recursion
+ * never runs during component renders. Returns `undefined` for mono-color
+ * (path `string[]`) icons.
+ */
+export const precomputeColorChildren = (
+  pathsOrSvg: string[] | string | SvgNode[],
+  options?: { color?: boolean },
+): React.ReactElement[] | undefined =>
+  typeof pathsOrSvg !== 'string' && (options?.color || Array.isArray(pathsOrSvg[0]))
+    ? (pathsOrSvg as SvgNode[]).map(renderSvgNode)
+    : undefined;
+
+type RenderSvgState = { fill?: string };
+
+/**
+ * Renders the `<svg>` element body for an already-resolved element `state`.
+ * Handles the three content forms:
+ * - raw innerHTML `string` (deprecated, CSP-unsafe `dangerouslySetInnerHTML`),
+ * - pre-rendered color children ({@link precomputeColorChildren}),
+ * - mono-color path `d` strings.
+ *
+ * `state` must already carry className/fill/width/height/viewBox/xmlns/ref.
+ */
+export const renderSvgBody = <TState extends RenderSvgState>(
+  state: TState,
+  pathsOrSvg: string[] | string | SvgNode[],
+  colorChildren: React.ReactElement[] | undefined,
+): React.ReactElement => {
+  if (typeof pathsOrSvg === 'string') {
+    return React.createElement('svg', { ...state, dangerouslySetInnerHTML: { __html: pathsOrSvg } });
+  }
+  if (colorChildren) {
+    return React.createElement('svg', state, ...colorChildren);
+  }
+  return React.createElement(
+    'svg',
+    state,
+    ...(pathsOrSvg as string[]).map((d) => React.createElement('path', { d, fill: state.fill })),
+  );
+};
+
+/**
+ * Renders the `<svg>` element body for a sprite icon — references an external
+ * symbol via `<use href>`. `state` must already carry
+ * className/width/height/viewBox/xmlns/ref.
+ */
+export const renderSpriteBody = <TState extends object>(
+  state: TState,
+  iconId: string,
+  spritePath?: string,
+): React.ReactElement => {
+  const href = spritePath ? `${spritePath}#${iconId}` : `#${iconId}`;
+  return React.createElement('svg', state, React.createElement('use', { href }));
+};

--- a/packages/react-icons/src/core/useBaseIconState.ts
+++ b/packages/react-icons/src/core/useBaseIconState.ts
@@ -1,0 +1,62 @@
+import type * as React from 'react';
+import { useIconContext } from '../contexts';
+import type { FluentIconsProps } from '../utils/FluentIconsProps.types';
+
+export type UseIconStateOptions = {
+  flipInRtl?: boolean;
+};
+
+export type BaseIconState<
+  TBaseAttributes extends React.SVGAttributes<SVGElement> | React.HTMLAttributes<HTMLElement>,
+  TRefType extends HTMLElement | SVGSVGElement,
+> = Omit<FluentIconsProps<TBaseAttributes, TRefType>, 'primaryFill'>;
+
+/**
+ * Styling-agnostic icon state shared by the Griffel and headless APIs.
+ *
+ * Handles the parts that are identical regardless of styling strategy:
+ * - strips non-DOM props (`filled`)
+ * - maps `primaryFill` -> `fill`
+ * - applies a11y (`title` -> `aria-label`, otherwise `aria-hidden`; `role="img"`)
+ * - resolves the RTL flip decision from icon context
+ *
+ * Callers layer their own className / `data-*` attribute styling on top, and
+ * apply the visual RTL flip using `isRtlFlip`.
+ */
+export const useBaseIconState = <
+  TBaseAttributes extends
+    | React.SVGAttributes<SVGElement>
+    | React.HTMLAttributes<HTMLElement> = React.SVGAttributes<SVGElement>,
+  TRefType extends HTMLElement | SVGSVGElement = SVGSVGElement,
+>(
+  props: FluentIconsProps<TBaseAttributes, TRefType>,
+  options?: UseIconStateOptions,
+): { state: BaseIconState<TBaseAttributes, TRefType>; isRtlFlip: boolean } => {
+  const {
+    // remove unwanted props to be set on the svg/html element
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    filled,
+    title,
+    primaryFill = 'currentColor',
+    ...rest
+  } = props;
+  const state = {
+    ...rest,
+    fill: primaryFill,
+  } as BaseIconState<TBaseAttributes, TRefType>;
+
+  const iconContext = useIconContext();
+  const isRtlFlip = Boolean(options?.flipInRtl && iconContext?.textDirection === 'rtl');
+
+  if (title) {
+    state['aria-label'] = title;
+  }
+
+  if (!state['aria-label'] && !state['aria-labelledby']) {
+    state['aria-hidden'] = true;
+  } else {
+    state['role'] = 'img';
+  }
+
+  return { state, isRtlFlip };
+};

--- a/packages/react-icons/src/headless/createFluentIcon.svg-sprite.tsx
+++ b/packages/react-icons/src/headless/createFluentIcon.svg-sprite.tsx
@@ -4,6 +4,7 @@ import type { FluentIconsProps } from './shared';
 import { cx, iconClassName } from './shared';
 import { useIconState } from './useIconState';
 import type { FluentIcon, CreateFluentIconOptions } from './createFluentIcon';
+import { computeViewBox, renderSpriteBody } from '../core/svg';
 
 export type { FluentIcon, CreateFluentIconOptions } from './createFluentIcon';
 
@@ -19,7 +20,7 @@ export const createFluentIcon = (
   spritePath?: string,
   options?: CreateFluentIconOptions,
 ): FluentIcon => {
-  const viewBoxWidth = size === '1em' ? '20' : size;
+  const viewBoxWidth = computeViewBox(size);
 
   const Icon = React.forwardRef((props: FluentIconsProps, ref: React.Ref<HTMLElement>) => {
     const iconState = useIconState(props, { flipInRtl: options?.flipInRtl });
@@ -33,9 +34,7 @@ export const createFluentIcon = (
       xmlns: 'http://www.w3.org/2000/svg',
     };
 
-    const href = spritePath ? `${spritePath}#${iconId}` : `#${iconId}`;
-
-    return React.createElement('svg', state, React.createElement('use', { href }));
+    return renderSpriteBody(state, iconId, spritePath);
   }) as FluentIcon;
   Icon.displayName = iconId;
   return Icon;

--- a/packages/react-icons/src/headless/createFluentIcon.ts
+++ b/packages/react-icons/src/headless/createFluentIcon.ts
@@ -3,19 +3,14 @@ import * as React from 'react';
 import type { FluentIconsProps } from './shared';
 import { iconClassName, cx } from './shared';
 import { useIconState } from './useIconState';
+import { computeViewBox, precomputeColorChildren, renderSvgBody } from '../core/svg';
+import type { SvgNode } from '../core/svg';
 
 export type FluentIcon = React.FC<FluentIconsProps>;
 
 export type CreateFluentIconOptions = {
   flipInRtl?: boolean;
   color?: boolean;
-};
-
-type SvgNode = [tag: string, attrs: Record<string, string | Record<string, string>> | null, ...children: SvgNode[]];
-
-const renderSvgNode = (node: SvgNode, key: number): React.ReactElement => {
-  const [tag, attrs, ...children] = node;
-  return React.createElement(tag, { ...attrs, key }, ...children.map(renderSvgNode));
 };
 
 /**
@@ -46,13 +41,10 @@ export const createFluentIcon = (
   pathsOrSvg: string[] | string | SvgNode[],
   options?: CreateFluentIconOptions,
 ): FluentIcon => {
-  const viewBoxWidth = width === '1em' ? '20' : width;
+  const viewBoxWidth = computeViewBox(width);
   // Pre-render color SVG nodes once in the factory so the recursion
   // never runs during React renders.
-  const colorChildren =
-    typeof pathsOrSvg !== 'string' && (options?.color || Array.isArray(pathsOrSvg[0]))
-      ? (pathsOrSvg as SvgNode[]).map(renderSvgNode)
-      : undefined;
+  const colorChildren = precomputeColorChildren(pathsOrSvg, options);
   const Icon = React.forwardRef((props: FluentIconsProps, ref: React.Ref<HTMLElement>) => {
     const iconState = useIconState(props, { flipInRtl: options?.flipInRtl });
     const state = {
@@ -64,17 +56,7 @@ export const createFluentIcon = (
       viewBox: `0 0 ${viewBoxWidth} ${viewBoxWidth}`,
       xmlns: 'http://www.w3.org/2000/svg',
     };
-    if (typeof pathsOrSvg === 'string') {
-      return React.createElement('svg', { ...state, dangerouslySetInnerHTML: { __html: pathsOrSvg } });
-    }
-    if (colorChildren) {
-      return React.createElement('svg', state, ...colorChildren);
-    }
-    return React.createElement(
-      'svg',
-      state,
-      ...(pathsOrSvg as string[]).map((d) => React.createElement('path', { d, fill: state.fill })),
-    );
+    return renderSvgBody(state, pathsOrSvg, colorChildren);
   }) as FluentIcon;
   Icon.displayName = displayName;
   return Icon;

--- a/packages/react-icons/src/headless/fonts/createFluentFontIcon.tsx
+++ b/packages/react-icons/src/headless/fonts/createFluentFontIcon.tsx
@@ -5,6 +5,7 @@ import { fontIconClassName, DATA_FUI_ICON, DATA_FUI_ICON_FONT, cx } from '../sha
 
 import { useIconState } from '../useIconState';
 import { FontFile } from '../../utils/fonts/createFluentFontIcon.shared';
+import { applyFontStyle, renderFontBody } from '../../core/fontIcon';
 
 export type CreateFluentFontIconOptions = {
   flipInRtl?: boolean;
@@ -50,21 +51,9 @@ export function createFluentFontIcon(
     state[DATA_FUI_ICON_FONT] = FONT_VARIANT_MAP[font];
 
     // Map primaryFill to color for font icons
-    if (props.primaryFill && props.primaryFill.toLowerCase() !== 'currentcolor') {
-      state.style = {
-        ...state.style,
-        color: props.primaryFill,
-      };
-    }
+    applyFontStyle(state, props.primaryFill, fontSize);
 
-    if (fontSize) {
-      state.style = {
-        ...state.style,
-        fontSize,
-      };
-    }
-
-    return <i {...state}>{codepoint}</i>;
+    return renderFontBody(state, codepoint);
   };
   Component.displayName = displayName;
   Component.codepoint = codepoint;

--- a/packages/react-icons/src/headless/useIconState.tsx
+++ b/packages/react-icons/src/headless/useIconState.tsx
@@ -1,11 +1,9 @@
-import * as React from 'react';
-import { useIconContext } from '../contexts';
 import type { FluentIconsProps } from './shared';
 import { DATA_FUI_ICON, DATA_FUI_ICON_RTL } from './shared';
+import { useBaseIconState } from '../core/useBaseIconState';
+import type { UseIconStateOptions } from '../core/useBaseIconState';
 
-export type UseIconStateOptions = {
-  flipInRtl?: boolean;
-};
+export type { UseIconStateOptions };
 
 /**
  * Headless version of useIconState
@@ -25,37 +23,12 @@ export const useIconState = <
   props: FluentIconsProps<TBaseAttributes, TRefType>,
   options?: UseIconStateOptions,
 ): Omit<FluentIconsProps<TBaseAttributes, TRefType>, 'primaryFill'> => {
-  const {
-    // remove unwanted props to be set on the svg/html element
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    filled,
-    title,
-
-    primaryFill = 'currentColor',
-    ...rest
-  } = props;
-  const state = {
-    ...rest,
-    fill: primaryFill,
-  } as Omit<FluentIconsProps<TBaseAttributes, TRefType>, 'primaryFill'>;
-
-  const iconContext = useIconContext();
-  const isRtlFlip = options?.flipInRtl && iconContext?.textDirection === 'rtl';
+  const { state, isRtlFlip } = useBaseIconState(props, options);
 
   // Data attributes for CSS targeting
   state[DATA_FUI_ICON] = '';
   if (isRtlFlip) {
     state[DATA_FUI_ICON_RTL] = '';
-  }
-
-  if (title) {
-    state['aria-label'] = title;
-  }
-
-  if (!state['aria-label'] && !state['aria-labelledby']) {
-    state['aria-hidden'] = true;
-  } else {
-    state['role'] = 'img';
   }
 
   return state;

--- a/packages/react-icons/src/utils/createFluentIcon.svg-sprite.tsx
+++ b/packages/react-icons/src/utils/createFluentIcon.svg-sprite.tsx
@@ -5,6 +5,7 @@ import type { FluentIconsProps } from './FluentIconsProps.types';
 import { useIconState } from './useIconState';
 import { useRootStyles } from './createFluentIcon.styles';
 import { iconClassName } from './constants';
+import { computeViewBox, renderSpriteBody } from '../core/svg';
 
 export type FluentIcon = React.FC<FluentIconsProps>;
 type CreateFluentIconOptions = {
@@ -30,7 +31,7 @@ export const createFluentIcon = (
   spritePath?: string,
   options?: CreateFluentIconOptions,
 ): FluentIcon => {
-  const viewBoxWidth = size === '1em' ? '20' : size;
+  const viewBoxWidth = computeViewBox(size);
 
   const Icon = React.forwardRef((props: FluentIconsProps, ref: React.Ref<HTMLElement>) => {
     const styles = useRootStyles();
@@ -45,16 +46,7 @@ export const createFluentIcon = (
       xmlns: 'http://www.w3.org/2000/svg',
     };
 
-    const href = spritePath ? `${spritePath}#${iconId}` : `#${iconId}`;
-
-    return React.createElement(
-      'svg',
-      state,
-      React.createElement('use', {
-        href,
-        // The fill is applied to the svg element and inherited by use
-      }),
-    );
+    return renderSpriteBody(state, iconId, spritePath);
   }) as FluentIcon;
   Icon.displayName = iconId;
   return Icon;

--- a/packages/react-icons/src/utils/createFluentIcon.ts
+++ b/packages/react-icons/src/utils/createFluentIcon.ts
@@ -4,6 +4,8 @@ import { FluentIconsProps } from './FluentIconsProps.types';
 import { useIconState } from './useIconState';
 import { useRootStyles } from './createFluentIcon.styles';
 import { iconClassName } from './constants';
+import { computeViewBox, precomputeColorChildren, renderSvgBody } from '../core/svg';
+import type { SvgNode } from '../core/svg';
 
 export type FluentIcon = React.FC<FluentIconsProps>;
 
@@ -12,16 +14,7 @@ export type CreateFluentIconOptions = {
   color?: boolean;
 };
 
-export type SvgNode = [
-  tag: string,
-  attrs: Record<string, string | Record<string, string>> | null,
-  ...children: SvgNode[],
-];
-
-const renderSvgNode = (node: SvgNode, key: number): React.ReactElement => {
-  const [tag, attrs, ...children] = node;
-  return React.createElement(tag, { ...attrs, key }, ...children.map(renderSvgNode));
-};
+export type { SvgNode };
 
 /**
  * Creates a Fluent icon React component with Griffel styling.
@@ -42,13 +35,10 @@ export const createFluentIcon = (
   pathsOrSvg: string[] | string | SvgNode[],
   options?: CreateFluentIconOptions,
 ): FluentIcon => {
-  const viewBoxWidth = width === '1em' ? '20' : width;
+  const viewBoxWidth = computeViewBox(width);
   // Pre-render color SVG nodes once in the factory so the recursion
   // never runs during React renders.
-  const colorChildren =
-    typeof pathsOrSvg !== 'string' && (options?.color || Array.isArray(pathsOrSvg[0]))
-      ? (pathsOrSvg as SvgNode[]).map(renderSvgNode)
-      : undefined;
+  const colorChildren = precomputeColorChildren(pathsOrSvg, options);
   const Icon = React.forwardRef((props: FluentIconsProps, ref: React.Ref<HTMLElement>) => {
     const styles = useRootStyles();
     const iconState = useIconState(props, { flipInRtl: options?.flipInRtl });
@@ -61,21 +51,7 @@ export const createFluentIcon = (
       viewBox: `0 0 ${viewBoxWidth} ${viewBoxWidth}`,
       xmlns: 'http://www.w3.org/2000/svg',
     };
-    // @deprecated - this branch is not used in our code, only keeping for backwards compatibility
-    // Color icon: render raw SVG children
-    if (typeof pathsOrSvg === 'string') {
-      return React.createElement('svg', { ...state, dangerouslySetInnerHTML: { __html: pathsOrSvg } });
-    }
-    // Color icon: use pre-rendered elements
-    if (colorChildren) {
-      return React.createElement('svg', state, ...colorChildren);
-    }
-
-    return React.createElement(
-      'svg',
-      state,
-      ...(pathsOrSvg as string[]).map((d) => React.createElement('path', { d, fill: state.fill })),
-    );
+    return renderSvgBody(state, pathsOrSvg, colorChildren);
   }) as FluentIcon;
   Icon.displayName = displayName;
   return Icon;

--- a/packages/react-icons/src/utils/fonts/createFluentFontIcon.tsx
+++ b/packages/react-icons/src/utils/fonts/createFluentFontIcon.tsx
@@ -7,6 +7,7 @@ import { fontIconClassName } from '../constants';
 
 import { useRootStyles, useStaticStyles } from './createFluentFontIcon.styles';
 import { FontFile } from './createFluentFontIcon.shared';
+import { applyFontStyle, renderFontBody } from '../../core/fontIcon';
 
 export type CreateFluentFontIconOptions = {
   flipInRtl?: boolean;
@@ -33,21 +34,9 @@ export function createFluentFontIcon(
     );
 
     // We want to keep the same API surface as the SVG icons, so translate `primaryFill` to `color`
-    if (props.primaryFill && props.primaryFill.toLowerCase() !== 'currentcolor') {
-      state.style = {
-        ...state.style,
-        color: props.primaryFill,
-      };
-    }
+    applyFontStyle(state, props.primaryFill, fontSize);
 
-    if (fontSize) {
-      state.style = {
-        ...state.style,
-        fontSize,
-      };
-    }
-
-    return <i {...state}>{codepoint}</i>;
+    return renderFontBody(state, codepoint);
   };
   Component.displayName = displayName;
   Component.codepoint = codepoint;

--- a/packages/react-icons/src/utils/useIconState.tsx
+++ b/packages/react-icons/src/utils/useIconState.tsx
@@ -1,11 +1,10 @@
-import { useIconContext } from '../contexts';
-import { FluentIconsProps } from './FluentIconsProps.types';
 import { mergeClasses } from '@griffel/react';
+import type { FluentIconsProps } from './FluentIconsProps.types';
 import { useStyles } from './useIconStyles.styles';
+import { useBaseIconState } from '../core/useBaseIconState';
+import type { UseIconStateOptions } from '../core/useBaseIconState';
 
-export type UseIconStateOptions = {
-  flipInRtl?: boolean;
-};
+export type { UseIconStateOptions };
 
 export const useIconState = <
   TBaseAttributes extends
@@ -16,38 +15,8 @@ export const useIconState = <
   props: FluentIconsProps<TBaseAttributes, TRefType>,
   options?: UseIconStateOptions,
 ): Omit<FluentIconsProps<TBaseAttributes, TRefType>, 'primaryFill'> => {
-  const {
-    // remove unwanted props to be set on the svg/html element
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    filled,
-    title,
-
-    primaryFill = 'currentColor',
-    ...rest
-  } = props;
-  const state = {
-    ...rest,
-    fill: primaryFill,
-  } as Omit<FluentIconsProps<TBaseAttributes, TRefType>, 'primaryFill'>;
-
   const styles = useStyles();
-  const iconContext = useIconContext();
-
-  state.className = mergeClasses(
-    styles.root,
-    options?.flipInRtl && iconContext?.textDirection === 'rtl' && styles.rtl,
-    state.className,
-  );
-
-  if (title) {
-    state['aria-label'] = title;
-  }
-
-  if (!state['aria-label'] && !state['aria-labelledby']) {
-    state['aria-hidden'] = true;
-  } else {
-    state['role'] = 'img';
-  }
-
+  const { state, isRtlFlip } = useBaseIconState(props, options);
+  state.className = mergeClasses(styles.root, isRtlFlip && styles.rtl, state.className);
   return state;
 };


### PR DESCRIPTION
## Summary

Extracts a styling-agnostic **`src/core/`** shared by both the Griffel and headless icon factories, so the two APIs can't drift on rendering or a11y behaviour — only their `className` / `data-*` styling line differs.

### Net-new commit
- **refactor(react-icons): extract shared icon core for griffel + headless** (`47763363fd`)
  - `core/svg.ts` — `SvgNode`, `renderSvgNode`, `computeViewBox`, `precomputeColorChildren`, `renderSvgBody`, `renderSpriteBody`
  - `core/useBaseIconState.ts` — shared a11y / RTL / fill state hook
  - `core/fontIcon.ts` — `applyFontStyle`, `renderFontBody`
  - rewires the `utils/` + `headless/` SVG, sprite and font factories onto the core
  - adds a `build-verify` guardrail asserting headless output stays Griffel-free

### Bundle-size note
Marginally increases per-bundle size (~60 B gzip, a fixed one-time cost) since a consumer only loads one API — accepted for the maintainability and drift-safety win. Verified via the headless monosize fixtures.

### Stacking
> ⚠️ **Stacked on #1119** (`react-icons/prepare-headless-for-release`). Until that merges, this PR's diff also includes the headless-stabilization commits. Review the `refactor(react-icons): extract shared icon core` commit in isolation, or rebase/retarget once #1119 lands.

> Draft — opened for review/CI while the work settles.