### PR TITLE
ci: replace `eskatos/gradle-command-action`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -106,13 +106,17 @@ jobs:
           distribution: temurin
           java-version: 11
 
-      # https://github.com/marketplace/actions/gradle-command
-      - name: Build Android library
-        uses: eskatos/gradle-command-action@v1
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
         with:
-          arguments: assembleRelease
-          build-root-directory: android
-          wrapper-directory: android
+          gradle-version: wrapper
+          gradle-home-cache-excludes: |
+            caches
+            jdks
+
+      - name: Build Android library
+        run: ./gradlew assembleRelease
+        working-directory: android
 
       - name: Generate BUILD.gn file for Android
         run: python3 generate_build_gn_android.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -229,6 +229,14 @@ jobs:
           distribution: temurin
           java-version: 11
 
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          gradle-version: wrapper
+          gradle-home-cache-excludes: |
+            caches
+            jdks
+
       # - name: Base64 decodes and pipes the GPG key content into the secret file
       #   env:
       #     GPG_KEY_CONTENT: ${{ secrets.GPG_KEY_CONTENT }}
@@ -238,16 +246,12 @@ jobs:
       #     sudo bash -c "echo '$GPG_KEY_CONTENT' | base64 -d > '$SIGNING_SECRET_KEY_RING_FILE'"
 
       - name: Build Android library
-        uses: eskatos/gradle-command-action@v1
-        with:
-          arguments: assembleRelease -DversionName='${{ env.NEW_VERSION }}'
-          build-root-directory: android
-          wrapper-directory: android
+        run: ./gradlew assembleRelease -DversionName='${{ env.NEW_VERSION }}'
+        working-directory: android
 
       # Temporarily commenting out the publishing to Maven Central, as it is blocking the release for other platforms
       # - name: Publish to Maven Central
       #   if: ${{ !inputs.dry-run }}
-      #   uses: eskatos/gradle-command-action@v1
       #   env:
       #     OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
       #     OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -256,10 +260,8 @@ jobs:
       #     SIGNING_SECRET_KEY_RING_FILE: ${{ secrets.SIGNING_SECRET_KEY_RING_FILE }}
       #     SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
       #     VERSION_NAME: ${{ env.NEW_VERSION }}
-      #   with:
-      #     arguments: publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
-      #     build-root-directory: android
-      #     wrapper-directory: android
+      #   run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
+      #   working-directory: android
 
       - name: Generate BUILD.gn file for Android
         run: python3 generate_build_gn_android.py
@@ -375,17 +377,22 @@ jobs:
   #       distribution: temurin
   #       java-version: 8
 
+  #   - name: Set up Gradle
+  #     uses: gradle/actions/setup-gradle@v5
+  #     with:
+  #       gradle-version: wrapper
+  #       gradle-home-cache-excludes: |
+  #         caches
+  #         jdks
+
   #   - name: Restore release keystore
   #     run: |
   #       echo "${{ secrets.ANDROID_KEYSTORE }}" > release.keystore.asc
   #       gpg -d --passphrase "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" --batch release.keystore.asc > release.keystore
 
   #   - name: Build Android demo app
-  #     uses: eskatos/gradle-command-action@v1
-  #     with:
-  #       arguments: ':sample-showcase:assembleRelease -DversionName=${{ env.NEW_VERSION }} -DversionCode=${{ github.run_number }} -Pandroid.injected.signing.store.file=/home/runner/work/fluentui-system-icons/fluentui-system-icons/release.keystore -Pandroid.injected.signing.store.password=${{ secrets.ANDROID_KEYSTORE_PASSWORD }} -Pandroid.injected.signing.key.alias=${{ secrets.ANDROID_KEYSTORE_ALIAS }} -Pandroid.injected.signing.key.password=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}'
-  #       build-root-directory: android
-  #       wrapper-directory: android
+  #     run: ./gradlew :sample-showcase:assembleRelease -DversionName=${{ env.NEW_VERSION }} -DversionCode=${{ github.run_number }} -Pandroid.injected.signing.store.file=/home/runner/work/fluentui-system-icons/fluentui-system-icons/release.keystore -Pandroid.injected.signing.store.password=${{ secrets.ANDROID_KEYSTORE_PASSWORD }} -Pandroid.injected.signing.key.alias=${{ secrets.ANDROID_KEYSTORE_ALIAS }} -Pandroid.injected.signing.key.password=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+  #     working-directory: android
 
   #   - name: Publish apk to App Center
   #     uses: wzieba/AppCenter-Github-Action@v1.0.0


### PR DESCRIPTION
Replaces defunct `eskatos/gradle-command-action` with the official `gradle/actions/setup-gradle` and explicit `gradlew` invocation.

- Closes https://github.com/microsoft/fluentui-system-icons/pull/1042