### PR TITLE
feat(docsite): set up eslint, modernize griffel, add version badges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19184,6 +19184,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/memoizee": {
@@ -22925,6 +22926,7 @@
       "version": "1.8.11",
       "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
       "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
@@ -28495,24 +28497,19 @@
       "dependencies": {
         "@fluentui/react-components": "^9.46.0",
         "@fluentui/react-icons": "*",
-        "@fluentui/react-icons-file-type": "*",
-        "react": "19.2.3",
-        "react-dom": "19.2.3",
-        "react-window": "^1.8.10"
+        "@fluentui/react-icons-file-type": "*"
       },
       "devDependencies": {
         "@fluentui/react-storybook-addon": "0.6.0",
         "@fluentui/react-storybook-addon-export-to-sandbox": "0.2.1",
         "@fluentui/storybook-llms-extractor": "0.0.4",
+        "@griffel/eslint-plugin": "^2.0.2",
         "@storybook/addon-docs": "9.1.19",
         "@storybook/addon-webpack5-compiler-swc": "^4.0.3",
         "@storybook/react": "9.1.19",
         "@storybook/react-webpack5": "9.1.19",
-        "@types/react": "19.1.13",
-        "@types/react-dom": "19.1.9",
-        "remark-gfm": "^4.0.1",
-        "storybook": "9.1.19",
-        "typescript": "5.0.4"
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "remark-gfm": "^4.0.1"
       }
     },
     "packages/icon-app": {

--- a/packages/docsite/.storybook/docs-root-v9.css
+++ b/packages/docsite/.storybook/docs-root-v9.css
@@ -21,3 +21,22 @@
 .sb-errordisplay {
   display: none !important;
 }
+
+/* package version badge shown on Overview docs pages (see stories/components/VersionBadge.tsx) */
+#storybook-docs .fluent-version-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 4px 12px;
+  border-radius: var(--borderRadiusMedium, 4px);
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 600;
+  color: var(--colorBrandForeground1, #0f6cbd); /* --color-brand-foreground-1 */
+  background: var(--colorBrandBackground2, #e6f2fb); /* --color-brand-background-2 */
+}
+
+#storybook-docs .fluent-version-badge__name {
+  font-family: 'Cascadia Code', Menlo, 'Courier New', Courier, monospace;
+}

--- a/packages/docsite/.storybook/main.ts
+++ b/packages/docsite/.storybook/main.ts
@@ -1,5 +1,11 @@
 import type { StorybookConfig } from '@storybook/react-webpack5';
 import remarkGfm from 'remark-gfm';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import webpack from 'webpack';
+
+const readPackageVersion = (packageDir: string): string =>
+  JSON.parse(fs.readFileSync(path.resolve(__dirname, packageDir, 'package.json'), 'utf8')).version;
 
 const config: StorybookConfig = {
   stories: ['../stories/**/index.stories.@(ts|tsx)', '../stories/**/*.mdx'],
@@ -31,6 +37,17 @@ const config: StorybookConfig = {
 
   docs: {
     docsMode: true,
+  },
+
+  webpackFinal: async (webpackConfig) => {
+    webpackConfig.plugins = webpackConfig.plugins ?? [];
+    webpackConfig.plugins.push(
+      new webpack.DefinePlugin({
+        STORYBOOK_REACT_ICONS_VERSION: JSON.stringify(readPackageVersion('../../react-icons')),
+        STORYBOOK_REACT_ICONS_FILE_TYPE_VERSION: JSON.stringify(readPackageVersion('../../react-icons-file-type')),
+      }),
+    );
+    return webpackConfig;
   },
 };
 

--- a/packages/docsite/eslint.config.mjs
+++ b/packages/docsite/eslint.config.mjs
@@ -1,0 +1,37 @@
+// @ts-check
+import tseslint from 'typescript-eslint';
+import griffelPlugin from '@griffel/eslint-plugin';
+import reactHooksPlugin from 'eslint-plugin-react-hooks';
+
+export default tseslint.config(
+  {
+    ignores: [
+      // generated output
+      'storybook-static/',
+      'public/',
+      'node_modules/',
+      // build scripts and configs
+      '*.js',
+      '*.config.js',
+    ],
+  },
+  ...tseslint.configs.recommended,
+  {
+    files: ['**/*.{ts,tsx}'],
+    plugins: {
+      '@griffel': griffelPlugin,
+      'react-hooks': reactHooksPlugin,
+    },
+    rules: {
+      // Griffel supports CSS shorthands natively — disallow the deprecated `shorthands.*` helper.
+      '@griffel/no-deprecated-shorthands': 'error',
+      // Complementary safety-net for the few border-group/`all` shorthands Griffel can't atomically expand.
+      '@griffel/no-shorthands': 'error',
+      '@griffel/no-invalid-shorthand-argument': 'error',
+      '@griffel/hook-naming': 'error',
+      '@griffel/pseudo-element-naming': 'error',
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+    },
+  },
+);

--- a/packages/docsite/package.json
+++ b/packages/docsite/package.json
@@ -5,28 +5,24 @@
   "scripts": {
     "dev": "storybook dev -p 6006 --docs",
     "build": "storybook build --docs",
+    "lint": "eslint stories .storybook",
     "extract-storybook-llms": "storybook-llms-extractor --distPath storybook-static --summaryBaseUrl https://microsoft.github.io/fluentui-system-icons/"
   },
   "dependencies": {
     "@fluentui/react-components": "^9.46.0",
     "@fluentui/react-icons": "*",
-    "@fluentui/react-icons-file-type": "*",
-    "react": "19.2.3",
-    "react-dom": "19.2.3",
-    "react-window": "^1.8.10"
+    "@fluentui/react-icons-file-type": "*"
   },
   "devDependencies": {
     "@fluentui/react-storybook-addon": "0.6.0",
     "@fluentui/react-storybook-addon-export-to-sandbox": "0.2.1",
     "@fluentui/storybook-llms-extractor": "0.0.4",
+    "@griffel/eslint-plugin": "^2.0.2",
     "@storybook/addon-docs": "9.1.19",
     "@storybook/addon-webpack5-compiler-swc": "^4.0.3",
     "@storybook/react": "9.1.19",
     "@storybook/react-webpack5": "9.1.19",
-    "@types/react": "19.1.13",
-    "@types/react-dom": "19.1.9",
-    "remark-gfm": "^4.0.1",
-    "storybook": "9.1.19",
-    "typescript": "5.0.4"
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "remark-gfm": "^4.0.1"
   }
 }

--- a/packages/docsite/project.json
+++ b/packages/docsite/project.json
@@ -10,6 +10,10 @@
       "inputs": ["{projectRoot}/.storybook/**", "{projectRoot}/stories/**", "{projectRoot}/public/**"],
       "outputs": ["{projectRoot}/storybook-static"]
     },
