### PR TITLE
test(react-icons): add dynamic import() bundle-size fixtures

### DIFF
--- a/packages/react-icons/bundle-size/dynamic-atomic-import.fixture.js
+++ b/packages/react-icons/bundle-size/dynamic-atomic-import.fixture.js
@@ -1,0 +1,8 @@
+async function load() {
+  const { AirplaneRegular } = await import('@fluentui/react-icons/svg/airplane');
+  console.log(AirplaneRegular);
+}
+
+load();
+
+export default { name: 'Dynamic - Atomic Imports' };

--- a/packages/react-icons/bundle-size/dynamic-headless-bundle.fixture.js
+++ b/packages/react-icons/bundle-size/dynamic-headless-bundle.fixture.js
@@ -1,0 +1,12 @@
+async function load() {
+  const { AirplaneFilled, AirplaneRegular } = await import('@fluentui/react-icons/headless/svg/airplane');
+  const { bundleIcon } = await import('@fluentui/react-icons/headless/utils');
+
+  const Airplane = bundleIcon(AirplaneFilled, AirplaneRegular);
+
+  console.log(Airplane);
+}
+
+load();
+
+export default { name: 'Dynamic - Headless Bundle Icon' };

--- a/packages/react-icons/bundle-size/dynamic-import-all.fixture.js
+++ b/packages/react-icons/bundle-size/dynamic-import-all.fixture.js
@@ -1,0 +1,14 @@
+async function load() {
+  // Whole-barrel dynamic import. Intentionally does NOT log the namespace:
+  // a dynamic/namespace access (e.g. `icons[name]`) forces webpack to retain
+  // the ENTIRE icon set (~16 MB async chunk), which makes the bundle-size
+  // measurement extremely slow. Statically-destructured usage tree-shakes, so
+  // this fixture only exercises the barrel resolution + async-chunk wiring.
+  const all = await import('@fluentui/react-icons');
+  // uncomment to DEMO the ~16 MB async chunk retention (and the resulting bundle-size regression):
+  // console.log(all)
+}
+
+load();
+
+export default { name: 'Dynamic - Import All (barrel)' };

--- a/packages/react-icons/bundle-size/dynamic-single-icons.fixture.js
+++ b/packages/react-icons/bundle-size/dynamic-single-icons.fixture.js
@@ -1,0 +1,8 @@
+async function load() {
+  const { AirplaneRegular } = await import('@fluentui/react-icons');
+  console.log(AirplaneRegular);
+}
+
+load();
+
+export default { name: 'Dynamic - Single Icons' };


### PR DESCRIPTION
## Summary

Adds dynamic `import()` counterparts to the existing static bundle-size fixtures so we track how code-split icon imports behave, complementing the static ones.

## New fixtures

| File | Pattern | Mirrors |
| --- | --- | --- |
| `dynamic-atomic-import.fixture.js` | `const { AirplaneRegular } = await import('@fluentui/react-icons/svg/airplane')` | `atomic-import` |
| `dynamic-single-icons.fixture.js` | `const { AirplaneRegular } = await import('@fluentui/react-icons')` | `single-icons` |
| `dynamic-headless-bundle.fixture.js` | dynamic `headless/svg/airplane` + `headless/utils` + `bundleIcon` | `headless-bundle` |
| `dynamic-import-all.fixture.js` | `await import('@fluentui/react-icons')` (whole barrel) | `icons-import-all` |

## Note on the whole-barrel fixture

`dynamic-import-all` deliberately **omits a namespace `console.log`**. A dynamic/namespace access (e.g. `icons[name]`) forces webpack to retain the **entire icon set** (~16 MB async chunk), which makes the bundle-size measurement extremely slow. Statically-destructured usage tree-shakes, so this fixture only exercises barrel resolution + async-chunk wiring while staying fast.

## Measured (async fixtures, ~3 kB main chunk each)

```
Dynamic - Atomic Imports        2.999 kB / 1.538 kB gz
Dynamic - Single Icons          2.999 kB / 1.540 kB gz
Dynamic - Headless Bundle Icon  3.052 kB / 1.561 kB gz
Dynamic - Import All (barrel)   3.098 kB / 1.560 kB gz
```

All 12 fixtures build in ~13s (no barrel explosion).

> Reminder: monosize's table measures only the **main** entry chunk; the `import()`-split async chunk is emitted separately and not summed. These numbers reflect the main chunk (loader/runtime glue), which is expected for code-split fixtures.
