### PR TITLE
feat(react-icons-atomic-webpack-loader): add headless option

### DIFF
--- a/packages/react-icons-atomic-webpack-loader/README.md
+++ b/packages/react-icons-atomic-webpack-loader/README.md
@@ -142,6 +142,7 @@ With the example above:
 Notes:
 
 - **Best-effort per module:** a module without a headless build for the resolved variant degrades to its standard (Griffel) implementation with a warning rather than failing the build. This applies to headless `svg-sprite` (not generated yet).
+- **Version requirement:** headless `@fluentui/react-brand-icons` requires `>= 2.0.206`. The loader rewrites imports statically and does not check the installed version, so an older brand-icons will fail to resolve the `/headless/*` entries at build time.
 - **Context is shared:** `useIconContext` / `IconDirectionContextProvider` always resolve to `@fluentui/react-icons/providers` — it is framework-agnostic and reused by both APIs.
 - **CSS is your responsibility:** the loader only rewrites component/utility imports. You must still import the headless CSS in your app entry point:
   ```js
@@ -195,3 +196,4 @@ Files that don't reference a supported module are passed through untouched (fast
 - `webpack` >= 5
 - `@fluentui/react-icons` >= 2 (with atomic subpath exports)
 - `@fluentui/react-brand-icons` (with atomic subpath exports), if used
+  - `>= 2.0.206` when using `headless: true` — earlier versions do not ship the `/headless/svg/*` and `/headless/utils` entries, so the loader's rewritten imports will fail to resolve.

--- a/packages/react-icons-atomic-webpack-loader/README.md
+++ b/packages/react-icons-atomic-webpack-loader/README.md
@@ -66,7 +66,7 @@ module.exports = {
 | Module                        | Variants                     | Headless       | Notes                         |
 | ----------------------------- | ---------------------------- | -------------- | ----------------------------- |
 | `@fluentui/react-icons`       | `svg`, `fonts`, `svg-sprite` | `svg`, `fonts` | Has `/providers` and `/utils` |
-| `@fluentui/react-brand-icons` | `svg`                        | — (none yet)   | Has `/utils`; no `/providers` |
+| `@fluentui/react-brand-icons` | `svg`                        | `svg`          | Has `/utils`; no `/providers` |
 
 ## Options
 
@@ -141,7 +141,7 @@ With the example above:
 
 Notes:
 
-- **Best-effort per module:** a module without a headless build for the resolved variant degrades to its standard (Griffel) implementation with a warning rather than failing the build. This applies to `@fluentui/react-brand-icons` (no headless build) and to headless `svg-sprite` (not generated yet).
+- **Best-effort per module:** a module without a headless build for the resolved variant degrades to its standard (Griffel) implementation with a warning rather than failing the build. This applies to headless `svg-sprite` (not generated yet).
 - **Context is shared:** `useIconContext` / `IconDirectionContextProvider` always resolve to `@fluentui/react-icons/providers` — it is framework-agnostic and reused by both APIs.
 - **CSS is your responsibility:** the loader only rewrites component/utility imports. You must still import the headless CSS in your app entry point:
   ```js

--- a/packages/react-icons-atomic-webpack-loader/README.md
+++ b/packages/react-icons-atomic-webpack-loader/README.md
@@ -63,10 +63,10 @@ module.exports = {
 
 ## Supported modules
 
-| Module                        | Variants                     | Notes                         |
-| ----------------------------- | ---------------------------- | ----------------------------- |
-| `@fluentui/react-icons`       | `svg`, `fonts`, `svg-sprite` | Has `/providers` and `/utils` |
-| `@fluentui/react-brand-icons` | `svg`                        | Has `/utils`; no `/providers` |
+| Module                        | Variants                     | Headless       | Notes                         |
+| ----------------------------- | ---------------------------- | -------------- | ----------------------------- |
+| `@fluentui/react-icons`       | `svg`, `fonts`, `svg-sprite` | `svg`, `fonts` | Has `/providers` and `/utils` |
+| `@fluentui/react-brand-icons` | `svg`                        | — (none yet)   | Has `/utils`; no `/providers` |
 
 ## Options
 
@@ -74,6 +74,7 @@ module.exports = {
 | ----------------- | -------------------------------------- | ----------- | -------------------------------------------------------------------------- |
 | `iconVariant`     | `'svg'` \| `'fonts'` \| `'svg-sprite'` | `'svg'`     | Variant icons resolve to. Applied to every supported module.               |
 | `fallbackVariant` | `'svg'` \| `'fonts'` \| `'svg-sprite'` | `undefined` | Variant used for a module that does not support `iconVariant` (see below). |
+| `headless`        | `boolean`                              | `false`     | Resolve to the headless (Griffel-free) build where the module ships one.   |
 
 ### Variant resolution & `fallbackVariant`
 
@@ -115,6 +116,39 @@ Resolution is lazy and per file: only modules actually imported in a given file 
 ```
 
 This changes icon resolution from `@fluentui/react-icons/svg/*` to `@fluentui/react-icons/fonts/*`. Non-icon exports (`utils`, `providers`) are unaffected.
+
+### Using the headless API
+
+Set `headless: true` to resolve to the Griffel-free headless build. It composes with `iconVariant`:
+
+```js
+{
+  loader: '@fluentui/react-icons-atomic-webpack-loader',
+  options: {
+    iconVariant: 'fonts',
+    headless: true,
+  },
+}
+```
+
+With the example above:
+
+| Import              | Resolves to                                |
+| ------------------- | ------------------------------------------ |
+| `AddFilled`         | `@fluentui/react-icons/headless/fonts/add` |
+| `bundleIcon` (util) | `@fluentui/react-icons/headless/utils`     |
+| `useIconContext`    | `@fluentui/react-icons/providers` (shared) |
+
+Notes:
+
+- **Best-effort per module:** a module without a headless build for the resolved variant degrades to its standard (Griffel) implementation with a warning rather than failing the build. This applies to `@fluentui/react-brand-icons` (no headless build) and to headless `svg-sprite` (not generated yet).
+- **Context is shared:** `useIconContext` / `IconDirectionContextProvider` always resolve to `@fluentui/react-icons/providers` — it is framework-agnostic and reused by both APIs.
+- **CSS is your responsibility:** the loader only rewrites component/utility imports. You must still import the headless CSS in your app entry point:
+  ```js
+  import '@fluentui/react-icons/headless/styles.css';
+  // and, for font icons:
+  import '@fluentui/react-icons/headless/fonts/styles.css';
+  ```
 
 ### Using SVG sprite icons
 

--- a/packages/react-icons-atomic-webpack-loader/src/index.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/index.ts
@@ -25,9 +25,9 @@ export interface FluentIconsAtomicImportLoaderOptions {
    * referenced module ships one. Defaults to `false`.
    *
    * Headless is best-effort per module: a module without a headless build for
-   * the resolved variant (e.g. `@fluentui/react-brand-icons`, or headless
-   * `svg-sprite` which isn't generated yet) degrades to its standard
-   * implementation with a warning instead of failing the build.
+   * the resolved variant (e.g. headless `svg-sprite` which isn't generated yet)
+   * degrades to its standard implementation with a warning instead of failing
+   * the build.
    *
    * NOTE: the loader only rewrites component/utility imports — you must still
    * import the headless CSS (`@fluentui/react-icons/headless/styles.css`, plus

--- a/packages/react-icons-atomic-webpack-loader/src/index.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/index.ts
@@ -20,6 +20,20 @@ export interface FluentIconsAtomicImportLoaderOptions {
    * loader fails with a descriptive error.
    */
   fallbackVariant?: IconVariant;
