### PR TITLE
feat(react-icons-atomic-webpack-loader): warn on un-atomizable dynamic barrel imports

### DIFF
--- a/packages/react-icons-atomic-webpack-loader/README.md
+++ b/packages/react-icons-atomic-webpack-loader/README.md
@@ -247,6 +247,29 @@ flowchart TD
 
 Files that don't reference a supported module are passed through untouched (fast pre-check).
 
+## Limitations
+
+### Dynamic imports are not atomized
+
+The loader only rewrites **static** `import` / `export … from` declarations. A dynamic `import()` of a barrel cannot be atomized, because the returned module-namespace object is a runtime value whose usage the loader cannot statically prove:
+
+```js
+// ⚠️ Not rewritten — the ENTIRE icon set is pulled into the async chunk.
+const { AddFilled } = await import('@fluentui/react-icons');
+React.lazy(() => import('@fluentui/react-icons'));
+```
+
+When it detects a dynamic import of a supported barrel, the loader emits a warning. Import the atomic path directly instead — then you lazy-load only the icons you use:
+
+```js
+// ✅ Only this icon lands in the async chunk.
+const { AddFilled } = await import('@fluentui/react-icons/svg/add');
+```
+
+Alternatively, move the icons behind a local module that statically imports them; the loader atomizes that module, and only your lazy chunk pays for what it uses.
+
+> The same applies to full-barrel subpaths (`@fluentui/react-icons/svg`, `@fluentui/react-icons/fonts`) — dynamically importing those also bundles the whole set. Always target a per-icon atomic path.
+
 ## Requirements
 
 - `webpack` >= 5

--- a/packages/react-icons-atomic-webpack-loader/src/transform.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/transform.ts
@@ -7,6 +7,7 @@ import {
   resolveColorVariant,
   resolveModuleHeadless,
   isColorIconName,
+  SUPPORTED_MODULE_NAMES,
 } from './modules';
 import type { IconVariant, ModuleDescriptor } from './modules';
 
@@ -50,7 +51,7 @@ export function transformSource(source: string, options: TransformOptions): Tran
     throw new Error(result.errors[0].message);
   }
 
-  const { staticImports, staticExports } = result.module;
+  const { staticImports, staticExports, dynamicImports } = result.module;
   const src = new MagicString(source);
 
   const diagnostics: Diagnostic[] = [];
@@ -187,6 +188,36 @@ export function transformSource(source: string, options: TransformOptions): Tran
     if (lines.length === 0) continue;
 
     src.overwrite(exp.start, exp.end, lines.join('\n'));
+  }
+
+  // Dynamic imports of a barrel (`import('@fluentui/react-icons')`) cannot be
+  // atomized: the returned namespace object is a runtime value whose usage is
+  // not statically known, so the whole icon set ends up in the async chunk. We
+  // can't rewrite it safely, but we can warn and point at the atomic escape
+  // hatch (`import('@fluentui/react-icons/svg/add')`). Atomic and subpath
+  // requests don't match a barrel descriptor, so they never warn.
+  for (const dyn of dynamicImports) {
+    const request = dyn.moduleRequest;
+    if (!request) continue;
+
+    // Unlike static imports, oxc doesn't resolve a dynamic import's argument to a
+    // specifier value — it's an arbitrary expression. Match the raw span against
+    // each supported module's quoted spellings; this naturally ignores variables,
+    // interpolated templates, and subpath/atomic requests (module names never
+    // contain quotes).
+    const raw = source.slice(request.start, request.end);
+    const moduleName = SUPPORTED_MODULE_NAMES.find(
+      (name) => raw === `'${name}'` || raw === `"${name}"` || raw === `\`${name}\``,
+    );
+    if (!moduleName) continue;
+
+    pushDiagnostic({
+      level: 'warning',
+      message:
+        `dynamic import of the "${moduleName}" barrel cannot be atomized, so the entire icon ` +
+        `set will be bundled into the async chunk. Import an atomic path directly instead, ` +
+        `e.g. import('${moduleName}/svg/add').`,
+    });
   }
 
   return {

--- a/packages/react-icons-atomic-webpack-loader/test/src/dynamic-barrel-imports.js
+++ b/packages/react-icons-atomic-webpack-loader/test/src/dynamic-barrel-imports.js
@@ -1,0 +1,23 @@
+// Dynamic barrel imports — the loader canNOT atomize these (a dynamic import()
+// returns a runtime namespace whose usage isn't statically known), so each
+// barrel import below should surface a warning.
+
+// System icons barrel via top-level await + destructure.
+async function loadSystem() {
+  const { AddFilled } = await import('@fluentui/react-icons');
+  return AddFilled;
+}
+
+// Brand icons barrel via .then() member access.
+function loadBrand() {
+  return import('@fluentui/react-brand-icons').then((m) => m.ProjectColor);
+}
+
+// Atomic deep path — this one must NOT warn (already atomic). Uses a distinct
+// icon so it's obvious the warnings above are only for the barrel imports.
+async function loadAtomic() {
+  const { ArrowLeftRegular } = await import('@fluentui/react-icons/svg/arrow-left');
+  return ArrowLeftRegular;
+}
+
+console.log(loadSystem, loadBrand, loadAtomic);

--- a/packages/react-icons-atomic-webpack-loader/test/transform.test.ts
+++ b/packages/react-icons-atomic-webpack-loader/test/transform.test.ts
@@ -481,4 +481,76 @@ describe('transformSource', () => {
       expect(diagnostics).toHaveLength(1);
     });
   });
