### PR TITLE
feat(font-subsetting-plugin): subset headless font atoms

### DIFF
--- a/packages/react-icons-font-subsetting-webpack-plugin/README.md
+++ b/packages/react-icons-font-subsetting-webpack-plugin/README.md
@@ -25,6 +25,18 @@ import { DeleteRegular } from '@fluentui/react-icons/fonts/delete';
 
 Atomic imports provide better tree-shaking and faster build times for applications using a small number of icons.
 
+### 3. Using headless atomic imports from `@fluentui/react-icons/headless/fonts/*`
+
+```js
+// Headless font atoms — no Griffel runtime.
+// You MUST also import the headless font CSS so the @font-face declarations and
+// font files enter the module graph (the headless atoms don't import them):
+import '@fluentui/react-icons/headless/fonts/styles.css';
+import { AddRegular, AddFilled } from '@fluentui/react-icons/headless/fonts/add';
+```
+
+The plugin subsets the same shared font files used by the standard API, based on the headless icons you actually use. Because the font files arrive via `styles.css`, your config needs a CSS loader (e.g. `css-loader`) so the `url(...)` references resolve into webpack assets.
+
 ## Usage
 
 ### With `fluentIconFont` condition

--- a/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
@@ -15,12 +15,14 @@ const FONT_FILES_BASE_NAMES = [
 const FONT_EXTENSIONS = ['.ttf', '.woff', '.woff2'];
 
 /**
- *  Match both chunk files and atomic font imports:
- *  - lib/fonts/sizedIcons/chunk-0.js (chunk-based)
- *  - lib/atoms/fonts/access-time.js (atomic imports)
+ *  Match both chunk files and atomic font imports, for the standard (Griffel)
+ *  and headless APIs:
+ *  - lib/fonts/sizedIcons/chunk-0.js        (chunk-based, standard)
+ *  - lib/atoms/fonts/access-time.js         (atomic imports, standard)
+ *  - lib/atoms/headless-fonts/access-time.js (atomic imports, headless)
  */
 const REACT_ICONS_FONT_MODULE_IMPORT_PATTERN =
-  /react-icons[\/\\]lib(-cjs)?[\/\\](fonts[\/\\](sizedIcons|icons)[\/\\]chunk-\d+|atoms[\/\\]fonts[\/\\][\w-]+)\.js$/;
+  /react-icons[\/\\]lib(-cjs)?[\/\\](fonts[\/\\](sizedIcons|icons)[\/\\]chunk-\d+|atoms[\/\\](headless-)?fonts[\/\\][\w-]+)\.js$/;
 
 export default class FluentUIReactIconsFontSubsettingPlugin implements webpack.WebpackPluginInstance {
   /**

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/src/headless-atoms.js
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/src/headless-atoms.js
@@ -1,0 +1,17 @@
+// @ts-check
+
+// Headless font icons: the atom imports drive icon *usage* tracking, while
+// `headless/fonts/styles.css` brings the `@font-face` declarations (and the
+// referenced font files) into the module graph so the subsetting plugin has
+// assets to subset. In a real app this CSS import is required for headless fonts.
+import '@fluentui/react-icons/headless/fonts/styles.css';
+import { XboxConsole24Filled } from '@fluentui/react-icons/headless/fonts/xbox-console';
+import { BoardGames20Regular } from '@fluentui/react-icons/headless/fonts/board-games';
+import { GamesFilled } from '@fluentui/react-icons/headless/fonts/games';
+
+console.log('headless atomic fonts loaded');
+console.dir({
+  XboxConsole24Filled,
+  BoardGames20Regular,
+  GamesFilled,
+});

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/webpack.config.js
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/webpack.config.js
@@ -2,6 +2,7 @@
 const { resolve } = require('path');
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const { default: FluentUIReactIconsFontSubsettingPlugin } = require('../lib/');
 
@@ -49,9 +50,11 @@ function createConfig(name, entry) {
         },
         {
           // Headless fonts pull their `@font-face` (and font files) in via CSS.
-          // css-loader resolves the `url(...)` references into asset modules.
+          // MiniCssExtractPlugin emits a real `[name].css` asset (instead of inlining the CSS
+          // string into the JS bundle), and css-loader resolves the `url(...)` references into
+          // asset modules so the subsetting plugin has font files to process.
           test: /\.css$/,
-          use: ['css-loader'],
+          use: [MiniCssExtractPlugin.loader, 'css-loader'],
         },
       ],
     },
@@ -71,6 +74,7 @@ function createConfig(name, entry) {
             }),
           ]
         : []),
+      new MiniCssExtractPlugin(),
       new FluentUIReactIconsFontSubsettingPlugin(),
       {
         apply(compiler) {

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/webpack.config.js
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/webpack.config.js
@@ -14,6 +14,8 @@ const entries = {
   atoms: { src: './src/atoms.js', threshold: 2 * 1_024 }, // 2 KB
   // atomsImportStar uses `import *` and references more icon variants, producing a larger (but still properly subset) font.
   atomsImportStar: { src: './src/atoms-import-star.js', threshold: 3 * 1_024 }, // 3.0 KB
+  // Headless font atoms — fonts arrive via the headless `styles.css` import (css-loader) rather than Griffel.
+  headlessAtoms: { src: './src/headless-atoms.js', threshold: 2 * 1_024 }, // 2 KB
 };
 
 const isDevServer = process.env.WEBPACK_SERVE === 'true';
@@ -43,6 +45,12 @@ function createConfig(name, entry) {
             filename: `[name]-[contenthash][ext]`,
             dataUrl: {},
           },
+        },
+        {
+          // Headless fonts pull their `@font-face` (and font files) in via CSS.
+          // css-loader resolves the `url(...)` references into asset modules.
+          test: /\.css$/,
+          use: ['css-loader'],
         },
       ],
     },

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/webpack.config.js
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/webpack.config.js
@@ -15,7 +15,8 @@ const entries = {
   // atomsImportStar uses `import *` and references more icon variants, producing a larger (but still properly subset) font.
   atomsImportStar: { src: './src/atoms-import-star.js', threshold: 3 * 1_024 }, // 3.0 KB
   // Headless font atoms — fonts arrive via the headless `styles.css` import (css-loader) rather than Griffel.
-  headlessAtoms: { src: './src/headless-atoms.js', threshold: 2 * 1_024 }, // 2 KB
+  // No Griffel runtime is involved, so a tighter threshold is used to validate subsetting.
+  headlessAtoms: { src: './src/headless-atoms.js', threshold: 1.5 * 1_024 }, // 1.5 KB
 };
 
 const isDevServer = process.env.WEBPACK_SERVE === 'true';


### PR DESCRIPTION
## Summary

Teaches the font-subsetting plugin to recognize **headless** font atoms, so headless font icons get the same glyph subsetting as the standard (Griffel) API.

### Change
- `src/index.ts`: extend `REACT_ICONS_FONT_MODULE_IMPORT_PATTERN` to also match `lib/atoms/headless-fonts/*.js` (`atoms/(headless-)?fonts/…`). The shared fonts + codepoints (`lib/utils/fonts`) and export-usage analysis are unchanged, so that's the only gate.

### Test
- New fixture `test/src/headless-atoms.js` imports `@fluentui/react-icons/headless/fonts/styles.css` (so the `@font-face` font files enter the graph) + headless font atoms, wired as a `headlessAtoms` webpack entry with a `css-loader` rule.
- Result: headless fonts subset to **0.3–1.1 KiB each** (from MB-scale originals), under the 2 KB threshold.

### Docs
- README: documented the headless import pattern and the required `styles.css` import + CSS-loader.

### Notes
- Headless fonts arrive via the user-imported `styles.css` (not Griffel JS), so consumers must import it and have a CSS loader — called out in the README.
- `css-loader` is intentionally **not** added to this package's `devDependencies` (monorepo single-version policy — it resolves from the root).

> ⚠️ **Stacked on #1119** (`react-icons/prepare-headless-for-release`) — needs the headless font atoms + `headless/fonts/styles.css`. Until #1119 merges, this PR's diff also includes those commits; rebase/retarget after it lands.

> Draft — opened for review/CI while the stack settles.