### PR TITLE
ci: make standalone release changelog/tag steps idempotent and change-aware

### DIFF
--- a/.github/workflows/publish-standalone.yml
+++ b/.github/workflows/publish-standalone.yml
@@ -83,9 +83,21 @@ jobs:
         # --first-release: allows changelog generation when no prior git tag exists (first release).
         # Safe to keep permanently — once per-package tags exist, they take priority and this flag becomes a no-op.
         # Scoped here instead of global nx.json `automaticFromRef` to avoid masking tag-resolution failures in other release groups.
+        #
+        # Change-aware guard: `nx release version` only bumps packages with releasable
+        # conventional-commit changes; unchanged packages keep their version (and therefore
+        # their existing tag). We use "the {pkg}@{version} tag already exists" as the signal for
+        # "this version was already released" and skip it — this prevents a duplicate changelog
+        # entry for an unchanged package and keeps re-runs idempotent (a re-run after a partial
+        # failure re-generates only the not-yet-tagged versions).
         run: |
           for pkg in $(echo "${{ steps.projects.outputs.nx-names }}" | tr ',' '\n'); do
             VERSION=$(node -p "require('./packages/${pkg}/package.json').version")
+            TAG="${pkg}@${VERSION}"
+            if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+              echo "Skipping changelog for ${TAG} — tag already exists (no new release for ${pkg})"
+              continue
+            fi
             echo "Generating changelog for ${pkg}@${VERSION}"
             npx nx release changelog "$VERSION" --projects="$pkg" --first-release --no-git-tag --no-git-commit --verbose
           done
@@ -107,17 +119,35 @@ jobs:
         if: ${{ !inputs.dry-run }}
         run: |
           git add -A
-          git commit -m "chore(release): publish standalone packages [skip ci]"
+          # Guard against an empty commit: if every targeted package was unchanged there is
+          # nothing staged, and `git commit` would fail the job. Skip cleanly instead.
+          if git diff --cached --quiet; then
+            echo "No release changes to commit — all targeted packages were already released"
+          else
+            git commit -m "chore(release): publish standalone packages [skip ci]"
+          fi
 
       - name: Tag releases
-        # Tags must be created manually after the final commit (which includes lockfile updates, changelogs, etc.)
-        # rather than by nx release (git.tag: false in nx.json) — nx would tag before the commit is finalized,
-        # causing tags to point to an intermediate state instead of the release commit.
+        # Tags are created manually (git.tag: false in nx.json) after the final commit so they point
+        # at the release commit that also includes the lockfile update — nx would otherwise tag before
+        # that commit is finalized. nx.json uses granular `version.git`/`changelog.git` config, which
+        # the unified `nx release` command (the only variant that natively skips unchanged packages
+        # when tagging) refuses to run with; migrating to top-level `release.git` would also alter the
+        # sub-command flow that publish.yml depends on. So we tag here, but idempotently.
+        #
+        # Idempotent guard: skip any tag that already exists. This turns the reported failure
+        # (`fatal: tag '<pkg>@<version>' already exists` for an unchanged package) into a no-op and,
+        # combined with nx release publish's built-in "already published" skip, makes the whole
+        # workflow safely re-runnable after a partial failure (e.g. npm published but git push failed).
         if: ${{ !inputs.dry-run }}
         run: |
           for pkg in $(echo "${{ steps.projects.outputs.nx-names }}" | tr ',' '\n'); do
             VERSION=$(node -p "require('./packages/${pkg}/package.json').version")
             TAG="${pkg}@${VERSION}"
+            if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+              echo "Tag ${TAG} already exists — skipping"
+              continue
+            fi
             echo "Creating tag: $TAG"
             git tag "$TAG"
           done

--- a/.github/workflows/publish-standalone.yml
+++ b/.github/workflows/publish-standalone.yml
@@ -170,26 +170,57 @@ jobs:
 
       - name: Dry-run summary
         if: ${{ inputs.dry-run }}
+        # Mirrors the real run exactly: only the change-aware "released" set (see "Resolve released
+        # projects") is published/committed/tagged. Unchanged/already-released packages are listed
+        # separately as skipped, so the summary reflects what would actually happen — not the full
+        # candidate list.
         run: |
+          RELEASED="${{ steps.released.outputs.names }}"
+
           echo "## 🧪 Dry-run Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "The following actions would have been performed:" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+
           echo "### 📦 Packages that would be published" >> $GITHUB_STEP_SUMMARY
+          echo "_nx release publish additionally skips any version already on the npm registry._" >> $GITHUB_STEP_SUMMARY
+          if [ -z "$RELEASED" ]; then
+            echo "- (none — every targeted package is already released)" >> $GITHUB_STEP_SUMMARY
+          else
+            for pkg in $(echo "$RELEASED" | tr ',' '\n'); do
+              VERSION=$(node -p "require('./packages/${pkg}/package.json').version")
+              NAME=$(node -p "require('./packages/${pkg}/package.json').name")
+              echo "- \`${NAME}@${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+            done
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### ⏭️ Packages skipped (tag already exists — no new release)" >> $GITHUB_STEP_SUMMARY
+          SKIPPED_ANY=false
           for pkg in $(echo "${{ steps.projects.outputs.nx-names }}" | tr ',' '\n'); do
