### PR TITLE
feat(react-icons): render data-fui-icon attribute on all icon factories

### DIFF
--- a/packages/docsite/stories/Icons/Recipes/TargetIconsFromCss.stories.tsx
+++ b/packages/docsite/stories/Icons/Recipes/TargetIconsFromCss.stories.tsx
@@ -1,0 +1,67 @@
+import { makeStyles, mergeClasses, tokens } from '@fluentui/react-components';
+import { AccessTimeFilled, CalendarLtrRegular, SendRegular, SettingsFilled } from '@fluentui/react-icons';
+import * as React from 'react';
+
+const useStyles = makeStyles({
+  // A single rule styles *every* descendant icon at once via the `data-fui-icon`
+  // attribute that all icons render — no per-icon className required.
+  toolbar: {
+    display: 'flex',
+    gap: '16px',
+    padding: '12px',
+    borderRadius: tokens.borderRadiusMedium,
+    backgroundColor: tokens.colorNeutralBackground3,
+    '& [data-fui-icon]': {
+      color: tokens.colorBrandForeground1,
+      fontSize: '32px',
+    },
+  },
+  // A second scope proves the selector is scoped to its container: these icons
+  // pick up a different color from the same attribute, with zero code changes
+  // on the icons themselves.
+  danger: {
+    '& [data-fui-icon]': {
+      color: tokens.colorPaletteRedForeground1,
+    },
+  },
+});
+
+export const TargetIconsFromCss = () => {
+  const styles = useStyles();
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', alignItems: 'flex-start' }}>
+      <div className={styles.toolbar}>
+        <AccessTimeFilled aria-label="Access time" />
+        <CalendarLtrRegular aria-label="Calendar" />
+        <SendRegular aria-label="Send" />
+        <SettingsFilled aria-label="Settings" />
+      </div>
+
+      <div className={mergeClasses(styles.toolbar, styles.danger)}>
+        <AccessTimeFilled aria-label="Access time" />
+        <CalendarLtrRegular aria-label="Calendar" />
+        <SendRegular aria-label="Send" />
+        <SettingsFilled aria-label="Settings" />
+      </div>
+    </div>
+  );
+};
+TargetIconsFromCss.storyName = 'Target every icon from CSS';
+TargetIconsFromCss.parameters = {
+  docs: {
+    description: {
+      story: [
+        'Every icon — SVG or font, `Filled`, `Regular`, sized or resizable — renders a **`data-fui-icon`** attribute.',
+        'That gives you one universal selector, `[data-fui-icon]`, to style *all* icons within a scope from a single CSS rule,',
+        'without adding a `className` to each icon.',
+        '',
+        'The two toolbars below share the same base rule (`& [data-fui-icon]` sets color + size); the second layers a scoped',
+        'override that recolors its icons — the icon markup is identical in both.',
+        '',
+        'The attribute name is also exported as the `DATA_FUI_ICON` constant. For more specific targeting, icons also carry the',
+        'class-name constants (`fui-Icon`, `fui-Icon-filled`, `fui-Icon-regular`, `fui-Icon-light`, `fui-Icon-color`, `fui-Icon-font`).',
+      ].join('\n'),
+    },
+  },
+};

--- a/packages/docsite/stories/Icons/Recipes/index.stories.tsx
+++ b/packages/docsite/stories/Icons/Recipes/index.stories.tsx
@@ -2,6 +2,7 @@ import { ShieldLock48Regular } from '@fluentui/react-icons';
 
 import descriptionMd from './RecipesDescription.md';
 
+export { TargetIconsFromCss } from './TargetIconsFromCss.stories';
 export { MultipleColors } from './MultipleColors.stories';
 export { ColorIdPrefix } from '../ColorVariants/ColorIdPrefix.stories';
 

--- a/packages/react-icons/src/core/useBaseIconState.ts
+++ b/packages/react-icons/src/core/useBaseIconState.ts
@@ -1,5 +1,6 @@
 import type * as React from 'react';
 import { useIconContext } from '../contexts';
+import { DATA_FUI_ICON } from '../utils/constants';
 import type { FluentIconsProps } from '../utils/FluentIconsProps.types';
 
 export type UseIconStateOptions = {
@@ -18,10 +19,11 @@ export type BaseIconState<
  * - strips non-DOM props (`filled`)
  * - maps `primaryFill` -> `fill`
  * - applies a11y (`title` -> `aria-label`, otherwise `aria-hidden`; `role="img"`)
+ * - sets the base `data-fui-icon` attribute so any icon is CSS-selectable
  * - resolves the RTL flip decision from icon context
  *
- * Callers layer their own className / `data-*` attribute styling on top, and
- * apply the visual RTL flip using `isRtlFlip`.
+ * Callers layer their own className / additional `data-*` attribute styling on
+ * top, and apply the visual RTL flip using `isRtlFlip`.
  */
 export const useBaseIconState = <
   TBaseAttributes extends
@@ -60,6 +62,9 @@ export const useBaseIconState = <
   } else {
     state['role'] = 'img';
   }