+
+  describe('dynamic imports (cannot be atomized)', () => {
+    it('warns and leaves a dynamic barrel import untouched', () => {
+      const source = `const icons = await import('@fluentui/react-icons');`;
+
+      const { code, diagnostics } = transformSource(source, { iconVariant: 'svg', path: 'input.js' });
+
+      expect(code).toBe(source);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0].level).toBe('warning');
+      expect(diagnostics[0].message).toMatchInlineSnapshot(
+        `"dynamic import of the "@fluentui/react-icons" barrel cannot be atomized, so the entire icon set will be bundled into the async chunk. Import an atomic path directly instead, e.g. import('@fluentui/react-icons/svg/add')."`,
+      );
+    });
+
+    it('warns for a dynamic brand-icons barrel import', () => {
+      const { diagnostics } = transformSource(`import('@fluentui/react-brand-icons').then(m => m.ProjectColor);`, {
+        iconVariant: 'svg',
+        path: 'input.js',
+      });
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0].level).toBe('warning');
+      expect(diagnostics[0].message).toMatchInlineSnapshot(
+        `"dynamic import of the "@fluentui/react-brand-icons" barrel cannot be atomized, so the entire icon set will be bundled into the async chunk. Import an atomic path directly instead, e.g. import('@fluentui/react-brand-icons/svg/add')."`,
+      );
+    });
+
+    it('does not warn for a dynamic import of an atomic path', () => {
+      const source = `const { AddFilled } = await import('@fluentui/react-icons/svg/add');`;
+
+      const { code, diagnostics } = transformSource(source, { iconVariant: 'svg', path: 'input.js' });
+
+      expect(code).toBe(source);
+      expect(diagnostics).toEqual([]);
+    });
+
+    it('does not warn for a dynamic import of a subpath barrel (not a supported bare module)', () => {
+      const { diagnostics } = transformSource(`const m = await import('@fluentui/react-icons/svg');`, {
+        iconVariant: 'svg',
+        path: 'input.js',
+      });
+
+      expect(diagnostics).toEqual([]);
+    });
+
+    it('does not warn for a dynamic import with a non-static specifier', () => {
+      const source = [`const pkg = '@fluentui/react-icons';`, `const m = await import(pkg);`].join('\n');
+
+      const { diagnostics } = transformSource(source, { iconVariant: 'svg', path: 'input.js' });
+
+      expect(diagnostics).toEqual([]);
+    });
+
+    it('warns once per dynamic barrel and still rewrites sibling static imports', () => {
+      const source = [
+        `import { AddFilled } from '@fluentui/react-icons';`,
+        `const lazy = () => import('@fluentui/react-icons');`,
+      ].join('\n');
+
+      const { code, diagnostics } = transformSource(source, { iconVariant: 'svg', path: 'input.js' });
+
+      expect(code).toBe(
+        [
+          `import { AddFilled } from '@fluentui/react-icons/svg/add';`,
+          `const lazy = () => import('@fluentui/react-icons');`,
+        ].join('\n'),
+      );
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0].level).toBe('warning');
+    });
+  });
 });

--- a/packages/react-icons-atomic-webpack-loader/test/webpack.config.js
+++ b/packages/react-icons-atomic-webpack-loader/test/webpack.config.js
@@ -2,6 +2,18 @@
 const { resolve } = require('path');
 const { readFileSync } = require('fs');
 
