### PR TITLE
fix(react-icons): honor fontSize prop on resizable font icons (SVG/font parity)

### DIFF
--- a/packages/react-icons/src/core/fontIcon.ts
+++ b/packages/react-icons/src/core/fontIcon.ts
@@ -10,7 +10,7 @@ import * as React from 'react';
 export const applyFontStyle = (
   state: { style?: React.CSSProperties },
   primaryFill: string | undefined,
-  fontSize: number | undefined,
+  fontSize: number | string | undefined,
 ): void => {
   if (primaryFill && primaryFill.toLowerCase() !== 'currentcolor') {
     state.style = {

--- a/packages/react-icons/src/headless/fonts/createFluentFontIcon.tsx
+++ b/packages/react-icons/src/headless/fonts/createFluentFontIcon.tsx
@@ -40,9 +40,11 @@ export function createFluentFontIcon(
   options?: CreateFluentFontIconOptions,
 ): FluentFontIcon {
   const Component: FluentFontIcon = (props) => {
+    // `fontSize` is applied as a CSS style below, so keep it off the spread onto the `<i>` element.
+    const { fontSize: fontSizeOverride, ...rest } = props;
     const className = cx(fontIconClassName, props.className);
     const state = useIconState<React.HTMLAttributes<HTMLElement>, HTMLElement>(
-      { ...props, className },
+      { ...rest, className },
       { flipInRtl: options?.flipInRtl },
     );
 
@@ -50,8 +52,10 @@ export function createFluentFontIcon(
     state[DATA_FUI_ICON] = 'font';
     state[DATA_FUI_ICON_FONT] = FONT_VARIANT_MAP[font];
 
-    // Map primaryFill to color for font icons
-    applyFontStyle(state, props.primaryFill, fontSize);
+    // Map primaryFill to color for font icons. Only resizable icons (no baked-in size) honor a
+    // `fontSize` prop; sized icons keep their baked-in size, mirroring sized SVG icons whose
+    // hardcoded width/height ignore `font-size`.
+    applyFontStyle(state, props.primaryFill, fontSize === undefined ? fontSizeOverride : fontSize);
 
     return renderFontBody(state, codepoint);
   };

--- a/packages/react-icons/src/utils/FluentIconsProps.types.ts
+++ b/packages/react-icons/src/utils/FluentIconsProps.types.ts
@@ -24,4 +24,14 @@ export type FluentIconsProps<
      * NOTE: This prop only applies to `Color` icon variants; it is ignored by mono-color icons.
      */
     idPrefix?: string;
+    /**
+     * Sets the rendered size of a **resizable** icon. For SVG icons this maps to the `font-size`
+     * presentation attribute (the icon is `1em`); for font icons it maps to the `font-size` CSS
+     * style. Exposing it on both keeps the prop working when an icon is switched between the SVG
+     * and font variants.
+     *
+     * NOTE: **Sized** variants (e.g. `Send24Regular`) render at their fixed design size and ignore
+     * this prop in both SVG and font form.
+     */
+    fontSize?: string | number;
   };

--- a/packages/react-icons/src/utils/fonts/createFluentFontIcon.tsx
+++ b/packages/react-icons/src/utils/fonts/createFluentFontIcon.tsx
@@ -27,14 +27,18 @@ export function createFluentFontIcon(
   const Component: FluentFontIcon = (props) => {
     useStaticStyles();
     const styles = useRootStyles();
+    // `fontSize` is applied as a CSS style below, so keep it off the spread onto the `<i>` element.
+    const { fontSize: fontSizeOverride, ...rest } = props;
     const className = mergeClasses(styles.root, styles[font], fontIconClassName, props.className);
     const state = useIconState<React.HTMLAttributes<HTMLElement>, HTMLElement>(
-      { ...props, className },
+      { ...rest, className },
       { flipInRtl: options?.flipInRtl },
     );
 
-    // We want to keep the same API surface as the SVG icons, so translate `primaryFill` to `color`
-    applyFontStyle(state, props.primaryFill, fontSize);
+    // We want to keep the same API surface as the SVG icons, so translate `primaryFill` to `color`.
+    // Only resizable icons (no baked-in size) honor a `fontSize` prop; sized icons keep their
+    // baked-in size, mirroring sized SVG icons whose hardcoded width/height ignore `font-size`.
+    applyFontStyle(state, props.primaryFill, fontSize === undefined ? fontSizeOverride : fontSize);
 
     return renderFontBody(state, codepoint);
   };

--- a/packages/react-icons/src/utils/icon-factories.test.tsx
+++ b/packages/react-icons/src/utils/icon-factories.test.tsx
@@ -57,6 +57,34 @@ describe('React component tests', () => {
     `);
   });
 
+  test('createFontIcon applies the `fontSize` prop as a CSS style (API parity with SVG icons)', () => {
+    const AccessTimeRegular: FluentFontIcon = createFluentFontIcon('AccessTimeRegular', '', 2, undefined);
+
+    const { container } = render(<AccessTimeRegular fontSize="32px" />);
+    const i = container.querySelector('i');
+
+    expect(i).toBeTruthy();
+    expect(i).toHaveStyle({ fontSize: '32px' });
+    // The prop must NOT leak onto the element as an (inert) DOM attribute.
+    expect(i).not.toHaveAttribute('fontSize');
+    expect(i).not.toHaveAttribute('fontsize');
+  });
+
+  test('createFontIcon sized icons ignore the `fontSize` prop and keep their baked-in size (parity with sized SVG)', () => {
+    // A non-undefined baked size marks a *sized* icon (e.g. Send24Regular).
+    const Send24Regular: FluentFontIcon = createFluentFontIcon('Send24Regular', '', 1, 24);
+
+    // No prop -> baked-in size is used.
+    const withDefault = render(<Send24Regular />).container.querySelector('i');
+    expect(withDefault).toHaveStyle({ fontSize: '24px' });
+
+    // `fontSize` prop is ignored: sized icons are fixed-size, matching sized SVG icons
+    // (whose hardcoded width/height ignore font-size), so a SVG->font swap stays consistent.
+    const withProp = render(<Send24Regular fontSize={16} />).container.querySelector('i');
+    expect(withProp).toHaveStyle({ fontSize: '24px' });
+    expect(withProp).not.toHaveAttribute('fontsize');
+  });
+
   test('createFluentIcon renders an SVG with expected path', () => {
     const d = 'M1 2 L3 4';
     const MyIcon = createFluentIcon('MyIcon', '1em', [d]);


### PR DESCRIPTION
## Summary

The `fontSize` prop resized **SVG** icons (it's a valid SVG `font-size` presentation attribute, and the icon is `1em`) but was a **no-op on font icons** — the font factory only applied its baked-in size, and any `fontSize` prop leaked onto the `<i>` as an inert HTML attribute.

That breaks a real scenario: when an icon is switched from the SVG to the font variant (e.g. via a bundler loader / barrel import), a consumer's `fontSize` prop silently stops sizing it.

This PR makes the prop behave consistently across both variants.

## Behavior

Both font factories (Griffel and headless) now map a `fontSize` prop to the `font-size` CSS style. To keep the SVG↔font swap transparent, the rule mirrors the SVG side exactly:

| variant | `fontSize` prop | SVG | font |
|---|---|---|---|
| **resizable** (`SendRegular`) | honored | `1em` scales with `font-size` | `style.fontSize` |
| **sized** (`Send24Regular`) | **ignored** | hardcoded `width`/`height` px | baked-in design size |

Only **resizable** font icons honor the prop. **Sized** font icons keep their baked-in design size — matching sized SVG icons, whose hardcoded `width`/`height` already ignore `font-size`. So an (accidental) `fontSize` on a sized icon is a no-op in *both* variants, and the swap stays visually identical.

## Changes

- `src/utils/fonts/createFluentFontIcon.tsx` + `src/headless/fonts/createFluentFontIcon.tsx` — pull `fontSize` off props and apply it via `applyFontStyle`, gated on the icon being resizable (`bakedFontSize === undefined ? propFontSize : bakedFontSize`).
- `src/core/fontIcon.ts` — `applyFontStyle` accepts `number | string`.
- `src/utils/FluentIconsProps.types.ts` — documents `fontSize?: string | number` (with a note that sized variants ignore it).
- `src/utils/icon-factories.test.tsx` — tests: resizable applies the prop (and doesn't leak it as an attribute); sized ignores it.

## Testing

- `nx run react-icons:test` — 90 passing (icon-factories: 13).
- `nx run react-icons:build-verify` — 135 passing.

## Note

Split out from #1145 (the font-icon `1em` box / CLS fix); this change is independent of it.
