### PR TITLE
docs: sync standalone package release artifacts after failed publish commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28565,7 +28565,7 @@
     },
     "packages/react-icons-atomic-webpack-loader": {
       "name": "@fluentui/react-icons-atomic-webpack-loader",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "magic-string": "^0.30.0",
@@ -28654,7 +28654,7 @@
     },
     "packages/react-icons-svg-sprite-subsetting-webpack-plugin": {
       "name": "@fluentui/react-icons-svg-sprite-subsetting-webpack-plugin",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "schema-utils": "^4.2.0"

--- a/packages/react-icons-atomic-webpack-loader/CHANGELOG.md
+++ b/packages/react-icons-atomic-webpack-loader/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.5 (2026-07-03)
+
+### 🚀 Features
+
+- **react-icons-atomic-webpack-loader:** reroute SVG-only color icons off font variants ([#1137](https://github.com/microsoft/fluentui-system-icons/pull/1137))
+- **react-icons-atomic-webpack-loader:** add headless option ([#1122](https://github.com/microsoft/fluentui-system-icons/pull/1122))
+
 ## 0.0.4 (2026-06-30)
 
 This release contains icon updates

--- a/packages/react-icons-atomic-webpack-loader/package.json
+++ b/packages/react-icons-atomic-webpack-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-icons-atomic-webpack-loader",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Webpack loader that transforms barrel imports and re-exports from @fluentui/react-icons into atomic deep paths",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/react-icons-svg-sprite-subsetting-webpack-plugin/CHANGELOG.md
+++ b/packages/react-icons-svg-sprite-subsetting-webpack-plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.5 (2026-07-03)
+
+This release contains icon updates
+
 ## 0.0.4 (2026-06-30)
 
 This release contains icon updates

--- a/packages/react-icons-svg-sprite-subsetting-webpack-plugin/package.json
+++ b/packages/react-icons-svg-sprite-subsetting-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-icons-svg-sprite-subsetting-webpack-plugin",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Webpack plugin to subset or merge SVG sprite assets used by @fluentui/react-icons svg-sprite APIs.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Recovery sync for the standalone release run [#28669548663](https://github.com/microsoft/fluentui-system-icons/actions/runs/28669548663/job/85029425736) that **published to npm but failed before pushing to `main`**.

The run published:

- `@fluentui/react-icons-atomic-webpack-loader@0.0.5` ✅ (on npm)
- `@fluentui/react-icons-svg-sprite-subsetting-webpack-plugin@0.0.5` ✅ (on npm)

…but died at the **Tag** step (`fatal: tag 'react-icons-file-type@0.0.1' already exists`), which runs *before* `git push`. As a result the version bumps, changelogs, and lockfile update never landed on `main`, and no `@0.0.5` tags exist upstream.

## What this PR does

Re-applies the artifacts the failed run would have committed (mirrors #1133):

- `react-icons-atomic-webpack-loader` → `0.0.5` (package.json + CHANGELOG)
- `react-icons-svg-sprite-subsetting-webpack-plugin` → `0.0.5` (package.json + CHANGELOG)
- `package-lock.json` version refs

`react-icons-file-type` is intentionally untouched (already published + tagged at `0.0.1`).

## Follow-up

After merge, the `@0.0.5` git tags will be created at the merge commit to realign tags ↔ npm ↔ disk. A separate change will make the publish workflow idempotent so a mid-run failure (existing tag / already-published version) can no longer abort the pipeline.