+
+  // Universal data attribute so any icon (SVG or font) can be targeted via `[data-fui-icon]`.
+  state[DATA_FUI_ICON] = '';
 
   return { state, isRtlFlip };
 };

--- a/packages/react-icons/src/headless/shared.ts
+++ b/packages/react-icons/src/headless/shared.ts
@@ -1,8 +1,8 @@
 // Data attribute names used by headless icons for CSS targeting.
 // The shipped styles.css file uses these attribute selectors for styling.
 
-/** Base data attribute applied to all icons (SVG and font). */
-export const DATA_FUI_ICON = 'data-fui-icon';
+// Base data attribute applied to all icons (SVG and font). Shared with the
+// default (Griffel) API — single source of truth lives in ../utils/constants.
 
 /** Data attribute applied to icons that should flip in RTL text direction. */
 export const DATA_FUI_ICON_RTL = 'data-fui-icon-rtl';
@@ -21,6 +21,7 @@ export {
   iconLightClassName,
   iconColorClassName,
   fontIconClassName,
+  DATA_FUI_ICON,
 } from '../utils/constants';
 
 // Re-export types

--- a/packages/react-icons/src/headless/useIconState.tsx
+++ b/packages/react-icons/src/headless/useIconState.tsx
@@ -1,5 +1,5 @@
 import type { FluentIconsProps } from './shared';
-import { DATA_FUI_ICON, DATA_FUI_ICON_RTL } from './shared';
+import { DATA_FUI_ICON_RTL } from './shared';
 import { useBaseIconState } from '../core/useBaseIconState';
 import type { UseIconStateOptions } from '../core/useBaseIconState';
 
@@ -25,8 +25,7 @@ export const useIconState = <
 ): Omit<FluentIconsProps<TBaseAttributes, TRefType>, 'primaryFill'> => {
   const { state, isRtlFlip } = useBaseIconState(props, options);
 
-  // Data attributes for CSS targeting
-  state[DATA_FUI_ICON] = '';
+  // Headless-only data attribute for RTL flip via CSS.
   if (isRtlFlip) {
     state[DATA_FUI_ICON_RTL] = '';
   }

--- a/packages/react-icons/src/utils/constants.tsx
+++ b/packages/react-icons/src/utils/constants.tsx
@@ -4,3 +4,9 @@ export const iconRegularClassName = 'fui-Icon-regular';
 export const iconLightClassName = 'fui-Icon-light';
 export const iconColorClassName = 'fui-Icon-color';
 export const fontIconClassName = 'fui-Icon-font';
+
+/**
+ * Data attribute applied to every icon (SVG and font) for CSS targeting.
+ * Enables selecting any icon from the catalogue via the `[data-fui-icon]` selector.
+ */
+export const DATA_FUI_ICON = 'data-fui-icon';

--- a/packages/react-icons/src/utils/icon-factories.test.tsx
+++ b/packages/react-icons/src/utils/icon-factories.test.tsx
@@ -23,6 +23,7 @@ describe('React component tests', () => {
         <svg
           aria-hidden="true"
           class="fui-Icon ___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
+          data-fui-icon=""
           fill="currentColor"
           height="1em"
           viewBox="0 0 20 20"
@@ -49,6 +50,7 @@ describe('React component tests', () => {
         <i
           aria-hidden="true"
           class="fui-Icon-font ___qaf4230_1r6c92s f14t3ns0 fne0op0 fmd4ok8 f303qgw f1sxfq9t"
+          data-fui-icon=""
           fill="currentColor"
         />
       </div>


### PR DESCRIPTION
## Summary

Backports the `data-fui-icon` attribute from the headless (`base`) API to the default Griffel-powered icon factories, so **any** icon in the catalogue can be matched with a single CSS selector: `[data-fui-icon]`.

Previously only the headless API emitted `data-fui-icon`; the default SVG and font components exposed only class names (`fui-Icon`, `fui-Icon-font`), which made "select every icon" selectors awkward and inconsistent across the two APIs.

## What changed

- Added a single `DATA_FUI_ICON = 'data-fui-icon'` constant in `utils/constants.tsx` (now the single source of truth; re-exported from `headless/shared.ts`).
- The shared `core/useBaseIconState` hook now sets `data-fui-icon=""` once, so both the default and headless `useIconState` hooks inherit it without duplication.
- The default SVG factory, `wrapIcon`, and the default font factory all now render `data-fui-icon` (font icons keep their headless `data-fui-icon="font"` override).
- Updated the two inline snapshots in `utils/icon-factories.test.tsx`.

## Scope / decisions

- **Additive only** — Griffel still drives all visuals. This attribute exists purely for consumer CSS targeting.
- Intentionally **only** `data-fui-icon` is backported. RTL flip, font-variant selection, and bundle visibility remain Griffel-driven in the default API, so `data-fui-icon-rtl` / `-font` / `-hidden` are **not** added there (they would be noise for Griffel factories).
- No `fui-Icon` class was added to font `<i>` elements — `[data-fui-icon]` is the universal selector, avoiding any class-contract breaking change.

## Testing

- `npx vitest run` for `utils/icon-factories.test.tsx` and `headless/headless.test.tsx` — all pass (34 tests).
- No type or lint errors on changed files.
