### PR TITLE
chore(tooling): run prettier on yaml files in pre-commit hook

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,6 +34,7 @@ ios/ @nickromano
 package-lock.json @microsoft/cxe-prg
 package.json @microsoft/cxe-prg
 nx.json @microsoft/cxe-prg
+nano-staged.js @microsoft/cxe-prg
 monosize.config.mjs @microsoft/cxe-prg
 .prettierignore @microsoft/cxe-prg
 .prettierrc @microsoft/cxe-prg

--- a/nano-staged.js
+++ b/nano-staged.js
@@ -2,5 +2,5 @@
 'use strict';
 
 module.exports = {
-  '**/*.{ts,tsx,js,mjs,cjs,json,md,mdx,css,html}': 'prettier --write',
+  '**/*.{ts,tsx,js,mjs,cjs,json,md,mdx,css,html,yml,yaml}': 'prettier --write',
 };


### PR DESCRIPTION
## Summary

Adds `yml`/`yaml` to the nano-staged (pre-commit) Prettier glob.

## Why

The pre-commit hook only ran Prettier on `**/*.{ts,tsx,js,mjs,cjs,json,md,mdx,css,html}`, so `.yml`/`.yaml` files (e.g. GitHub Actions workflows) were never auto-formatted locally. CI's `nx format:check` checks *all* files, so YAML formatting issues were only surfaced in CI instead of being fixed at commit time.

## Change

```diff
-  '**/*.{ts,tsx,js,mjs,cjs,json,md,mdx,css,html}': 'prettier --write',
+  '**/*.{ts,tsx,js,mjs,cjs,json,md,mdx,css,html,yml,yaml}': 'prettier --write',
```

This aligns the local pre-commit hook with what CI enforces.
