### PR TITLE
docs: add .NET MAUI to Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ dependencies:
 
 For library docs, see [flutter/README.md](flutter/README.md).
 
+### .NET MAUI
+
+Install the community package:
+
+```shell
+dotnet add package IconFont.Maui.FluentIcons
+```
+
+For library docs, see [IconFont.Maui.FluentIcons](https://github.com/jfversluis/IconFont.Maui.FluentIcons).
+
 ### Plain svg
 
 Inline svg directly. See [packages/svg-icons/README.md](packages/svg-icons/README.md).


### PR DESCRIPTION
Closes #984.

Adds a **.NET MAUI** subsection to the Installation section of the README, linking the community [`IconFont.Maui.FluentIcons`](https://www.nuget.org/packages/IconFont.Maui.FluentIcons) NuGet package, as requested by its author (Gerald Versluis of the .NET MAUI team) in the issue.

- Placed it alongside the other platform subsections (after **Flutter**, before **Plain svg**).
- Matches the existing subsection style, ending with a "For library docs, see …" link.
- Uses the exact wording the issue author proposed, and clearly labels it a **community** package (the repo doesn't need to maintain it — just link for discoverability).

No code or build changes; README only.