+  /**
+   * Resolve atomic imports to the **headless** (Griffel-free) build where the
+   * referenced module ships one. Defaults to `false`.
+   *
+   * Headless is best-effort per module: a module without a headless build for
+   * the resolved variant (e.g. `@fluentui/react-brand-icons`, or headless
+   * `svg-sprite` which isn't generated yet) degrades to its standard
+   * implementation with a warning instead of failing the build.
+   *
+   * NOTE: the loader only rewrites component/utility imports — you must still
+   * import the headless CSS (`@fluentui/react-icons/headless/styles.css`, plus
+   * `headless/fonts/styles.css` for font icons) in your app entry point.
+   */
+  headless?: boolean;
 }
 
 export default function fluentIconsAtomicImportLoader(
@@ -34,14 +48,19 @@ export default function fluentIconsAtomicImportLoader(
     return this.callback(null, sourceCode);
   }
 
-  const { iconVariant = 'svg', fallbackVariant } = this.getOptions();
+  const { iconVariant = 'svg', fallbackVariant, headless = false } = this.getOptions();
 
   let code: string;
   let map: ReturnType<typeof transformSource>['map'];
   let diagnostics: ReturnType<typeof transformSource>['diagnostics'];
 
   try {
-    ({ code, map, diagnostics } = transformSource(sourceCode, { iconVariant, fallbackVariant, path: resourcePath }));
+    ({ code, map, diagnostics } = transformSource(sourceCode, {
+      iconVariant,
+      fallbackVariant,
+      headless,
+      path: resourcePath,
+    }));
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     return this.callback(new Error(`FluentIconsAtomicImportLoader: Failed to transform "${resourcePath}": ${reason}`));

--- a/packages/react-icons-atomic-webpack-loader/src/modules.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/modules.ts
@@ -31,33 +31,46 @@ export interface ModuleDescriptor {
   /** Icon variants this module ships atomic entry points for. */
   supportedVariants: IconVariant[];
   /**
+   * Icon variants for which this module ships a *headless* (Griffel-free) build.
+   * Empty when the module has no headless build at all.
+   */
+  headlessVariants: IconVariant[];
+  /**
    * Resolves the atomic subpath for a single named import.
    *
    * @param importName - The imported binding name (e.g. `AddFilled`, `bundleIcon`).
    * @param variant - The already-resolved, supported icon variant for this module.
+   * @param headless - Whether to resolve to the headless (Griffel-free) build.
    */
-  resolve(importName: string, variant: IconVariant): string;
+  resolve(importName: string, variant: IconVariant, headless: boolean): string;
 }
 
 const reactIcons: ModuleDescriptor = {
   name: '@fluentui/react-icons',
   supportedVariants: ['svg', 'fonts', 'svg-sprite'],
-  resolve(importName, variant) {
+  // Headless ships svg + fonts today; headless svg-sprite is not generated yet.
+  headlessVariants: ['svg', 'fonts'],
+  resolve(importName, variant, headless) {
     if (importName === 'useIconContext' || importName === 'IconDirectionContextProvider') {
+      // Context is framework-agnostic and shared by both APIs.
       return '@fluentui/react-icons/providers';
     }
 
+    const pkg = headless ? '@fluentui/react-icons/headless' : '@fluentui/react-icons';
+
     if (!isIconName(importName)) {
-      return '@fluentui/react-icons/utils';
+      return `${pkg}/utils`;
     }
 
-    return `@fluentui/react-icons/${variant}/${iconBaseName(importName)}`;
+    return `${pkg}/${variant}/${iconBaseName(importName)}`;
   },
 };
 
 const reactBrandIcons: ModuleDescriptor = {
   name: '@fluentui/react-brand-icons',
   supportedVariants: ['svg'],
+  // No headless build for brand icons yet.
+  headlessVariants: [],
   resolve(importName) {
     if (!isIconName(importName)) {
       return '@fluentui/react-brand-icons/utils';
@@ -124,5 +137,43 @@ export function resolveModuleVariant(
       `"${descriptor.name}" supports neither iconVariant "${iconVariant}" nor ` +
       `fallbackVariant "${fallbackVariant}" (supported: ${supported}). ` +
       `Falling back to "${DEFAULT_SAFETY_VARIANT}".`,
+  };
+}
+
+/**
+ * Resolves whether to use a module's headless build, given the requested
+ * `headless` flag and the already-resolved `variant`.
+ *
+ * Headless is best-effort: when a module has no headless build for the resolved
+ * variant, the loader degrades to the standard (Griffel) implementation and
+ * records a warning rather than failing the build.
+ */
+export function resolveModuleHeadless(
+  descriptor: ModuleDescriptor,
+  variant: IconVariant,
+  headless: boolean,
+): { headless: boolean; warning?: string } {
+  if (!headless) {
+    return { headless: false };
+  }
+
+  if (descriptor.headlessVariants.includes(variant)) {
+    return { headless: true };
+  }
+
+  if (descriptor.headlessVariants.length === 0) {
+    return {
+      headless: false,
+      warning:
+        `"${descriptor.name}" has no headless build; using its standard (Griffel) ` + `implementation for this import.`,
+    };
+  }
+
+  return {
+    headless: false,
+    warning:
+      `"${descriptor.name}" has no headless build for variant "${variant}" ` +
+      `(headless supports: ${descriptor.headlessVariants.join(', ')}); using its standard ` +
+      `(Griffel) implementation for this import.`,
   };
 }

--- a/packages/react-icons-atomic-webpack-loader/src/modules.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/modules.ts
@@ -69,14 +69,16 @@ const reactIcons: ModuleDescriptor = {
 const reactBrandIcons: ModuleDescriptor = {
   name: '@fluentui/react-brand-icons',
   supportedVariants: ['svg'],
-  // No headless build for brand icons yet.
-  headlessVariants: [],
-  resolve(importName) {
+  // Brand icons ship a headless (Griffel-free) svg build.
+  headlessVariants: ['svg'],
+  resolve(importName, _variant, headless) {
+    const pkg = headless ? '@fluentui/react-brand-icons/headless' : '@fluentui/react-brand-icons';
+
     if (!isIconName(importName)) {
-      return '@fluentui/react-brand-icons/utils';
+      return `${pkg}/utils`;
     }
 
-    return `@fluentui/react-brand-icons/svg/${iconBaseName(importName)}`;
+    return `${pkg}/svg/${iconBaseName(importName)}`;
   },
 };
 

--- a/packages/react-icons-atomic-webpack-loader/src/transform.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/transform.ts
@@ -1,7 +1,7 @@
 import { parseSync } from 'oxc-parser';
 import MagicString from 'magic-string';
 
-import { getModuleDescriptor, resolveModuleVariant } from './modules';
+import { getModuleDescriptor, resolveModuleVariant, resolveModuleHeadless } from './modules';
 import type { IconVariant, ModuleDescriptor } from './modules';
 
 interface TransformOptions {
@@ -9,6 +9,8 @@ interface TransformOptions {
   iconVariant: IconVariant;
   /** The variant to fall back to when a module does not support `iconVariant`. */
   fallbackVariant?: IconVariant;
+  /** Resolve to the headless (Griffel-free) build where the module supports it. */
+  headless?: boolean;
   path: string;
 }
 
@@ -28,8 +30,11 @@ export interface TransformResult {
   diagnostics: Diagnostic[];
 }
 
+/** A module's resolved rewrite target: the icon variant and whether to use its headless build. */
+type ResolvedTarget = { variant: IconVariant; headless: boolean };
+
 export function transformSource(source: string, options: TransformOptions): TransformResult {
-  const { iconVariant, fallbackVariant, path } = options;
+  const { iconVariant, fallbackVariant, headless = false, path } = options;
 
   const result = parseSync(path, source, {
     sourceType: 'module',
@@ -44,16 +49,16 @@ export function transformSource(source: string, options: TransformOptions): Tran
 
   const diagnostics: Diagnostic[] = [];
   // Resolve (and diagnose) each referenced module at most once.
-  const resolvedVariants = new Map<string, IconVariant | null>();
+  const resolvedTargets = new Map<string, ResolvedTarget | null>();
 
   /**
-   * Returns the variant to rewrite a referenced module with, or `null` when it
-   * could not be resolved (an error diagnostic has been recorded and the module
-   * should be left untouched).
+   * Returns the target (variant + headless) to rewrite a referenced module
+   * with, or `null` when it could not be resolved (an error diagnostic has been
+   * recorded and the module should be left untouched).
    */
-  const variantFor = (descriptor: ModuleDescriptor): IconVariant | null => {
-    if (resolvedVariants.has(descriptor.name)) {
-      return resolvedVariants.get(descriptor.name)!;
+  const targetFor = (descriptor: ModuleDescriptor): ResolvedTarget | null => {
+    if (resolvedTargets.has(descriptor.name)) {
+      return resolvedTargets.get(descriptor.name)!;
     }
 
     const resolution = resolveModuleVariant(descriptor, iconVariant, fallbackVariant);
@@ -65,9 +70,19 @@ export function transformSource(source: string, options: TransformOptions): Tran
       diagnostics.push({ level: 'error', message: resolution.error });
     }
 
-    const variant = resolution.variant ?? null;
-    resolvedVariants.set(descriptor.name, variant);
-    return variant;
+    if (!resolution.variant) {
+      resolvedTargets.set(descriptor.name, null);
+      return null;
+    }
+
+    const headlessResolution = resolveModuleHeadless(descriptor, resolution.variant, headless);
+    if (headlessResolution.warning) {
+      diagnostics.push({ level: 'warning', message: headlessResolution.warning });
+    }
+
+    const target: ResolvedTarget = { variant: resolution.variant, headless: headlessResolution.headless };
+    resolvedTargets.set(descriptor.name, target);
+    return target;
   };
 
   for (const imp of staticImports) {
@@ -75,7 +90,7 @@ export function transformSource(source: string, options: TransformOptions): Tran
     const descriptor = getModuleDescriptor(moduleName);
     if (!descriptor) continue;
 
-    const variant = variantFor(descriptor);
+    const variant = targetFor(descriptor);
     if (!variant) continue;
 
     const namedEntries = imp.entries.filter((e) => e.importName.kind === 'Name');
@@ -94,7 +109,7 @@ export function transformSource(source: string, options: TransformOptions): Tran
     for (const entry of namedEntries) {
       const importedName = entry.importName.name!;
       const localName = entry.localName.value;
-      const newSource = descriptor.resolve(importedName, variant);
+      const newSource = descriptor.resolve(importedName, variant.variant, variant.headless);
       const spec = importedName === localName ? importedName : `${importedName} as ${localName}`;
       lines.push(`import { ${spec} } from '${newSource}';`);
     }
@@ -118,12 +133,12 @@ export function transformSource(source: string, options: TransformOptions): Tran
     for (const entry of relevantEntries) {
       const moduleName = entry.moduleRequest!.value;
       const descriptor = getModuleDescriptor(moduleName)!;
-      const variant = variantFor(descriptor);
+      const variant = targetFor(descriptor);
       if (!variant) continue;
 
       const importedName = entry.importName.name!;
       const exportedName = entry.exportName.name!;
-      const newSource = descriptor.resolve(importedName, variant);
+      const newSource = descriptor.resolve(importedName, variant.variant, variant.headless);
       const spec = importedName === exportedName ? importedName : `${importedName} as ${exportedName}`;
       lines.push(`export { ${spec} } from '${newSource}';`);
     }

--- a/packages/react-icons-atomic-webpack-loader/test/src/headless-imports.js
+++ b/packages/react-icons-atomic-webpack-loader/test/src/headless-imports.js
@@ -1,0 +1,6 @@
+import { AddFilled } from '@fluentui/react-icons';
+import { ArrowLeftRegular, ArrowCircleDownFilled } from '@fluentui/react-icons';
+import { useIconContext, bundleIcon, PeopleColor } from '@fluentui/react-icons';
+import { useState } from 'react';
+
+console.log(AddFilled, ArrowLeftRegular, ArrowCircleDownFilled, useIconContext, bundleIcon, PeopleColor, useState);

--- a/packages/react-icons-atomic-webpack-loader/test/transform.test.ts
+++ b/packages/react-icons-atomic-webpack-loader/test/transform.test.ts
@@ -224,6 +224,83 @@ describe('transformSource', () => {
     });
   });
 
+  describe('headless option', () => {
+    const transformHeadless = (source: string, iconVariant: IconVariant = 'svg', fallbackVariant?: IconVariant) =>
+      transformSource(source, { iconVariant, fallbackVariant, headless: true, path: 'input.js' }).code;
+
+    it('rewrites icon imports to the headless svg atomic path', () => {
+      expect(transformHeadless(`import { AddFilled } from '@fluentui/react-icons';`)).toBe(
+        `import { AddFilled } from '@fluentui/react-icons/headless/svg/add';`,
+      );
+    });
+
+    it('rewrites icon imports to the headless fonts atomic path', () => {
+      expect(transformHeadless(`import { AddFilled } from '@fluentui/react-icons';`, 'fonts')).toBe(
+        `import { AddFilled } from '@fluentui/react-icons/headless/fonts/add';`,
+      );
+    });
+
+    it('routes utility bindings to /headless/utils', () => {
+      expect(transformHeadless(`import { bundleIcon } from '@fluentui/react-icons';`)).toBe(
+        `import { bundleIcon } from '@fluentui/react-icons/headless/utils';`,
+      );
+    });
+
+    it('routes provider bindings to the shared /providers (not headless)', () => {
+      expect(transformHeadless(`import { useIconContext } from '@fluentui/react-icons';`)).toBe(
+        `import { useIconContext } from '@fluentui/react-icons/providers';`,
+      );
+    });
+
+    it('rewrites direct re-exports to headless paths', () => {
+      expect(transformHeadless(`export { AddFilled } from '@fluentui/react-icons';`)).toBe(
+        `export { AddFilled } from '@fluentui/react-icons/headless/svg/add';`,
+      );
+    });
+
+    it('degrades headless svg-sprite to the standard sprite with a warning', () => {
+      const { code, diagnostics } = transformSource(`import { AddFilled } from '@fluentui/react-icons';`, {
+        iconVariant: 'svg-sprite',
+        headless: true,
+        path: 'input.js',
+      });
+
+      expect(code).toBe(`import { AddFilled } from '@fluentui/react-icons/svg-sprite/add';`);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0].level).toBe('warning');
+      expect(diagnostics[0].message).toContain('headless');
+    });
+
+    it('degrades brand icons (no headless build) to standard svg with a warning', () => {
+      const { code, diagnostics } = transformSource(`import { ProjectColor } from '@fluentui/react-brand-icons';`, {
+        iconVariant: 'svg',
+        headless: true,
+        path: 'input.js',
+      });
+
+      expect(code).toBe(`import { ProjectColor } from '@fluentui/react-brand-icons/svg/project';`);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0].level).toBe('warning');
+      expect(diagnostics[0].message).toContain('@fluentui/react-brand-icons');
+    });
+
+    it('keeps system icons headless while degrading brand icons in the same module', () => {
+      const source = [
+        `import { AddFilled } from '@fluentui/react-icons';`,
+        `import { ProjectColor } from '@fluentui/react-brand-icons';`,
+      ].join('\n');
+
+      const { code } = transformSource(source, { iconVariant: 'svg', headless: true, path: 'input.js' });
+
+      expect(code).toBe(
+        [
+          `import { AddFilled } from '@fluentui/react-icons/headless/svg/add';`,
+          `import { ProjectColor } from '@fluentui/react-brand-icons/svg/project';`,
+        ].join('\n'),
+      );
+    });
+  });
+
   describe('diagnostics', () => {
     it('does not diagnose a module that only appears in a comment', () => {
       const source = [

--- a/packages/react-icons-atomic-webpack-loader/test/transform.test.ts
+++ b/packages/react-icons-atomic-webpack-loader/test/transform.test.ts
@@ -271,20 +271,24 @@ describe('transformSource', () => {
       expect(diagnostics[0].message).toContain('headless');
     });
 
-    it('degrades brand icons (no headless build) to standard svg with a warning', () => {
+    it('rewrites brand icons to the headless svg atomic path', () => {
       const { code, diagnostics } = transformSource(`import { ProjectColor } from '@fluentui/react-brand-icons';`, {
         iconVariant: 'svg',
         headless: true,
         path: 'input.js',
       });
 
-      expect(code).toBe(`import { ProjectColor } from '@fluentui/react-brand-icons/svg/project';`);
-      expect(diagnostics).toHaveLength(1);
-      expect(diagnostics[0].level).toBe('warning');
-      expect(diagnostics[0].message).toContain('@fluentui/react-brand-icons');
+      expect(code).toBe(`import { ProjectColor } from '@fluentui/react-brand-icons/headless/svg/project';`);
+      expect(diagnostics).toEqual([]);
     });
 
-    it('keeps system icons headless while degrading brand icons in the same module', () => {
+    it('routes brand utility bindings to /headless/utils', () => {
+      expect(transformHeadless(`import { bundleIcon } from '@fluentui/react-brand-icons';`)).toBe(
+        `import { bundleIcon } from '@fluentui/react-brand-icons/headless/utils';`,
+      );
+    });
+
+    it('keeps both system and brand icons headless in the same module', () => {
       const source = [
         `import { AddFilled } from '@fluentui/react-icons';`,
         `import { ProjectColor } from '@fluentui/react-brand-icons';`,
@@ -295,7 +299,7 @@ describe('transformSource', () => {
       expect(code).toBe(
         [
           `import { AddFilled } from '@fluentui/react-icons/headless/svg/add';`,
-          `import { ProjectColor } from '@fluentui/react-brand-icons/svg/project';`,
+          `import { ProjectColor } from '@fluentui/react-brand-icons/headless/svg/project';`,
         ].join('\n'),
       );
     });

--- a/packages/react-icons-atomic-webpack-loader/test/webpack.config.js
+++ b/packages/react-icons-atomic-webpack-loader/test/webpack.config.js
@@ -82,6 +82,22 @@ const entries = {
     mustExclude: ['"@fluentui/react-icons"', '@fluentui/react-icons/svg/', '@fluentui/react-icons/fonts/'],
   },
 
+  'headless-imports': {
+    src: './src/headless-imports.js',
+    loaderOptions: { headless: true },
+    mustInclude: [
+      '@fluentui/react-icons/headless/svg/add',
+      '@fluentui/react-icons/headless/svg/arrow-left',
+      '@fluentui/react-icons/headless/svg/arrow-circle-down',
+      '@fluentui/react-icons/headless/svg/people',
+      // context stays on the shared (non-headless) providers entry
+      '@fluentui/react-icons/providers',
+      '@fluentui/react-icons/headless/utils',
+    ],
+    // no standard (non-headless) svg/utils paths should leak through
+    mustExclude: ['"@fluentui/react-icons"', '@fluentui/react-icons/svg/', '@fluentui/react-icons/utils'],
+  },
+
   'brand-icons-imports': {
     src: './src/brand-icons-imports.js',
     loaderOptions: {},


### PR DESCRIPTION
## Summary

Adds an orthogonal **`headless`** option to the atomic webpack loader so barrel imports can be rewritten to the Griffel-free headless build.

### Behavior
With `{ headless: true }` (composes with `iconVariant`):

| Import | Resolves to |
| --- | --- |
| icon (e.g. `AddFilled`) | `@fluentui/react-icons/headless/{svg,fonts}/` |
| utility (e.g. `bundleIcon`) | `@fluentui/react-icons/headless/utils` |
| context (`useIconContext`, `IconDirectionContextProvider`) | `@fluentui/react-icons/providers` (shared, framework-agnostic) |

`@fluentui/react-brand-icons` now ships a headless build too — with `{ headless: true }` brand icon and utility imports resolve to `@fluentui/react-brand-icons/headless/svg/` and `@fluentui/react-brand-icons/headless/utils`.

### Best-effort policy
A module without a headless build for the resolved variant **degrades to its standard (Griffel) implementation with a warning** rather than failing the build:
- headless `svg-sprite` — not generated yet (`headlessVariants: ['svg', 'fonts']`).

### Changes
- `modules.ts`: `headlessVariants` per descriptor (`@fluentui/react-brand-icons` now `['svg']`), `resolve(importName, variant, headless)`, `resolveModuleHeadless()` policy.
- `transform.ts`: per-module `ResolvedTarget` (variant + headless), warnings surfaced as diagnostics.
- `index.ts`: new `headless?: boolean` loader option (default `false`).
- Tests: `transform.test.ts` covers headless system + brand resolution (39 pass), plus the `headless-imports` webpack integration entry/fixture.
- README: supported-modules Headless column, options table, "Using the headless API" section, and brand-icons headless resolution.

### Notes
- The loader rewrites imports only — consumers must still import the headless CSS (`headless/styles.css` [+ `headless/fonts/styles.css`]). Documented in the option JSDoc and README.
- **Version requirement:** headless `@fluentui/react-brand-icons` requires `>= 2.0.206`. The loader rewrites imports statically and does not check the installed version, so an older brand-icons will fail to resolve the `/headless/*` entries at build time. Documented in the README "Requirements" and headless notes.
- `lib/` is gitignored (source-only); no package-level devDependencies added (monorepo single-version policy).

> ⚠️ **Stacked on #1119** (`react-icons/prepare-headless-for-release`) — relies on the `/headless/*` + `/headless/utils` exports. Until #1119 merges this PR's diff also includes those commits; rebase/retarget afterward.
>
> Pairs with **#1121** (headless font subsetting) for the end-to-end story.