+    "lint": {
+      "cache": true,
+      "inputs": ["{projectRoot}/stories/**", "{projectRoot}/.storybook/**", "{projectRoot}/eslint.config.mjs"]
+    },
     "extract-storybook-llms": {
       "cache": true,
       "dependsOn": ["build"],

--- a/packages/docsite/stories/FileTypeIcons/FileTypeIconsDefault.stories.tsx
+++ b/packages/docsite/stories/FileTypeIcons/FileTypeIconsDefault.stories.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, shorthands } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 import { FileTypeIcon } from '@fluentui/react-icons-file-type';
 import * as React from 'react';
 
@@ -6,7 +6,7 @@ const useClasses = makeStyles({
   container: {
     display: 'flex',
     alignItems: 'center',
-    ...shorthands.gap('16px'),
+    gap: '16px',
   },
 });
 

--- a/packages/docsite/stories/FileTypeIcons/FileTypeIconsProvider.stories.tsx
+++ b/packages/docsite/stories/FileTypeIcons/FileTypeIconsProvider.stories.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, shorthands } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 import { FileTypeIcon, FileTypeIconsProvider, DEFAULT_BASE_URL } from '@fluentui/react-icons-file-type';
 import * as React from 'react';
 
@@ -6,7 +6,7 @@ const useClasses = makeStyles({
   container: {
     display: 'flex',
     alignItems: 'center',
-    ...shorthands.gap('16px'),
+    gap: '16px',
   },
 });
 

