### PR TITLE
fix(react-icons): resolve [data-fui-icon-hidden] specificity ordering

### DIFF
--- a/packages/react-icons/src/headless/styles.css
+++ b/packages/react-icons/src/headless/styles.css
@@ -13,6 +13,14 @@
   }
 }
 
+/* ===== Font Icon Defaults ===== */
+[data-fui-icon='font'] {
+  display: inline-block;
+  font-style: normal;
+  line-height: 1em;
+  color: currentColor;
+}
+
 /* ===== RTL Directional Flip ===== */
 [data-fui-icon-rtl] {
   transform: scaleX(-1);
@@ -21,14 +29,6 @@
 /* ===== bundleIcon: Hidden Variant ===== */
 [data-fui-icon-hidden] {
   display: none;
-}
-
-/* ===== Font Icon Defaults ===== */
-[data-fui-icon='font'] {
-  display: inline-block;
-  font-style: normal;
-  line-height: 1em;
-  color: currentColor;
 }
 
 /* ===== Font Icon Family Variants ===== */


### PR DESCRIPTION
## Summary:
- move the font icon defaults block above hidden-state rules in headless styles
- ensure `[data-fui-icon-hidden]` wins in the cascade when an icon is also marked as a font icon

## Problem:

`[data-fui-icon=font]` and `[data-fui-icon-hidden]` have equivalent specificity. When font defaults are declared later, they override hidden behavior depending on order.

## Fix:

Reorder selectors so the hidden rule is evaluated after the font defaults, preserving expected hidden behavior.

Validation:
- reviewed resulting cascade in packages/react-icons/src/headless/styles.css