### PR TITLE
ci: prevent orphaned release tags on main push race

### DIFF
--- a/.github/workflows/publish-standalone.yml
+++ b/.github/workflows/publish-standalone.yml
@@ -144,29 +144,48 @@ jobs:
             git commit -m "chore(release): publish standalone packages [skip ci]"
           fi
 
-      - name: Tag releases
-        # Tags are created manually (git.tag: false in nx.json) after the final commit so they point
-        # at the release commit that also includes the lockfile update — nx would otherwise tag before
-        # that commit is finalized. nx.json uses granular `version.git`/`changelog.git` config, which
-        # the unified `nx release` command (the only variant that natively skips unchanged packages
-        # when tagging) refuses to run with; migrating to top-level `release.git` would also alter the
-        # sub-command flow that publish.yml depends on. So we tag here, over the already-filtered
-        # released set (see "Resolve released projects") — so an unchanged/already-tagged package can
-        # never abort the job, and re-runs after a partial failure only create the missing tags.
+      - name: Push release commit
         if: ${{ !inputs.dry-run }}
         run: |
+          set -euo pipefail
+          # Re-sync ONLY here (never rebuild): replay the already-built release commit onto
+          # the latest main. main can advance during the long build via any writer — another
+          # automated job or a PR merge. Those changes are normally disjoint from a release
+          # commit, so this replays cleanly and keeps the just-published artifacts byte-for-
+          # byte. A genuine conflict aborts the job instead of silently mutating a published
+          # artifact.
+          git fetch origin main
+          git rebase origin/main
+          # Branch FIRST: push the commit, then (in the next step) tag the SHA now guaranteed
+          # on main. This ordering makes an orphaned tag impossible and fails closed if main
+          # moved in the interim — just re-run to retry.
+          git push origin HEAD:main
+
+      - name: Tag releases
+        # Tags are created manually (git.tag: false in nx.json) AFTER the release commit is
+        # pushed to main (previous step), so each tag points at a SHA already on main — an
+        # orphaned tag (tag without its commit on main) is therefore impossible. Tagging after
+        # the rebase/push also guarantees the tag targets the rebased commit, not a stale SHA.
+        # nx.json uses granular `version.git`/`changelog.git` config, which the unified
+        # `nx release` command (the only variant that natively skips unchanged packages when
+        # tagging) refuses to run with; migrating to top-level `release.git` would also alter
+        # the sub-command flow that publish.yml depends on. So we tag here, over the already-
+        # filtered released set (see "Resolve released projects") — so an unchanged/already-
+        # tagged package can never abort the job, and re-runs after a partial failure only
+        # create the missing tags. Tags are pushed explicitly (never --tags/--follow-tags,
+        # which push tags independently of the branch, so a rejected branch push could still
+        # leave a tag pointing at a commit not on main).
+        if: ${{ !inputs.dry-run }}
+        run: |
+          set -euo pipefail
           for pkg in $(echo "${{ steps.released.outputs.names }}" | tr ',' '\n'); do
             [ -z "$pkg" ] && continue
             VERSION=$(node -p "require('./packages/${pkg}/package.json').version")
             TAG="${pkg}@${VERSION}"
-            echo "Creating tag: $TAG"
+            echo "Creating and pushing tag: $TAG"
             git tag "$TAG"
+            git push origin "refs/tags/$TAG"
           done
-
-      - name: Push release
-        if: ${{ !inputs.dry-run }}
-        run: |
-          git push origin HEAD:main --follow-tags --tags
 
       - name: Dry-run summary
         if: ${{ inputs.dry-run }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -279,14 +279,26 @@ jobs:
           git add -A
           git commit -m "chore(release): publish $NEW_VERSION [skip ci]"
 
-      - name: Tag release
-        if: ${{ !inputs.dry-run }}
-        run: git tag "$NEW_VERSION"
-
       - name: Push release
         if: ${{ !inputs.dry-run }}
         run: |
-          git push origin HEAD:main --follow-tags --tags
+          set -euo pipefail
+          # Re-sync ONLY here (never rebuild): replay the already-built release commit onto
+          # the latest main. main can advance during the long build via any writer — another
+          # automated job or a PR merge. Those changes are normally disjoint from a release
+          # commit, so this replays cleanly and keeps the just-published artifacts byte-for-
+          # byte. A genuine conflict aborts the job instead of silently mutating a published
+          # artifact.
+          git fetch origin main
+          git rebase origin/main
+          # Branch FIRST, tag SECOND: push the commit, then tag the SHA now guaranteed on
+          # main. This ordering makes an orphaned tag (tag without its commit on main)
+          # impossible, and fails closed if main moved in the interim — just re-run to retry.
+          # (Do NOT use --tags/--follow-tags: they push tags independently of the branch, so
+          # a rejected branch push can still leave a tag pointing at a commit not on main.)
+          git push origin HEAD:main
+          git tag "$NEW_VERSION"
+          git push origin "refs/tags/$NEW_VERSION"
 
       - name: Trigger CocoaPods publish
         if: ${{ !inputs.dry-run }}


### PR DESCRIPTION
## Problem

The release workflows push the release commit and tag with `git push origin HEAD:main --follow-tags --tags`. Because that sends the branch and tag as independent refspecs, a **non-fast-forward rejection of the branch update does not stop the tag from being pushed**. If `main` advances during the long release build (via another automated writer *or* a PR merge), the branch push is rejected but the tag still lands — leaving a release tag pointing at a commit that never made it onto `main` (orphaned tag / out-of-sync repo).

## Fix

For both `publish.yml` and `publish-standalone.yml`, change the push contract to **branch-first, tag-second**, with a re-sync at push time:

1. `git fetch origin main` + `git rebase origin/main` — replay the already-built release commit onto the latest `main`.
2. `git push origin HEAD:main` — push the **branch first**.
3. Create the tag(s) and push them explicitly — **only after** the commit is confirmed on `main`.

Dropped `--follow-tags --tags` entirely.

## Why this is safe

- **Orphaned tag impossible** — a tag is only created/pushed after its commit is on `main`.
- **Fails closed** — if `main` moves in the tiny rebase→push window, the branch push is rejected and `set -euo pipefail` aborts *before* any tag is pushed. Just re-run.
- **Idempotency preserved** — the rebase only *replays* the already-built commit (no rebuild); changes on `main` are normally disjoint from a release commit, so published artifacts stay byte-for-byte identical. A genuine conflict aborts rather than silently mutating a published artifact.
- Complements the existing `main-writer` concurrency group (which serializes automated writers but cannot cover human PR merges).

## Notes

- Minimal version by design: no retry loop, no `--atomic` (deliberately avoided — not portable, and unnecessary given the ordering guarantee), no post-push assertion. All are easy optional follow-ups.
- `publish-standalone.yml` keeps its idempotent "tag already exists → skip" behavior; a re-run after a partial failure only creates the missing tags.

## Related issues

- https://github.com/microsoft/fluentui-system-icons/pull/1157
- https://github.com/microsoft/fluentui-system-icons/actions/runs/29118043696
