### PR TITLE
test(font-subsetting): e2e atomic-loader + subsetting for headless fonts

### DIFF
--- a/packages/react-icons-font-subsetting-webpack-plugin/README.md
+++ b/packages/react-icons-font-subsetting-webpack-plugin/README.md
@@ -37,6 +37,8 @@ import { AddRegular, AddFilled } from '@fluentui/react-icons/headless/fonts/add'
 
 The plugin subsets the same shared font files used by the standard API, based on the headless icons you actually use. Because the font files arrive via `styles.css`, your config needs a CSS loader (e.g. `css-loader`) so the `url(...)` references resolve into webpack assets.
 
+> **Tip 💡:** You don't have to write atomic headless imports by hand. Pair this plugin with [`@fluentui/react-icons-atomic-webpack-loader`](../react-icons-atomic-webpack-loader) using `{ headless: true, iconVariant: 'fonts' }` — it rewrites plain barrel imports (`import { AddFilled } from '@fluentui/react-icons'`) into headless font atoms, which this plugin then subsets. You still import `@fluentui/react-icons/headless/fonts/styles.css` yourself.
+
 ## Usage
 
 ### With `fluentIconFont` condition

--- a/packages/react-icons-font-subsetting-webpack-plugin/project.json
+++ b/packages/react-icons-font-subsetting-webpack-plugin/project.json
@@ -11,7 +11,7 @@
       "outputs": ["{projectRoot}/lib"]
     },
     "test": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build", { "projects": ["react-icons-atomic-webpack-loader"], "target": "build" }]
     }
   }
 }

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/src/e2e-barrel-headless-fonts.js
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/src/e2e-barrel-headless-fonts.js
@@ -1,0 +1,13 @@
+// @ts-check
+
+// End-to-end: a *barrel* import is rewritten by the atomic webpack loader
+// (headless + fonts) into headless font atoms, then the font-subsetting plugin
+// subsets the shared font — and the resulting graph stays Griffel-free.
+//
+// The headless `styles.css` brings the @font-face (and font files) into the
+// module graph; the loader rewrites component imports only, never the CSS
+// side-effect import.
+import '@fluentui/react-icons/headless/fonts/styles.css';
+import { XboxConsole24Filled, BoardGames20Regular, GamesFilled } from '@fluentui/react-icons';
+
+console.log(XboxConsole24Filled, BoardGames20Regular, GamesFilled);

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/webpack.config.js
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/webpack.config.js
@@ -17,12 +17,12 @@ const entries = {
   atomsImportStar: { src: './src/atoms-import-star.js', threshold: 3 * 1_024 }, // 3.0 KB
   // Headless font atoms — fonts arrive via the headless `styles.css` import (css-loader) rather than Griffel.
   // No Griffel runtime is involved, so a tighter threshold is used to validate subsetting.
-  headlessAtoms: { src: './src/headless-atoms.js', threshold: 1.5 * 1_024 }, // 1.5 KB
+  headlessAtoms: { src: './src/headless-atoms.js', threshold: 1.5 * 1_024, assertNoGriffel: true }, // 1.5 KB
   // End-to-end: a *barrel* import is rewritten by the atomic loader (headless + fonts) into
   // headless font atoms, then subset here. Also asserts the graph stays Griffel-free.
   e2eBarrelHeadlessFonts: {
     src: './src/e2e-barrel-headless-fonts.js',
-    threshold: 2 * 1_024, // 2 KB
+    threshold: 1.5 * 1_024, // 1.5 KB
     useAtomicLoader: true,
     assertNoGriffel: true,
   },
@@ -46,8 +46,9 @@ function createConfig(name, entry) {
     // This is enabled by default in production mode.
     // In development mode, webpack doesn't track used exports, so the plugin skips subsetting.
     mode: 'production',
-    // Keep modules un-concatenated for the e2e entry so the Griffel-free assertion
-    // can inspect individual module resources.
+    // Keep modules un-concatenated for entries that assert Griffel-freedom so the assertion
+    // can inspect individual module resources (scope hoisting would merge them into a
+    // ConcatenatedModule with no per-module `resource`, hiding a leaked @griffel module).
     optimization: entry.assertNoGriffel ? { concatenateModules: false } : undefined,
     module: {
       rules: [

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/webpack.config.js
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/webpack.config.js
@@ -18,6 +18,14 @@ const entries = {
   // Headless font atoms — fonts arrive via the headless `styles.css` import (css-loader) rather than Griffel.
   // No Griffel runtime is involved, so a tighter threshold is used to validate subsetting.
   headlessAtoms: { src: './src/headless-atoms.js', threshold: 1.5 * 1_024 }, // 1.5 KB
+  // End-to-end: a *barrel* import is rewritten by the atomic loader (headless + fonts) into
+  // headless font atoms, then subset here. Also asserts the graph stays Griffel-free.
+  e2eBarrelHeadlessFonts: {
+    src: './src/e2e-barrel-headless-fonts.js',
+    threshold: 2 * 1_024, // 2 KB
+    useAtomicLoader: true,
+    assertNoGriffel: true,
+  },
 };
 
 const isDevServer = process.env.WEBPACK_SERVE === 'true';
@@ -26,7 +34,7 @@ console.log(`Running webpack in ${isDevServer ? 'development' : 'production'} mo
 
 /**
  * @param {string} name
- * @param {{ src: string, threshold: number }} entry
+ * @param {{ src: string, threshold: number, useAtomicLoader?: boolean, assertNoGriffel?: boolean }} entry
  * @returns {import('webpack').Configuration}
  */
 function createConfig(name, entry) {
@@ -38,8 +46,28 @@ function createConfig(name, entry) {
     // This is enabled by default in production mode.
     // In development mode, webpack doesn't track used exports, so the plugin skips subsetting.
     mode: 'production',
+    // Keep modules un-concatenated for the e2e entry so the Griffel-free assertion
+    // can inspect individual module resources.
+    optimization: entry.assertNoGriffel ? { concatenateModules: false } : undefined,
     module: {
       rules: [
+        ...(entry.useAtomicLoader
+          ? [
+              {
+                // Rewrite barrel `@fluentui/react-icons` imports to headless font atoms
+                // before webpack parses them.
+                test: /\.js$/,
+                include: resolve(__dirname, 'src'),
+                enforce: /** @type {'pre'} */ ('pre'),
+                use: [
+                  {
+                    loader: resolve(__dirname, '../../react-icons-atomic-webpack-loader/lib/index.js'),
+                    options: { headless: true, iconVariant: 'fonts' },
+                  },
+                ],
+              },
+            ]
+          : []),
         {
           test: /\.(ttf|woff2?)$/,
           type: 'asset',
@@ -85,6 +113,19 @@ function createConfig(name, entry) {
                   `[${name}] Asset "${assetName}" (${source.size()} bytes) exceeds the ` +
                     `${entry.threshold}-byte threshold — font may not have been properly subset.`,
                 );
+              }
+            }
+
+            // Headless builds must not pull in Griffel.
+            if (entry.assertNoGriffel) {
+              for (const m of compilation.modules) {
+                const resource = /** @type {{ resource?: string }} */ (m).resource;
+                if (resource && /[\\/]@griffel[\\/]/.test(resource)) {
+                  throw new Error(
+                    `[${name}] Module graph includes a @griffel module (${resource}) — ` +
+                      `headless build expected to be Griffel-free.`,
+                  );
+                }
               }
             }
           });


### PR DESCRIPTION
## Summary

End-to-end integration proving the full **headless font pipeline** works when the atomic loader and the font-subsetting plugin are combined.

### What it verifies
A new webpack test entry (`e2eBarrelHeadlessFonts`) in the font-subsetting plugin:
1. Starts from a plain **barrel** import — `import { … } from '@fluentui/react-icons'`.
2. The **atomic loader** (`{ headless: true, iconVariant: 'fonts' }`) rewrites it into headless font atoms (`@fluentui/react-icons/headless/fonts/*`).
3. The **font-subsetting plugin** recognizes those headless atoms and subsets the shared font → emitted fonts stay under the **1.5 KiB** threshold (from MB-scale originals).
4. Asserts the module graph stays **Griffel-free** (no `@griffel/*` module in the graph).

The existing `headlessAtoms` entry now also carries the **Griffel-free assertion**, giving both headless-fonts entries the same guarantee.

### Changes
- `test/src/e2e-barrel-headless-fonts.js` — the barrel fixture (+ the required `headless/fonts/styles.css` import).
- `test/webpack.config.js` — new `e2eBarrelHeadlessFonts` entry (scoped atomic-loader rule referencing the loader's built `lib` via relative path) and a shared `assertNoGriffel` path. Entries that assert Griffel-freedom disable module concatenation (`concatenateModules: false`) so the verify hook can inspect individual module `resource`s — otherwise scope hoisting would merge modules into a `ConcatenatedModule` and hide a leaked `@griffel` module.
- `project.json` — the plugin's `test` target now `dependsOn` the atomic loader's `build`. Because the test references the loader through a raw filesystem path (not a package import), Nx's project-graph inference can't detect the dependency; without this, CI (`nx affected -t test`) wouldn't build the loader's `lib/` when only this package is affected, causing a `Module not found` failure.
- `README.md` — tip on pairing the subsetting plugin with the atomic loader so consumers don't hand-write headless atomic imports.

### Notes
- No package `devDependencies` added (monorepo single-version policy); the loader is referenced via its built `lib` path, mirroring how the loader's own tests reference `../lib`.
- `lib/` is gitignored (source/test-only commit).