### PR TITLE
chore(react-icons-file-type): prepare package for release

### DIFF
--- a/packages/react-icons-file-type/package.json
+++ b/packages/react-icons-file-type/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@fluentui/react-icons-file-type",
-  "private": true,
   "version": "0.0.0",
   "description": "Fluent UI React (v9-compatible) file type icon components rendered from CDN-hosted assets.",
   "main": "lib-cjs/index.js",


### PR DESCRIPTION
## Summary

Prepares `@fluentui/react-icons-file-type` for its first npm release.

- Removes `"private": true` from the package's `package.json`.
- No other config changes were required: the package is already in the nx `standalone` release group (`nx.json`) and tagged `npm:standalone` (`project.json`).

## Released only from the standalone pipeline

| Pipeline | Resolver | Picks up file-type? |
|---|---|---|
| `publish-standalone.yml` | `tag:npm:standalone --exclude tag:npm:private` | ✅ versions, changelogs, publishes & tags |
| `publish.yml` (public GA) | `--group=react` / `--group=native` + explicit per-package publish steps | ❌ only built via `tag:npm:public`, never versioned/published |

After removing the private flag the package resolves as Nx-inferred `npm:public`, so it is now selected by the standalone resolver while remaining excluded from the public `publish.yml` versioning/publish steps.

> Note: the pre-release workflow (`publish-prerelease.yml`) uses a `react-*` glob that also matches this package — that is by design for alpha/beta/rc pre-releases.

## Verification

- `npx nx show projects -p "tag:npm:standalone" --exclude "tag:npm:private"` now includes `react-icons-file-type`.
- `npx nx run react-icons-file-type:build` succeeds (`lib/` + `lib-cjs/` emitted).