+/**
+ * @typedef {object} EntryConfig
+ * @property {string} src Entry source file, relative to this config.
+ * @property {object} loaderOptions Options passed to the atomic import loader.
+ * @property {string[]} mustInclude Substrings the emitted bundle must contain.
+ * @property {string[]} mustExclude Substrings the emitted bundle must NOT contain.
+ * @property {string[]} [mustWarn] Substrings each of which must appear in at least
+ *   one emitted build warning. When set, all warnings are also printed so they are
+ *   directly visible in the test output.
+ */
+
+/** @type {Record<string, EntryConfig>} */
 const entries = {
   'svg-imports': {
     src: './src/svg-imports.js',
@@ -147,11 +159,26 @@ const entries = {
     mustInclude: ['@fluentui/react-icons/svg/add', '@fluentui/react-icons/svg/arrow-left'],
     mustExclude: ['"@fluentui/react-icons"'],
   },
+
+  'dynamic-barrel-imports': {
+    src: './src/dynamic-barrel-imports.js',
+    loaderOptions: {},
+    // Dynamic imports are code-split into separate async chunks and left
+    // untouched by the loader, so there is nothing to assert on the main bundle
+    // content — the point of this fixture is the emitted warnings below.
+    mustInclude: [],
+    mustExclude: [],
+    // Each barrel dynamic import must surface a warning; the atomic one must not.
+    mustWarn: [
+      'dynamic import of the "@fluentui/react-icons" barrel cannot be atomized',
+      'dynamic import of the "@fluentui/react-brand-icons" barrel cannot be atomized',
+    ],
+  },
 };
 
 /**
  * @param {string} name
- * @param {typeof entries[keyof typeof entries]} entry
+ * @param {EntryConfig} entry
  * @returns {import('webpack').Configuration}
  */
 function createConfig(name, entry) {
@@ -201,7 +228,7 @@ function createConfig(name, entry) {
     plugins: [
       {
         apply(compiler) {
-          compiler.hooks.afterEmit.tap('verify-transforms', () => {
+          compiler.hooks.afterEmit.tap('verify-transforms', (compilation) => {
             const outputPath = resolve(__dirname, 'dist', name, `${name}.js`);
             const output = readFileSync(outputPath, 'utf8');
 
@@ -214,6 +241,20 @@ function createConfig(name, entry) {
             for (const pattern of entry.mustExclude) {
               if (output.includes(pattern)) {
                 throw new Error(`[${name}] Expected output NOT to contain "${pattern}" but it was found.`);
+              }
+            }
+
+            if (entry.mustWarn && entry.mustWarn.length > 0) {
+              const warnings = compilation.warnings.map((w) => (w instanceof Error ? w.message : String(w)));
+
+              for (const warning of warnings) {
+                console.log(`  ⚠ ${name}: ${warning}`);
+              }
+
+              for (const expected of entry.mustWarn) {
+                if (!warnings.some((w) => w.includes(expected))) {
+                  throw new Error(`[${name}] Expected a build warning containing "${expected}" but none was emitted.`);
+                }
               }
             }
 


### PR DESCRIPTION
## Summary

The loader only rewrites **static** `import` / `export … from` declarations. A dynamic `import()` of a supported barrel (e.g. `import('@fluentui/react-icons')`) is left untouched, and when the returned module‑namespace object is used dynamically the **entire icon set** ends up in the async chunk — a silent bundle‑size regression that the loader previously gave no signal about.

This PR makes the transform inspect the parsed `dynamicImports` and emit a **warning** when a dynamic import targets a supported barrel, pointing at the atomic escape hatch:

```
dynamic import of the "@fluentui/react-icons" barrel cannot be atomized, so the entire icon
set will be bundled into the async chunk. Import an atomic path directly instead,
e.g. import('@fluentui/react-icons/svg/add').
```

It does **not** attempt to rewrite dynamic imports: a dynamic `import()` returns a runtime namespace whose usage cannot be statically proven in the general case (dynamic member access, `React.lazy`, namespace passed around), so rewriting is only safe for a narrow literal‑destructure subset that is better handled by users importing the atomic path directly.

## What changed

- `src/transform.ts`: read `dynamicImports` from the oxc module record and warn for dynamic imports of supported barrels. Detection matches the raw specifier span against each supported module's quoted spellings, so atomic (`/svg/add`) and subpath (`/svg`) requests, variables, and interpolated templates never warn.
- `test/transform.test.ts`: adds a `dynamic imports` suite (barrel warns + left untouched, `.then()` form, atomic path no‑warn, subpath‑barrel no‑warn, non‑static specifier no‑warn, warns once while sibling static imports still rewrite). Message assertions use inline snapshots.
- `README.md`: new **Limitations → Dynamic imports are not atomized** section with the recommended atomic pattern and the local‑module workaround.

## Evidence (measured async‑chunk sizes)

Real emitted async chunks (monosize's table only measures the main entry chunk, hiding split chunks):

| Pattern | Async chunk | Tree‑shakes? |
| --- | --- | --- |
| `import('@fluentui/react-icons/svg/add')` (atomic) | ~2.26 kB | ✅ |
| `const { AddFilled } = await import('@fluentui/react-icons')` (static destructure) | ~2.72 kB | ✅ (webpack shakes) |
| `const icons = await import('@fluentui/react-icons'); icons[name]` (namespace access) | **~15.9 MB** | ❌ whole set |
| `import('@fluentui/react-icons/')` (trailing slash) | *does not build* | ❌ exports‑field resolution error |

## Testing

- `nx test react-icons-atomic-webpack-loader` (55 passing, incl. new dynamic‑import cases)
- `nx build react-icons-atomic-webpack-loader`

> Draft: opening for review of the warning wording — it says "the entire icon set will be bundled," which is precise for dynamic namespace usage but conservative for the pure static‑destructure case that webpack does tree‑shake.
