### PR TITLE
docs(docsite): fix ColorVariants story 'Show code' to follow index re-export pattern

### DIFF
--- a/packages/docsite/stories/Icons/ColorVariants/ColorVariants.stories.tsx
+++ b/packages/docsite/stories/Icons/ColorVariants/ColorVariants.stories.tsx
@@ -1,0 +1,50 @@
+import { CalendarColor } from '@fluentui/react-icons';
+import { Body1Stronger, makeStyles, shorthands, tokens } from '@fluentui/react-components';
+import * as React from 'react';
+
+const useClasses = makeStyles({
+  root: {
+    display: 'flex',
+    ...shorthands.gap('32px'),
+  },
+  column: {
+    display: 'flex',
+    flexDirection: 'column',
+    ...shorthands.gap('8px'),
+    ...shorthands.padding('12px'),
+    ...shorthands.border('1px', 'solid', tokens.colorNeutralStroke2),
+    borderRadius: tokens.borderRadiusMedium,
+  },
+  icons: {
+    fontSize: '48px',
+  },
+  // Hiding one instance with display:none triggers the gradient ID collision
+  // for any sibling that shares the same (unscoped) IDs.
+  hidden: {
+    display: 'none',
+  },
+});
+
+export const ColorIdPrefix = () => {
+  const classes = useClasses();
+
+  return (
+    <div className={classes.root}>
+      <div className={classes.column}>
+        <Body1Stronger>❌ Without idPrefix</Body1Stronger>
+        <div className={classes.icons}>
+          <CalendarColor className={classes.hidden} aria-hidden />
+          <CalendarColor aria-label="Calendar without idPrefix" />
+        </div>
+      </div>
+
+      <div className={classes.column}>
+        <Body1Stronger>✅ With idPrefix</Body1Stronger>
+        <div className={classes.icons}>
+          <CalendarColor idPrefix="cal-a-" className={classes.hidden} aria-hidden />
+          <CalendarColor idPrefix="cal-b-" aria-label="Calendar with idPrefix" />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/docsite/stories/Icons/ColorVariants/index.stories.tsx
+++ b/packages/docsite/stories/Icons/ColorVariants/index.stories.tsx
@@ -1,56 +1,9 @@
 import { CalendarColor } from '@fluentui/react-icons';
-import { Body1Stronger, makeStyles, shorthands, tokens } from '@fluentui/react-components';
 import { Controls, Description, Primary, Title } from '@storybook/addon-docs/blocks';
-import * as React from 'react';
 
 import descriptionMd from './ColorVariantsDescription.md';
 
-const useClasses = makeStyles({
-  root: {
-    display: 'flex',
-    ...shorthands.gap('32px'),
-  },
-  column: {
-    display: 'flex',
-    flexDirection: 'column',
-    ...shorthands.gap('8px'),
-    ...shorthands.padding('12px'),
-    ...shorthands.border('1px', 'solid', tokens.colorNeutralStroke2),
-    borderRadius: tokens.borderRadiusMedium,
-  },
-  icons: {
-    fontSize: '48px',
-  },
-  // Hiding one instance with display:none triggers the gradient ID collision
-  // for any sibling that shares the same (unscoped) IDs.
-  hidden: {
-    display: 'none',
-  },
-});
-
-export const ColorIdPrefix = () => {
-  const classes = useClasses();
-
-  return (
-    <div className={classes.root}>
-      <div className={classes.column}>
-        <Body1Stronger>❌ Without idPrefix</Body1Stronger>
-        <div className={classes.icons}>
-          <CalendarColor className={classes.hidden} aria-hidden />
-          <CalendarColor aria-label="Calendar without idPrefix" />
-        </div>
-      </div>
-
-      <div className={classes.column}>
-        <Body1Stronger>✅ With idPrefix</Body1Stronger>
-        <div className={classes.icons}>
-          <CalendarColor idPrefix="cal-a-" className={classes.hidden} aria-hidden />
-          <CalendarColor idPrefix="cal-b-" aria-label="Calendar with idPrefix" />
-        </div>
-      </div>
-    </div>
-  );
-};
+export { ColorIdPrefix } from './ColorVariants.stories';
 
 export default {
   title: 'Icons/Color Variants',


### PR DESCRIPTION
## Problem

The **Show code** panel on the *Icons / Color Variants* story was displaying the **entire story module** — the `default` meta, `argTypes`, and the custom `docs.page` render — instead of just the example component.

## Root cause

The Fluent `@fluentui/react-storybook-addon-export-to-sandbox` addon shows the *whole story module source* (so it can be exported to a sandbox). The rest of the docsite avoids this by following an **index re-export pattern**: each story lives in its own dedicated `*.stories.tsx` file containing only that example, while `index.stories.tsx` re-exports the stories and holds the meta/`argTypes`/page boilerplate.

`ColorVariants/index.stories.tsx` broke this by defining the `ColorIdPrefix` story inline alongside all the meta config, so everything leaked into the code display.

## Fix

- Add `ColorVariants/ColorVariants.stories.tsx` containing only the `ColorIdPrefix` story (imports, styles, component). This is now the clean source shown in **Show code**.
- Rewrite `ColorVariants/index.stories.tsx` to re-export the story and hold the `default` meta/`argTypes`/`page` config, mirroring `Icons/index.stories.tsx` and `FileTypeIcons/index.stories.tsx`.

The sibling `ColorVariants.stories.tsx` is not double-registered because the Storybook glob only matches `**/index.stories.@(ts|tsx)`.

## Verification

- `npx nx run docsite:build` completes successfully (Storybook + SWC compile all stories with no errors).