### PR TITLE
feat(react-icons): add idPrefix prop to scope Color variant SVG ids

### DIFF
--- a/packages/docsite/stories/Icons/ColorVariants/ColorVariantsDescription.md
+++ b/packages/docsite/stories/Icons/ColorVariants/ColorVariantsDescription.md
@@ -1,0 +1,31 @@
+A handful of icons ship a `Color` variant (e.g. `CalendarColor`) that renders with multiple colors via SVG gradients, clip paths, and filters.
+
+> **⚠️ Accessibility warning:** We strongly recommend avoiding `Color` variants. They are non‑compliant with Windows High Contrast Mode and can have insufficient contrast in dark themes. Prefer `Filled` or `Regular` variants. See the **User Guidance** page for details.
+
+## Scoping gradient IDs with `idPrefix`
+
+`Color` variants render their gradients, clip paths, and filters using locally-defined SVG `id`s. Because SVG IDs live in the **global DOM namespace**, rendering the same color icon multiple times produces duplicate IDs — and hiding one instance with `display: none` can break the gradients of the others ([#936](https://github.com/microsoft/fluentui-system-icons/issues/936)).
+
+Pass a unique **`idPrefix`** per rendered instance to scope every `id` and its `url(#…)` reference, eliminating the collision:
+
+```tsx
+<CalendarColor idPrefix="cal-a-" />
+<CalendarColor idPrefix="cal-b-" />
+```
+
+The example below renders the same icon twice per column with the first instance hidden via `display: none`. **Without** `idPrefix` (left) the visible icon loses its gradients because both instances share the same IDs; **with** a unique `idPrefix` per instance (right) it renders correctly.
+
+> **Notes**
+>
+> - `idPrefix` only applies to `Color` variants; mono-color icons ignore it.
+> - **On React 18+, `React.useId()` is the recommended source** — it's stable across re-renders and SSR-safe:
+>
+>   ```tsx
+>   const id = React.useId();
+>   return <CalendarColor idPrefix={id} />;
+>   ```
+>
+>   Use **one `useId()` per component instance**. If a component renders several color icons, append a discriminator so they don't collide with each other (e.g. ``idPrefix={`${id}-${i}`}``). The colons in `useId()` output are fine — `url(#…)` resolves via `getElementById`, not CSS selectors.
+>
+> - On React 16.8–17 (no `useId`), derive a **stable, unique** value from your data/key instead. Either way, avoid regenerating it on every render so the icon's memoized output stays cached.
+> - For color-icon-heavy trees that re-render frequently, also consider wrapping icons in `React.memo` to skip renders when props are unchanged — it is complementary to the built-in `idPrefix` memoization.

--- a/packages/docsite/stories/Icons/ColorVariants/index.stories.tsx
+++ b/packages/docsite/stories/Icons/ColorVariants/index.stories.tsx
@@ -1,0 +1,84 @@
+import { CalendarColor } from '@fluentui/react-icons';
+import { Body1Stronger, makeStyles, shorthands, tokens } from '@fluentui/react-components';
+import { Controls, Description, Primary, Title } from '@storybook/addon-docs/blocks';
+import * as React from 'react';
+
+import descriptionMd from './ColorVariantsDescription.md';
+
+const useClasses = makeStyles({
+  root: {
+    display: 'flex',
+    ...shorthands.gap('32px'),
+  },
+  column: {
+    display: 'flex',
+    flexDirection: 'column',
+    ...shorthands.gap('8px'),
+    ...shorthands.padding('12px'),
+    ...shorthands.border('1px', 'solid', tokens.colorNeutralStroke2),
+    borderRadius: tokens.borderRadiusMedium,
+  },
+  icons: {
+    fontSize: '48px',
+  },
+  // Hiding one instance with display:none triggers the gradient ID collision
+  // for any sibling that shares the same (unscoped) IDs.
+  hidden: {
+    display: 'none',
+  },
+});
+
+export const ColorIdPrefix = () => {
+  const classes = useClasses();
+
+  return (
+    <div className={classes.root}>
+      <div className={classes.column}>
+        <Body1Stronger>❌ Without idPrefix</Body1Stronger>
+        <div className={classes.icons}>
+          <CalendarColor className={classes.hidden} aria-hidden />
+          <CalendarColor aria-label="Calendar without idPrefix" />
+        </div>
+      </div>
+
+      <div className={classes.column}>
+        <Body1Stronger>✅ With idPrefix</Body1Stronger>
+        <div className={classes.icons}>
+          <CalendarColor idPrefix="cal-a-" className={classes.hidden} aria-hidden />
+          <CalendarColor idPrefix="cal-b-" aria-label="Calendar with idPrefix" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default {
+  title: 'Icons/Color Variants',
+  component: CalendarColor,
+  parameters: {
+    docs: {
+      description: {
+        component: descriptionMd,
+      },
+      // Single-story page: render the example once (Primary) and omit the
+      // autodocs `Stories` block, which would otherwise repeat the same story.
+      page: () => (
+        <>
+          <Title />
+          <Description />
+          <Primary />
+          <Controls />
+        </>
+      ),
+    },
+  },
+  argTypes: {
+    idPrefix: {
+      control: 'text',
+      description:
+        'Scopes the locally-defined SVG ids (gradients, clip paths, filters) of a `Color` variant per instance to avoid global DOM id collisions. Ignored by mono-color icons.',
+      table: { defaultValue: '' },
+      type: { name: 'string' },
+    },
+  },
+};

--- a/packages/docsite/stories/Icons/UserGuidance.mdx
+++ b/packages/docsite/stories/Icons/UserGuidance.mdx
@@ -223,7 +223,8 @@ Color icons with gradients use non-scoped `id` attributes. When multiple instanc
 
 **Workarounds:**
 
-- **SVG sprites** (recommended): Wrap the icon in a `<symbol>` and reference it via `<use>`, avoiding duplicate gradient IDs.
+- **Scoped IDs via `idPrefix`** (recommended): Pass a unique `idPrefix` per rendered instance so every locally-defined `id` (gradients, clip paths, filters) and its `url(#…)` reference is scoped, eliminating the collision. Applies to `Color` variants only.
+- **SVG sprites**: Wrap the icon in a `<symbol>` and reference it via `<use>`, avoiding duplicate gradient IDs.
 - **Absolute positioning off-screen**: Use `position: 'absolute', top: '-9999px'` instead of `display: 'none'`.
 - **`visibility: 'hidden'`**: Hides the icon while keeping the gradient definition accessible (maintains layout space).
 

--- a/packages/react-icons/README.md
+++ b/packages/react-icons/README.md
@@ -164,7 +164,22 @@ Color icons with gradients use non-scoped `id` attributes. When multiple instanc
 
 **Workarounds:**
 
-✅ **Option 1: Use SVG sprites (recommended for multiple instances)**
+✅ **Option 1: Scope the IDs with `idPrefix` (recommended)**
+
+Pass a unique `idPrefix` per rendered instance. Every locally-defined `id` (gradients, clip paths, filters) and its matching `url(#…)` reference is prefixed, so instances no longer share IDs in the global DOM namespace. The prop only applies to `Color` variants — mono-color icons ignore it.
+
+```tsx
+<CalendarColor idPrefix="cal-a-" />
+<CalendarColor idPrefix="cal-b-" />
+```
+
+> **Tips:**
+>
+> - **On React 18+, `React.useId()` is the recommended source** for the prefix — it's stable across re-renders and SSR-safe: `const id = React.useId()` then `<CalendarColor idPrefix={id} />`. Use one `useId()` per component instance; if you render several color icons in one component, append a discriminator (e.g. ``idPrefix={`${id}-${i}`}``) so they don't collide with each other. (The colons in `useId()` output are fine — `url(#…)` resolves via `getElementById`, not CSS selectors.)
+> - On React 16.8–17 (no `useId`), derive a **stable, unique** value from your data/key instead. Either way, avoid regenerating it on every render so the icon's memoized output stays cached.
+> - For color-icon-heavy trees that re-render frequently, also consider wrapping icons in `React.memo` to skip renders entirely when props are unchanged. `React.memo` (skips the whole render when props are stable) and `idPrefix` memoization (reuses the scoped SVG tree across re-renders) are complementary.
+
+✅ **Option 2: Use SVG sprites (good for many repeated instances)**
 
 ```tsx
 <svg>
@@ -182,13 +197,13 @@ Color icons with gradients use non-scoped `id` attributes. When multiple instanc
 </svg>
 ```
 
-✅ **Option 2: Move off-screen with absolute positioning**
+✅ **Option 3: Move off-screen with absolute positioning**
 
 ```tsx
 <Icon style={{ position: 'absolute', top: '-9999px', left: '-9999px' }} />
 ```
 
-✅ **Option 3: Use `visibility: 'hidden'`** (maintains layout space)
+✅ **Option 4: Use `visibility: 'hidden'`** (maintains layout space)
 
 ##### 3. Dark Theme Contrast Issues
 

--- a/packages/react-icons/src/core/svg.ts
+++ b/packages/react-icons/src/core/svg.ts
@@ -10,27 +10,96 @@ export type SvgNode = [
   ...children: SvgNode[],
 ];
 
-/** Recursively renders an {@link SvgNode} tree into React elements. */
-export const renderSvgNode = (node: SvgNode, key: number): React.ReactElement => {
+/** The literal prefix of an SVG `url(#…)` local reference. */
+const URL_REF = 'url(#';
+
+/**
+ * Recursively renders an {@link SvgNode} tree into React elements. When `prefix`
+ * is set, every `id` definition and `url(#…)` reference is scoped with it so
+ * repeated color icons don't collide in the global DOM id namespace.
+ */
+export const renderSvgNode = (node: SvgNode, key: number, prefix?: string): React.ReactElement => {
   const [tag, attrs, ...children] = node;
-  return React.createElement(tag, { ...attrs, key }, ...children.map(renderSvgNode));
+  let scoped = attrs;
+  if (prefix && attrs) {
+    const next: Record<string, string | Record<string, string>> = {};
+    for (const attrName in attrs) {
+      const attrValue = attrs[attrName];
+      if (typeof attrValue !== 'string') {
+        next[attrName] = attrValue; // style object — passthrough
+      } else if (attrName === 'id') {
+        next[attrName] = prefix + attrValue; // scope the id definition
+      } else {
+        // Scope a `url(#…)` reference by splicing `prefix` in right after `url(#`.
+        // A single indexOf locates it (-1 short-circuits with no allocation, e.g.
+        // for long `d` paths); color-icon attributes carry at most one reference,
+        // so no global replace is needed.
+        const refAt = attrValue.indexOf(URL_REF);
+        next[attrName] =
+          refAt < 0
+            ? attrValue
+            : attrValue.slice(0, refAt + URL_REF.length) + prefix + attrValue.slice(refAt + URL_REF.length);
+      }
+    }
+    scoped = next;
+  }
+  return React.createElement(
+    tag,
+    { ...scoped, key },
+    ...children.map((child, idx) => renderSvgNode(child, idx, prefix)),
+  );
 };
 
 /** Normalizes the icon width into a square viewBox dimension. */
 export const computeViewBox = (width: string): string => (width === '1em' ? '20' : width);
 
 /**
- * Pre-renders color SVG node trees once (outside React render) so the recursion
- * never runs during component renders. Returns `undefined` for mono-color
- * (path `string[]`) icons.
+ * Pre-renders color SVG node trees so the recursion stays out of the hot render
+ * path. Returns `undefined` for mono-color (path `string[]`) icons. When
+ * `prefix` is set, locally-scoped `id`s (gradients, clip paths, filters) and
+ * their `url(#…)` references are prefixed so repeated color icons don't collide
+ * in the global DOM id namespace.
  */
 export const precomputeColorChildren = (
   pathsOrSvg: string[] | string | SvgNode[],
   options?: { color?: boolean },
+  prefix?: string,
 ): React.ReactElement[] | undefined =>
   typeof pathsOrSvg !== 'string' && (options?.color || Array.isArray(pathsOrSvg[0]))
-    ? (pathsOrSvg as SvgNode[]).map(renderSvgNode)
+    ? (pathsOrSvg as SvgNode[]).map((node, i) => renderSvgNode(node, i, prefix))
     : undefined;
+
+/** Shared mono-color resolver — calls no hooks and allocates nothing per component. */
+const noColorChildren = (): React.ReactElement[] | undefined => undefined;
+
+/**
+ * Creates a per-component resolver for a color icon's rendered children.
+ *
+ * Color detection and the shared (unscoped) precompute run once here, at factory
+ * time. The returned hook:
+ * - for mono-color icons, is a shared no-op returning `undefined` (no React hook,
+ *   no per-component or per-instance allocation);
+ * - for color icons, memoizes per instance on `idPrefix`, so re-renders reuse the
+ *   element tree and only rebuild when the prefix actually changes.
+ *
+ * Branching here (an icon's "color-ness" is fixed at factory time) keeps hook
+ * order stable per component, so only color icons ever pay for the memo hook.
+ */
+export const createColorChildrenResolver = (
+  pathsOrSvg: string[] | string | SvgNode[],
+  options?: { color?: boolean },
+): ((idPrefix?: string) => React.ReactElement[] | undefined) => {
+  const colorChildren = precomputeColorChildren(pathsOrSvg, options);
+  if (!colorChildren) {
+    return noColorChildren;
+  }
+  return function useColorChildren(idPrefix?: string) {
+    return React.useMemo(
+      () => (idPrefix ? precomputeColorChildren(pathsOrSvg, options, idPrefix) : colorChildren),
+      [idPrefix],
+    );
+  };
+};
 
 type RenderSvgState = { fill?: string };
 
@@ -38,7 +107,7 @@ type RenderSvgState = { fill?: string };
  * Renders the `<svg>` element body for an already-resolved element `state`.
  * Handles the three content forms:
  * - raw innerHTML `string` (deprecated, CSP-unsafe `dangerouslySetInnerHTML`),
- * - pre-rendered color children ({@link precomputeColorChildren}),
+ * - pre-rendered color children ({@link createColorChildrenResolver}),
  * - mono-color path `d` strings.
  *
  * `state` must already carry className/fill/width/height/viewBox/xmlns/ref.

--- a/packages/react-icons/src/core/useBaseIconState.ts
+++ b/packages/react-icons/src/core/useBaseIconState.ts
@@ -36,6 +36,9 @@ export const useBaseIconState = <
     // remove unwanted props to be set on the svg/html element
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     filled,
+    // consumed by the icon factory to scope color-icon ids, never a DOM attribute
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    idPrefix,
     title,
     primaryFill = 'currentColor',
     ...rest

--- a/packages/react-icons/src/headless/createFluentIcon.ts
+++ b/packages/react-icons/src/headless/createFluentIcon.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import type { FluentIconsProps } from './shared';
 import { iconClassName, cx } from './shared';
 import { useIconState } from './useIconState';
-import { computeViewBox, precomputeColorChildren, renderSvgBody } from '../core/svg';
+import { computeViewBox, createColorChildrenResolver, renderSvgBody } from '../core/svg';
 import type { SvgNode } from '../core/svg';
 
 export type FluentIcon = React.FC<FluentIconsProps>;
@@ -42,11 +42,12 @@ export const createFluentIcon = (
   options?: CreateFluentIconOptions,
 ): FluentIcon => {
   const viewBoxWidth = computeViewBox(width);
-  // Pre-render color SVG nodes once in the factory so the recursion
-  // never runs during React renders.
-  const colorChildren = precomputeColorChildren(pathsOrSvg, options);
+  // Resolve color children once per component: mono-color icons pay nothing,
+  // color icons get per-instance memoized `idPrefix` scoping.
+  const useColorChildren = createColorChildrenResolver(pathsOrSvg, options);
   const Icon = React.forwardRef((props: FluentIconsProps, ref: React.Ref<HTMLElement>) => {
     const iconState = useIconState(props, { flipInRtl: options?.flipInRtl });
+    const colorChildren = useColorChildren(props.idPrefix);
     const state = {
       ...iconState,
       className: cx(iconClassName, iconState.className),

--- a/packages/react-icons/src/utils/FluentIconsProps.types.ts
+++ b/packages/react-icons/src/utils/FluentIconsProps.types.ts
@@ -15,4 +15,13 @@ export type FluentIconsProps<
      * NOTE: This prop is only applicable when using bundled icons created with `bundleIcon`.
      */
     filled?: boolean;
+    /**
+     * Prefix applied to the locally-scoped SVG `id`s (gradients, clip paths, filters) of a
+     * `Color` icon variant, along with their matching `url(#…)` references. Use a unique value
+     * per rendered instance to avoid global DOM id collisions when the same color icon appears
+     * multiple times on a page.
+     *
+     * NOTE: This prop only applies to `Color` icon variants; it is ignored by mono-color icons.
+     */
+    idPrefix?: string;
   };

--- a/packages/react-icons/src/utils/createFluentIcon.ts
+++ b/packages/react-icons/src/utils/createFluentIcon.ts
@@ -4,7 +4,7 @@ import { FluentIconsProps } from './FluentIconsProps.types';
 import { useIconState } from './useIconState';
 import { useRootStyles } from './createFluentIcon.styles';
 import { iconClassName } from './constants';
-import { computeViewBox, precomputeColorChildren, renderSvgBody } from '../core/svg';
+import { computeViewBox, createColorChildrenResolver, renderSvgBody } from '../core/svg';
 import type { SvgNode } from '../core/svg';
 
 export type FluentIcon = React.FC<FluentIconsProps>;
@@ -36,12 +36,13 @@ export const createFluentIcon = (
   options?: CreateFluentIconOptions,
 ): FluentIcon => {
   const viewBoxWidth = computeViewBox(width);
-  // Pre-render color SVG nodes once in the factory so the recursion
-  // never runs during React renders.
-  const colorChildren = precomputeColorChildren(pathsOrSvg, options);
+  // Resolve color children once per component: mono-color icons pay nothing,
+  // color icons get per-instance memoized `idPrefix` scoping.
+  const useColorChildren = createColorChildrenResolver(pathsOrSvg, options);
   const Icon = React.forwardRef((props: FluentIconsProps, ref: React.Ref<HTMLElement>) => {
     const styles = useRootStyles();
     const iconState = useIconState(props, { flipInRtl: options?.flipInRtl });
+    const colorChildren = useColorChildren(props.idPrefix);
     const state = {
       ...iconState,
       className: mergeClasses(iconClassName, iconState.className, styles.root),

--- a/packages/react-icons/src/utils/icon-factories.test.tsx
+++ b/packages/react-icons/src/utils/icon-factories.test.tsx
@@ -126,6 +126,71 @@ describe('React component tests', () => {
     expect(rect).toHaveStyle({ mixBlendMode: 'multiply' });
   });
 
+  test('createFluentIcon color icon scopes ids and url(#…) references with idPrefix', () => {
+    const MyColorIcon = createFluentIcon(
+      'MyColorIcon',
+      '1em',
+      [
+        ['path', { d: 'M0 0h20v20H0z', fill: 'url(#grad)' }],
+        ['defs', null, ['linearGradient', { id: 'grad' }, ['stop', { stopColor: '#fff' }]]],
+      ],
+      { color: true },
+    );
+
+    const { container } = render(<MyColorIcon idPrefix="x-" />);
+
+    expect(container.querySelector('linearGradient')).toHaveAttribute('id', 'x-grad');
+    expect(container.querySelector('path')).toHaveAttribute('fill', 'url(#x-grad)');
+  });
+
+  test('createFluentIcon color icon keeps original ids when no idPrefix is passed', () => {
+    const MyColorIcon = createFluentIcon(
+      'MyColorIcon',
+      '1em',
+      [
+        ['path', { d: 'M0 0h20v20H0z', fill: 'url(#grad)' }],
+        ['defs', null, ['linearGradient', { id: 'grad' }, ['stop', { stopColor: '#fff' }]]],
+      ],
+      { color: true },
+    );
+
+    const { container } = render(<MyColorIcon />);
+
+    expect(container.querySelector('linearGradient')).toHaveAttribute('id', 'grad');
+    expect(container.querySelector('path')).toHaveAttribute('fill', 'url(#grad)');
+  });
+
+  test('createFluentIcon idPrefix produces unique ids across two instances', () => {
+    const MyColorIcon = createFluentIcon(
+      'MyColorIcon',
+      '1em',
+      [
+        ['path', { d: 'M0 0h20v20H0z', fill: 'url(#grad)' }],
+        ['defs', null, ['linearGradient', { id: 'grad' }, ['stop', { stopColor: '#fff' }]]],
+      ],
+      { color: true },
+    );
+
+    const { container } = render(
+      <>
+        <MyColorIcon idPrefix="a-" />
+        <MyColorIcon idPrefix="b-" />
+      </>,
+    );
+
+    const ids = Array.from(container.querySelectorAll('linearGradient')).map((node) => node.getAttribute('id'));
+    expect(ids).toEqual(['a-grad', 'b-grad']);
+  });
+
+  test('createFluentIcon idPrefix is a no-op for mono-color (path string) icons', () => {
+    const MyIcon = createFluentIcon('MyIcon', '1em', ['M1 2 L3 4']);
+    const { container } = render(<MyIcon idPrefix="x-" />);
+
+    const svg = container.querySelector('svg');
+    expect(svg).toBeTruthy();
+    expect(container.querySelector('path')).toHaveAttribute('d', 'M1 2 L3 4');
+  });
+
   test('bundleIcon creates icon with fui-Icon className on both filled and regular icons', () => {
     const d = 'M1 2 L3 4';
     const FilledIcon = createFluentIcon('MyIconFilled', '1em', [d]);


### PR DESCRIPTION
## Summary

Adds an opt-in **`idPrefix`** prop to `Color` icon variants that scopes their locally-defined SVG `id`s (gradients, clip paths, filters) and the matching `url(#…)` references per rendered instance. This fixes the global DOM id collision where rendering the same color icon multiple times — and hiding one with `display: none` — breaks the gradients of the others ([#936](https://github.com/microsoft/fluentui-system-icons/issues/936)).

```tsx
<CalendarColor idPrefix="cal-a-" />
<CalendarColor idPrefix="cal-b-" />
```

## API

- New optional `idPrefix?: string` on `FluentIconsProps`.
- Applies to `Color` variants only; mono-color icons ignore it entirely.
- Stripped from the rendered DOM (never emitted as an attribute).

## Implementation notes

- A single `precomputeColorChildren(pathsOrSvg, options, prefix?)` performs the scoping inline during the existing `SvgNode` recursion (no extra tree clone; long path `d` strings short-circuit the `url(#…)` rewrite).
- A factory-time `createColorChildrenResolver` decides per **component** (an icon's "color-ness" is fixed) how children are produced:
  - **mono-color icons** → shared no-op, **no hook and no allocation** per instance;
  - **color icons** → a memoized hook keyed on `idPrefix`, so re-renders reuse the element tree and only rebuild when the prefix changes.
- Net result: zero added cost for the common (mono-color / no-prefix) path, O(1) shared precompute, and prefixed color icons don't rebuild their SVG tree on every re-render.
- Wired through both the Griffel (`utils`) and headless factories.

## Docs

- README: `idPrefix` documented as the recommended fix in the "SVG Gradient ID Collision" section, plus a note on `React.memo` as a complementary user-land optimization.
- Docsite: new **Icons/Color Variants** Storybook page with a side-by-side "without vs with `idPrefix`" example; User Guidance updated.

## Tests

- Added unit tests covering id/reference scoping, per-instance uniqueness across two instances, default (no-prefix) behavior, and the mono-color no-op.

## Why this approach (performance discussion)

The final design came out of working through a real tension between **per-instance memory** and **re-render cost**. The iterations:

1. **`useMemo` in every icon's render** — memoizes the scoped tree, but adds a hook slot (cached value + deps array) to *every* icon instance, including the ~99% mono-color icons that never use the feature. Rejected: a per-instance memory tax for a color-only edge case, multiplied across icon-heavy pages (1k+ icons).
2. **Plain ternary in render** (no hook) — zero overhead for mono-color icons, but prefixed color icons rebuild their whole SVG element tree on **every** re-render (no memoization). Rejected: degrades exactly the case the feature targets (many repeated color icons).
3. **Scoping inside `renderSvgBody`** — centralized and DRY, but since `renderSvgBody` runs every render it has the same "rebuild every re-render" problem as (2) for prefixed icons.

The constraint: you can't get *both* "no per-instance hook for mono-color" and "memoized scoping for prefixed color icons" from a single render-path branch, because hooks can't be called conditionally per render.

**Resolution — branch at factory time, not render time.** An icon's "color-ness" is fixed when the component is created, so `createColorChildrenResolver` decides once per component which strategy to install:

- **mono-color icons** → a shared no-op resolver: no hook is ever called, no per-component or per-instance allocation (identical cost to before the feature existed);
- **color icons** → a memoized `useMemo` hook keyed on `idPrefix`: re-renders reuse the element tree and only rebuild when the prefix actually changes.

Because the branch is fixed per component, hook order is stable across that component's renders, so it's Rules-of-Hooks-safe (verified with `eslint-plugin-react-hooks`). This satisfies **both** constraints: only color icons pay for the memo hook, and prefixed color icons no longer rebuild on every re-render.

### `React.memo` (complementary, user-land)

`React.memo(Icon)` is a separate, complementary lever and the bigger win when applicable — it skips the icon's render entirely (styles + state hooks + tree) when props are referentially stable. It's documented in the README as the recommended optimization for color-icon-heavy, frequently-updating trees. The two stack:

- `React.memo` → skips the whole render when **all** props are unchanged;
- internal `useMemo(idPrefix)` → reuses the scoped tree when the icon **does** re-render (e.g. `primaryFill` changed) but `idPrefix` did not.

We deliberately did **not** wrap icons in `React.memo` by default — shallow-compare across thousands of cheap icon renders isn't an obvious net win, and whether to memo is a consumer policy decision.

## Bundle size impact

This feature adds a **fixed ~353 B minified (~150–184 B gzip)** to every SVG icon fixture, plus a **~11 B minified (~10 B gzip)** bump to the font fixtures.

| Package & Exports | Baseline (min / gzip) | PR (min / gzip) | Change (min / gzip) |
|---|---|---|---|
| Atomic Imports | 7.125 kB / 3.285 kB | 7.478 kB / 3.435 kB | 🔺 353 B / 150 B |
| Headless - Bundle Icon | 2.767 kB / 1.437 kB | 3.12 kB / 1.621 kB | 🔺 353 B / 184 B |
| Headless - Single Fonts | 1.11 kB / 629 B | 1.121 kB / 639 B | 🔺 11 B / 10 B |
| Headless - Single SVG | 2.022 kB / 1.149 kB | 2.375 kB / 1.332 kB | 🔺 353 B / 183 B |
| Single Icon via Import all | 7.127 kB / 3.287 kB | 7.48 kB / 3.436 kB | 🔺 353 B / 149 B |
| Single Fonts | 8.133 kB / 3.533 kB | 8.144 kB / 3.543 kB | 🔺 11 B / 10 B |
| Single Icons | 7.127 kB / 3.287 kB | 7.48 kB / 3.436 kB | 🔺 353 B / 149 B |

### Why it grows

The `idPrefix` scoping logic — `renderSvgNode`'s id/`url(#…)` rewriting plus the per-instance memoized `createColorChildrenResolver` — lives in the **shared** `createFluentIcon` factory. Dead code inside a function body can't be tree-shaken based on call arguments, so **any** icon that imports `createFluentIcon` pulls in this color code. Hence the flat ~353 B on every SVG fixture.

### Why non-color (mono) variants are affected too

Mono icons are built by the **same** `createFluentIcon` factory, which statically references the color-rendering/scoping helpers (`renderSvgBody`'s color branch, `precomputeColorChildren`, `createColorChildrenResolver`). Importing even a single mono icon therefore bundles the whole factory — including code a mono icon never executes. That's why `Single Icons`, `Atomic Imports`, `Headless - Single SVG`, etc. all show the same +353 B, whether or not the icon has a color variant.

### Why font fixtures move by only ~11 B

Font icons bundle **no** SVG color code. Their small bump comes solely from the shared `useBaseIconState` hook, which now strips the `idPrefix` prop (one extra destructured binding) so it never lands on the DOM element. `createFluentFontIcon` routes through the same hook, so it inherits just that one-line cost.

## Follow-up — factory split (bigger change)

A stacked follow-up (`perf/react-icons-detach-color-factory`) **eliminates** this regression by splitting the factory into a lean `createFluentMonoIcon` (paths only, zero color code) and a `createFluentColorIcon` (`SvgNode[]` + `idPrefix`). Generated icons import only the factory they need, so mono icons stop bundling color code entirely — bringing them **below** the pre-feature baseline (e.g. `Headless - Single SVG` −149 B, `Single Icons` −126 B gzip). `createFluentIcon` is kept as a deprecated, fully backwards-compatible delegator. That change touches the generator and regenerates all icons, so it is split out for separate review.

## Notes

> This is a **draft** for review of the API shape and approach.