+            case ",$RELEASED," in
+              *",$pkg,"*) continue ;;
+            esac
             VERSION=$(node -p "require('./packages/${pkg}/package.json').version")
             NAME=$(node -p "require('./packages/${pkg}/package.json').name")
-            echo "- \`${NAME}@${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+            echo "- \`${NAME}@${VERSION}\` (tag \`${pkg}@${VERSION}\` already exists)" >> $GITHUB_STEP_SUMMARY
+            SKIPPED_ANY=true
           done
+          [ "$SKIPPED_ANY" = false ] && echo "- (none)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+
           echo "### 🏷️ Git operations that would be performed" >> $GITHUB_STEP_SUMMARY
-          echo "- Commit: \`chore(release): publish standalone packages [skip ci]\`" >> $GITHUB_STEP_SUMMARY
-          for pkg in $(echo "${{ steps.projects.outputs.nx-names }}" | tr ',' '\n'); do
-            VERSION=$(node -p "require('./packages/${pkg}/package.json').version")
-            echo "- Tag: \`${pkg}@${VERSION}\`" >> $GITHUB_STEP_SUMMARY
-          done
-          echo "- Push to: \`origin/main\`" >> $GITHUB_STEP_SUMMARY
+          if [ -z "$RELEASED" ]; then
+            echo "- Commit: _(skipped — nothing to commit)_" >> $GITHUB_STEP_SUMMARY
+            echo "- Tags: _(none)_" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- Commit: \`chore(release): publish standalone packages [skip ci]\`" >> $GITHUB_STEP_SUMMARY
+            for pkg in $(echo "$RELEASED" | tr ',' '\n'); do
+              VERSION=$(node -p "require('./packages/${pkg}/package.json').version")
+              echo "- Tag: \`${pkg}@${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+            done
+            echo "- Push to: \`origin/main\`" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "" >> $GITHUB_STEP_SUMMARY
+
           echo "### 📝 Files modified (not committed)" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           git status --short >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-standalone.yml
+++ b/.github/workflows/publish-standalone.yml
@@ -79,25 +79,42 @@ jobs:
         run: |
           npx nx release version --projects=${{ steps.projects.outputs.nx-names }} --verbose
 
-      - name: Generate changelogs (Nx Release)
-        # --first-release: allows changelog generation when no prior git tag exists (first release).
-        # Safe to keep permanently — once per-package tags exist, they take priority and this flag becomes a no-op.
-        # Scoped here instead of global nx.json `automaticFromRef` to avoid masking tag-resolution failures in other release groups.
-        #
-        # Change-aware guard: `nx release version` only bumps packages with releasable
-        # conventional-commit changes; unchanged packages keep their version (and therefore
-        # their existing tag). We use "the {pkg}@{version} tag already exists" as the signal for
-        # "this version was already released" and skip it — this prevents a duplicate changelog
-        # entry for an unchanged package and keeps re-runs idempotent (a re-run after a partial
-        # failure re-generates only the not-yet-tagged versions).
+      - name: Resolve released projects (new versions this run)
+        id: released
+        # `nx release version` only bumps packages with releasable conventional-commit changes;
+        # unchanged packages keep their version (and therefore their existing tag). We treat
+        # "the {pkg}@{version} tag already exists" as "this version was already released" and drop
+        # it from the set. Every downstream step (changelog, publish, tag) operates on this single
+        # source of truth, which also makes re-runs idempotent: a re-run after a partial failure
+        # only re-processes the versions that were not yet tagged.
         run: |
+          RELEASED=""
           for pkg in $(echo "${{ steps.projects.outputs.nx-names }}" | tr ',' '\n'); do
             VERSION=$(node -p "require('./packages/${pkg}/package.json').version")
             TAG="${pkg}@${VERSION}"
             if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
-              echo "Skipping changelog for ${TAG} — tag already exists (no new release for ${pkg})"
+              echo "Skipping ${TAG} — already released (tag exists)"
               continue
             fi
+            RELEASED="${RELEASED:+$RELEASED,}$pkg"
+          done
+          echo "names=$RELEASED" >> "$GITHUB_OUTPUT"
+          echo "### Released projects (new versions this run)" >> $GITHUB_STEP_SUMMARY
+          if [ -z "$RELEASED" ]; then
+            echo "- (none — all targeted packages already released)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "$RELEASED" | tr ',' '\n' | while read -r p; do echo "- $p" >> $GITHUB_STEP_SUMMARY; done
+          fi
+
+      - name: Generate changelogs (Nx Release)
+        # --first-release: allows changelog generation when no prior git tag exists (first release).
+        # Safe to keep permanently — once per-package tags exist, they take priority and this flag becomes a no-op.
+        # Scoped here instead of global nx.json `automaticFromRef` to avoid masking tag-resolution failures in other release groups.
+        # Operates on the already-filtered released set (see "Resolve released projects").
+        run: |
+          for pkg in $(echo "${{ steps.released.outputs.names }}" | tr ',' '\n'); do
+            [ -z "$pkg" ] && continue
+            VERSION=$(node -p "require('./packages/${pkg}/package.json').version")
             echo "Generating changelog for ${pkg}@${VERSION}"
             npx nx release changelog "$VERSION" --projects="$pkg" --first-release --no-git-tag --no-git-commit --verbose
           done
@@ -106,9 +123,9 @@ jobs:
         run: npm install --package-lock-only
 
       - name: Publish to npm (Nx Release)
-        if: ${{ !inputs.dry-run }}
+        if: ${{ !inputs.dry-run && steps.released.outputs.names != '' }}
         run: |
-          npx nx release publish --projects=${{ steps.projects.outputs.nx-names }} --access public --verbose
+          npx nx release publish --projects=${{ steps.released.outputs.names }} --access public --verbose
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -133,21 +150,15 @@ jobs:
         # that commit is finalized. nx.json uses granular `version.git`/`changelog.git` config, which
         # the unified `nx release` command (the only variant that natively skips unchanged packages
         # when tagging) refuses to run with; migrating to top-level `release.git` would also alter the
-        # sub-command flow that publish.yml depends on. So we tag here, but idempotently.
-        #
-        # Idempotent guard: skip any tag that already exists. This turns the reported failure
-        # (`fatal: tag '<pkg>@<version>' already exists` for an unchanged package) into a no-op and,
-        # combined with nx release publish's built-in "already published" skip, makes the whole
-        # workflow safely re-runnable after a partial failure (e.g. npm published but git push failed).
+        # sub-command flow that publish.yml depends on. So we tag here, over the already-filtered
+        # released set (see "Resolve released projects") — so an unchanged/already-tagged package can
+        # never abort the job, and re-runs after a partial failure only create the missing tags.
         if: ${{ !inputs.dry-run }}
         run: |
-          for pkg in $(echo "${{ steps.projects.outputs.nx-names }}" | tr ',' '\n'); do
+          for pkg in $(echo "${{ steps.released.outputs.names }}" | tr ',' '\n'); do
+            [ -z "$pkg" ] && continue
             VERSION=$(node -p "require('./packages/${pkg}/package.json').version")
             TAG="${pkg}@${VERSION}"
-            if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
-              echo "Tag ${TAG} already exists — skipping"
-              continue
-            fi
             echo "Creating tag: $TAG"
             git tag "$TAG"
           done


### PR DESCRIPTION
## Summary

Hardens the standalone publish workflow so it can no longer be aborted by a stale/duplicate git tag, and so a partially-failed run can be safely re-run. Follow-up to the failure in run [#28669548663](https://github.com/microsoft/fluentui-system-icons/actions/runs/28669548663/job/85029425736):

```
Creating tag: react-icons-file-type@0.0.1
fatal: tag 'react-icons-file-type@0.0.1' already exists
```

That step ran **before** `git push`, so the packages published to npm but the version bumps/changelogs/tags never reached `main` (recovered separately in #1139).

## Root cause

`nx release version` only bumps packages with releasable conventional-commit changes; an unchanged package (e.g. `react-icons-file-type`) keeps its version and its existing tag. The old **Tag** step then ran `git tag <pkg>@<version>` **unconditionally**, so it hit the already-existing tag and aborted the whole job.

## Changes (scoped to `publish-standalone.yml` only)

Uses *"the `<pkg>@<version>` tag already exists"* as the signal for *"already released — skip"*:

- **Generate changelogs** — skip packages whose tag already exists (avoids a duplicate changelog entry for an unchanged package).
- **Commit version changes** — guard against an empty commit when nothing was released.
- **Tag releases** — skip tags that already exist instead of failing.

Combined with `nx release publish`'s built-in "already published" check ([nx docs](https://nx.dev/recipes/nx-release/get-started-with-nx-release#future-releases)), the workflow is now **idempotent / self-healing**: re-running after a partial failure re-creates only the missing tags and pushes, with no manual sync PR required.

## Why not hand tagging to nx natively?

Investigated. The unified `nx release` command (the only variant that natively skips unchanged packages when tagging) **refuses to run with the granular `version.git`/`changelog.git` config** this repo uses, and the `changelog` sub-command requires an explicit per-version arg and would still tag the unchanged package. Migrating to top-level `release.git` would also alter the sub-command flow `publish.yml` depends on — out of scope here. `publish.yml` is intentionally left untouched (fixed versioning, one global tag).

## Validation

- `nx release version --dry-run` confirms `react-icons-file-type` reports `🚫 No changes were detected` (no bump).
- Guard logic dry-tested against real tags: `atomic@0.0.5`/`sprite@0.0.5` → tagged (new), `file-type@0.0.1` → skipped (exists).
- Workflow YAML parses.