--- a/packages/docsite/stories/FileTypeIcons/FileTypeIconsSizes.stories.tsx
+++ b/packages/docsite/stories/FileTypeIcons/FileTypeIconsSizes.stories.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, shorthands } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 import { FileTypeIcon, ICON_SIZES } from '@fluentui/react-icons-file-type';
 import * as React from 'react';
 
@@ -6,7 +6,7 @@ const useClasses = makeStyles({
   container: {
     display: 'flex',
     alignItems: 'flex-end',
-    ...shorthands.gap('16px'),
+    gap: '16px',
   },
 });
 

--- a/packages/docsite/stories/FileTypeIcons/FileTypeIconsTypes.stories.tsx
+++ b/packages/docsite/stories/FileTypeIcons/FileTypeIconsTypes.stories.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, shorthands } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 import { FileTypeIcon, FileIconType } from '@fluentui/react-icons-file-type';
 import * as React from 'react';
 
@@ -6,7 +6,7 @@ const useClasses = makeStyles({
   container: {
     display: 'flex',
     alignItems: 'center',
-    ...shorthands.gap('16px'),
+    gap: '16px',
   },
 });
 

--- a/packages/docsite/stories/FileTypeIcons/index.stories.tsx
+++ b/packages/docsite/stories/FileTypeIcons/index.stories.tsx
@@ -1,5 +1,7 @@
 import { FileTypeIcon, FileIconType } from '@fluentui/react-icons-file-type';
 import descriptionMd from './FileTypeIconsDescription.md';
+import { reactIconsFileTypeVersion } from '../utils/packageVersion';
+import { versionBadgeMarkup } from '../components/VersionBadge';
 
 export { Default } from './FileTypeIconsDefault.stories';
 export { Sizes } from './FileTypeIconsSizes.stories';
@@ -12,7 +14,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: descriptionMd,
+        component: `${versionBadgeMarkup({ packageName: '@fluentui/react-icons-file-type', version: reactIconsFileTypeVersion })}\n\n${descriptionMd}`,
       },
     },
   },

--- a/packages/docsite/stories/Icons/ColorVariants/ColorIdPrefix.stories.tsx
+++ b/packages/docsite/stories/Icons/ColorVariants/ColorIdPrefix.stories.tsx
@@ -1,4 +1,4 @@
-import { Body1Stronger, Button, makeStyles, shorthands, tokens } from '@fluentui/react-components';
+import { Body1Stronger, Button, makeStyles, tokens } from '@fluentui/react-components';
 import { CalendarColor } from '@fluentui/react-icons';
 import * as React from 'react';
 
@@ -6,19 +6,19 @@ const useClasses = makeStyles({
   root: {
     display: 'flex',
     flexDirection: 'column',
-    ...shorthands.gap('16px'),
+    gap: '16px',
     alignItems: 'flex-start',
   },
   columns: {
     display: 'flex',
-    ...shorthands.gap('32px'),
+    gap: '32px',
   },
   column: {
     display: 'flex',
     flexDirection: 'column',
-    ...shorthands.gap('8px'),
-    ...shorthands.padding('12px'),
-    ...shorthands.border('1px', 'solid', tokens.colorNeutralStroke2),
+    gap: '8px',
+    padding: '12px',
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
     borderRadius: tokens.borderRadiusMedium,
   },
   icons: {

--- a/packages/docsite/stories/Icons/Headless/Headless.stories.tsx
+++ b/packages/docsite/stories/Icons/Headless/Headless.stories.tsx
@@ -11,13 +11,14 @@ import * as React from 'react';
 // filled and regular variants of the bundled icon side by side.
 const AccessTime = bundleIcon(AccessTimeFilled, AccessTimeRegular);
 
-// Styling is plain CSS — no Griffel runtime. Inline styles make the point that
-// headless icons are colored/sized with ordinary CSS (color, font-size).
+// Styling is plain CSS — no Griffel runtime. Icons inherit `color` and `font-size`
+// from their container (SVG icons size via `font-size` and paint via `currentColor`),
+// so the shared look lives on the root and inline styles are used only to override.
 export const HeadlessIcons = () => {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
-      <AccessTime filled aria-label="AccessTime filled" style={{ fontSize: 32, color: '#0f6cbd' }} />
-      <AccessTime aria-label="AccessTime regular" style={{ fontSize: 32, color: '#0f6cbd' }} />
+    <div style={{ display: 'flex', alignItems: 'center', gap: 16, fontSize: 32, color: '#0f6cbd' }}>
+      <AccessTime filled aria-label="AccessTime filled" />
+      <AccessTime aria-label="AccessTime regular" />
       <SendRegular aria-label="Send" style={{ fontSize: 48, color: '#c50f1f' }} />
     </div>
   );

--- a/packages/docsite/stories/Icons/IconsBundleIcon.stories.tsx
+++ b/packages/docsite/stories/Icons/IconsBundleIcon.stories.tsx
@@ -5,15 +5,15 @@ import {
   iconFilledClassName,
   iconRegularClassName,
 } from '@fluentui/react-icons';
-import { Body1Stronger, makeStyles, shorthands, tokens } from '@fluentui/react-components';
+import { Body1Stronger, makeStyles, tokens } from '@fluentui/react-components';
 import * as React from 'react';
 
 import description from './IconsBundleIcon.md';
 
 const useClasses = makeStyles({
   container: {
-    ...shorthands.padding('10px'),
-    ...shorthands.border('2px', 'solid', tokens.colorBrandStroke1),
+    padding: '10px',
+    border: `2px solid ${tokens.colorBrandStroke1}`,
     boxSizing: 'border-box',
     width: '200px',
     borderBottomLeftRadius: tokens.borderRadiusMedium,
@@ -36,7 +36,7 @@ const useClasses = makeStyles({
     backgroundColor: tokens.colorBrandStroke1,
     color: tokens.colorNeutralForegroundOnBrand,
 
-    ...shorthands.padding('4px'),
+    padding: '4px',
     borderTopLeftRadius: tokens.borderRadiusMedium,
     borderTopRightRadius: tokens.borderRadiusMedium,
   },

--- a/packages/docsite/stories/Icons/IconsDefault.stories.tsx
+++ b/packages/docsite/stories/Icons/IconsDefault.stories.tsx
@@ -1,11 +1,11 @@
-import { makeStyles, shorthands } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 import { SendRegular, SendFilled } from '@fluentui/react-icons';
 import * as React from 'react';
 
 const useClasses = makeStyles({
   container: {
     display: 'flex',
-    ...shorthands.gap('5px'),
+    gap: '5px',
   },
 
   icon24: { fontSize: '24px' },

--- a/packages/docsite/stories/Icons/IconsFontSize.stories.tsx
+++ b/packages/docsite/stories/Icons/IconsFontSize.stories.tsx
@@ -1,11 +1,11 @@
 import { AccessTimeFilled } from '@fluentui/react-icons';
-import { makeStyles, shorthands } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 import * as React from 'react';
 
 const useClasses = makeStyles({
   container: {
     display: 'flex',
-    ...shorthands.gap('10px'),
+    gap: '10px',
   },
 });
 

--- a/packages/docsite/stories/Icons/IconsStyling.stories.tsx
+++ b/packages/docsite/stories/Icons/IconsStyling.stories.tsx
@@ -1,11 +1,11 @@
 import { AccessTimeFilled, SendRegular } from '@fluentui/react-icons';
-import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
+import { makeStyles, tokens } from '@fluentui/react-components';
 import * as React from 'react';
 
 const useClasses = makeStyles({
   container: {
     display: 'flex',
-    ...shorthands.gap('10px'),
+    gap: '10px',
   },
 
   iconAccessTime: {

--- a/packages/docsite/stories/Icons/index.stories.tsx
+++ b/packages/docsite/stories/Icons/index.stories.tsx
@@ -1,5 +1,7 @@
 import { SendRegular } from '@fluentui/react-icons';
 import descriptionMd from './IconsDescription.md';
+import { reactIconsVersion } from '../utils/packageVersion';
+import { versionBadgeMarkup } from '../components/VersionBadge';
 
 export { Default } from './IconsDefault.stories';
 export { BundleIcon as bundleIcon } from './IconsBundleIcon.stories';
@@ -12,7 +14,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: descriptionMd,
+        component: `${versionBadgeMarkup({ packageName: '@fluentui/react-icons', version: reactIconsVersion })}\n\n${descriptionMd}`,
       },
     },
   },

--- a/packages/docsite/stories/components/VersionBadge.tsx
+++ b/packages/docsite/stories/components/VersionBadge.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+export interface VersionBadgeProps {
+  /** The npm package name, e.g. `@fluentui/react-icons`. */
+  packageName: string;
+  /** The package version, e.g. `2.0.331`. */
+  version: string;
+}
+
+/**
+ * A small pill showing a package name and its version.
+ *
+ * Styling lives in `.storybook/docs-root-v9.css` (`.fluent-version-badge`) rather than
+ * Griffel because this badge is serialized to an HTML string and injected into a
+ * Storybook docs `description` — so it renders as static markup (via markdown-to-jsx),
+ * not as a live React component. The docs page is wrapped in a `FluentProvider`
+ * (`webLightTheme`) by `@fluentui/react-storybook-addon`, so the `var(--color…)` Fluent
+ * tokens referenced by that CSS class resolve on the page.
+ */
+export const VersionBadge: React.FC<VersionBadgeProps> = ({ packageName, version }) => (
+  <span className="fluent-version-badge">
+    <span className="fluent-version-badge__name">{packageName}</span>
+    <span>v{version}</span>
+  </span>
+);
+
+/**
+ * Serializes {@link VersionBadge} to static HTML so it can be embedded into a
+ * Storybook docs `description` (which accepts a markdown/HTML string, not React).
+ */
+export const versionBadgeMarkup = (props: VersionBadgeProps): string =>
+  renderToStaticMarkup(<VersionBadge {...props} />);

--- a/packages/docsite/stories/globals.d.ts
+++ b/packages/docsite/stories/globals.d.ts
@@ -1,0 +1,4 @@
+// Injected at build time by webpack `DefinePlugin` (see `.storybook/main.ts`),
+// resolved from each package's `package.json` version.
+declare const STORYBOOK_REACT_ICONS_VERSION: string;
+declare const STORYBOOK_REACT_ICONS_FILE_TYPE_VERSION: string;

--- a/packages/docsite/stories/utils/packageVersion.ts
+++ b/packages/docsite/stories/utils/packageVersion.ts
@@ -1,0 +1,4 @@
+// Package versions injected at build time (see `.storybook/main.ts`). Used to
+// surface the documented package version on the Overview docs pages.
+export const reactIconsVersion = STORYBOOK_REACT_ICONS_VERSION;
+export const reactIconsFileTypeVersion = STORYBOOK_REACT_ICONS_FILE_TYPE_VERSION;


### PR DESCRIPTION
## Summary

Sets up linting for the `docsite` package and modernizes its Griffel usage, adds per-package version badges to the Overview docs pages, and aligns dependencies with the monorepo single-version policy.

## Changes

### ESLint
- Add a flat ESLint config (`packages/docsite/eslint.config.mjs`) mirroring `react-icons`: `typescript-eslint` recommended + `eslint-plugin-react-hooks` + `@griffel/eslint-plugin`.
- Griffel rules: `no-deprecated-shorthands` (native shorthands preferred) **and** `no-shorthands` (guards the border-group/`all` shorthands Griffel can't atomically expand). `styles-file` intentionally excluded — stories colocate `makeStyles`.
- Add a `lint` npm script and a cache-only `lint` target in `project.json`.

### Griffel modernization
- Replace the deprecated `shorthands.*` helper with native CSS shorthands (`gap`, `padding`, `` border: `…` ``) across all stories and drop the now-unused import.

### Icon styling
- Headless story: move the shared `color`/`fontSize` onto the container so icons inherit; inline styles are used only for genuine overrides (e.g. `Send`).

### Version badges
- Inject `@fluentui/react-icons` / `@fluentui/react-icons-file-type` versions at build time via a webpack `DefinePlugin` (read from each package's `package.json`).
- Render a `VersionBadge` React component into the Overview docs `description`; styling lives in `docs-root-v9.css` (`.fluent-version-badge`) using Fluent token CSS vars with literal fallbacks.

### Single-version policy
- Remove dependencies already declared in the root `package.json` from `docsite` (they resolve via npm workspace hoisting).

## Validation
- `npm run lint` (docsite) — passes
- `npm run build` (docsite storybook) — succeeds; version badges present on both Overview pages
