### PR TITLE
feat(react-icons-atomic-webpack-loader): atomize dynamic barrel imports behind allowDynamicImports

### DIFF
--- a/packages/react-icons-atomic-webpack-loader/README.md
+++ b/packages/react-icons-atomic-webpack-loader/README.md
@@ -72,11 +72,12 @@ module.exports = {
 
 ## Options
 
-| Option            | Type                                   | Default     | Description                                                                |
-| ----------------- | -------------------------------------- | ----------- | -------------------------------------------------------------------------- |
-| `iconVariant`     | `'svg'` \| `'fonts'` \| `'svg-sprite'` | `'svg'`     | Variant icons resolve to. Applied to every supported module.               |
-| `fallbackVariant` | `'svg'` \| `'fonts'` \| `'svg-sprite'` | `undefined` | Variant used for a module that does not support `iconVariant` (see below). |
-| `headless`        | `boolean`                              | `false`     | Resolve to the headless (Griffel-free) build where the module ships one.   |
+| Option                | Type                                   | Default     | Description                                                                             |
+| --------------------- | -------------------------------------- | ----------- | --------------------------------------------------------------------------------------- |
+| `iconVariant`         | `'svg'` \| `'fonts'` \| `'svg-sprite'` | `'svg'`     | Variant icons resolve to. Applied to every supported module.                            |
+| `fallbackVariant`     | `'svg'` \| `'fonts'` \| `'svg-sprite'` | `undefined` | Variant used for a module that does not support `iconVariant` (see below).              |
+| `headless`            | `boolean`                              | `false`     | Resolve to the headless (Griffel-free) build where the module ships one.                |
+| `allowDynamicImports` | `boolean`                              | `false`     | Atomize a narrow, statically-provable subset of dynamic `import()` barrels (see below). |
 
 ### Variant resolution & `fallbackVariant`
 
@@ -269,6 +270,63 @@ const { AddFilled } = await import('@fluentui/react-icons/svg/add');
 Alternatively, move the icons behind a local module that statically imports them; the loader atomizes that module, and only your lazy chunk pays for what it uses.
 
 > The same applies to full-barrel subpaths (`@fluentui/react-icons/svg`, `@fluentui/react-icons/fonts`) — dynamically importing those also bundles the whole set. Always target a per-icon atomic path.
+
+### Opt-in: `allowDynamicImports`
+
+> **Prefer a dedicated module of static imports.** The most robust pattern is a
+> small module that statically imports the icons you need and is itself lazy-loaded
+> (`const { AddFilled } = await import('./lazy-icons')`). Static imports are
+> atomized unconditionally, tree-shake predictably, and avoid every gotcha below.
+> Reach for `allowDynamicImports` only when refactoring to that pattern isn't
+> practical.
+
+With `allowDynamicImports: true`, the loader additionally rewrites a **narrow,
+statically-provable** subset of dynamic barrel imports into atomic ones. Only two
+call-site shapes qualify — where the imported names are literals at the `import()`:
+
+```js
+// await + object destructure
+const { AddFilled } = await import('@fluentui/react-icons');
+// → const { AddFilled } = await import('@fluentui/react-icons/svg/add');
+
+// .then + object-pattern callback param
+import('@fluentui/react-icons').then(({ AddFilled }) => …);
+// → import('@fluentui/react-icons/svg/add').then(({ AddFilled }) => …);
+```
+
+Names from the **same** atom are grouped into one import; names from **different**
+atoms become a positional `Promise.all([...])`:
+
+```js
+const { AddFilled, ArrowLeftRegular } = await import('@fluentui/react-icons');
+// →
+const [{ AddFilled }, { ArrowLeftRegular }] = await Promise.all([
+  import('@fluentui/react-icons/svg/add'),
+  import('@fluentui/react-icons/svg/arrow-left'),
+]);
+```
+
+It honors `iconVariant` / `fallbackVariant` / `headless` and per-name color
+rerouting exactly like static imports.
+
+#### Gotchas — what is **not** rewritten (left untouched, still warns)
+
+- **Namespace binding**: `const ns = await import('@fluentui/react-icons')` — `ns`
+  is a runtime object; usage isn't statically known, so the whole set ships.
+- **`.then(m => m.AddFilled)`**: namespace parameter + member access — not a
+  destructure, so the names aren't visible at the call site.
+- **Rest / computed / default / nested patterns**: `{ AddFilled, ...rest }`,
+  `{ [name]: icon }`, `{ AddFilled = fallback }`, `{ Add: { … } }`.
+- **Non-literal specifiers**: `import(pkg)`, template interpolation, or a promise
+  stored in a variable and `.then`-ed elsewhere.
+
+For any of these the loader leaves your code as-is and emits the standard
+"cannot be atomized" warning — the safe default.
+
+> ⚠️ The `Promise.all` rewrite changes the emitted runtime structure (parallel
+> chunk loading, positional destructuring). It's semantically equivalent for the
+> supported shapes, but if you depend on the exact expression shape, prefer the
+> dedicated-module pattern above.
 
 ## Requirements
 

--- a/packages/react-icons-atomic-webpack-loader/src/index.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/index.ts
@@ -43,6 +43,24 @@ export interface FluentIconsAtomicImportLoaderOptions {
    * `headless/fonts/styles.css` for font icons) in your app entry point.
    */
   headless?: boolean;
+  /**
+   * Rewrite a **narrow, statically-provable** subset of dynamic `import()` barrel
+   * calls into atomic dynamic imports. Defaults to `false`.
+   *
+   * Only two shapes are rewritten, where the imported names are known literals at
+   * the call site:
+   * - `const { AddFilled } = await import('@fluentui/react-icons')`
+   * - `import('@fluentui/react-icons').then(({ AddFilled }) => …)`
+   *
+   * Names from the same atom are grouped into one import; names from different
+   * atoms become a positional `Promise.all([...])`. Anything else (namespace
+   * binding `const ns = await import(…)`, `.then(m => m.X)`, rest/computed/default
+   * patterns, non-literal specifiers) is left untouched and still warns.
+   *
+   * Prefer a dedicated module of **static** atomic imports that you lazy-load
+   * (`import('./icons')`) over relying on this; see the README for the gotchas.
+   */
+  allowDynamicImports?: boolean;
 }
 
 export default function fluentIconsAtomicImportLoader(
@@ -57,7 +75,7 @@ export default function fluentIconsAtomicImportLoader(
     return this.callback(null, sourceCode);
   }
 
-  const { iconVariant = 'svg', fallbackVariant, headless = false } = this.getOptions();
+  const { iconVariant = 'svg', fallbackVariant, headless = false, allowDynamicImports = false } = this.getOptions();
 
   let code: string;
   let map: ReturnType<typeof transformSource>['map'];
@@ -68,6 +86,7 @@ export default function fluentIconsAtomicImportLoader(
       iconVariant,
       fallbackVariant,
       headless,
+      allowDynamicImports,
       path: resourcePath,
     }));
   } catch (error) {

--- a/packages/react-icons-atomic-webpack-loader/src/transform.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/transform.ts
@@ -1,4 +1,5 @@
-import { parseSync } from 'oxc-parser';
+import { parseSync, Visitor } from 'oxc-parser';
+import type { ObjectPattern } from 'oxc-parser';
 import MagicString from 'magic-string';
 
 import {
@@ -45,24 +46,6 @@ export interface TransformResult {
 
 /** A module's resolved rewrite target: the icon variant and whether to use its headless build. */
 type ResolvedTarget = { variant: IconVariant; headless: boolean };
-
-/** A minimal AST node view — oxc emits ESTree-shaped nodes with `type` + spans. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AstNode = any;
-
-/** Depth-first walk over the oxc AST, invoking `visit` on every node with a `type`. */
-function walkAst(node: AstNode, visit: (n: AstNode) => void): void {
-  if (!node || typeof node !== 'object') return;
-  if (Array.isArray(node)) {
-    for (const child of node) walkAst(child, visit);
-    return;
-  }
-  if (typeof node.type === 'string') visit(node);
-  for (const key in node) {
-    if (key === 'type' || key === 'start' || key === 'end' || key === 'range' || key === 'loc') continue;
-    walkAst(node[key], visit);
-  }
-}
 
 /** One atom's worth of destructured specifiers, e.g. `{ source, specs: ['AddFilled', 'AddRegular'] }`. */
 type RewriteGroup = { source: string; specs: string[] };
@@ -233,13 +216,13 @@ export function transformSource(source: string, options: TransformOptions): Tran
     // Turn an object pattern (`{ AddFilled, ArrowLeftRegular: arrow }`) into atom
     // groups, or `null` when any property is not a plain, statically-known
     // name→binding pair (rest, computed, default, nested pattern, string key…).
-    const buildGroups = (objectPattern: AstNode, descriptor: ModuleDescriptor): RewriteGroup[] | null => {
+    const buildGroups = (objectPattern: ObjectPattern, descriptor: ModuleDescriptor): RewriteGroup[] | null => {
       const bySource = new Map<string, string[]>();
       const order: string[] = [];
 
       for (const prop of objectPattern.properties) {
         if (prop.type !== 'Property' || prop.computed || prop.kind !== 'init') return null;
-        if (prop.key?.type !== 'Identifier' || prop.value?.type !== 'Identifier') return null;
+        if (prop.key.type !== 'Identifier' || prop.value.type !== 'Identifier') return null;
 
         const importedName: string = prop.key.name;
         const localName: string = prop.value.name;
@@ -268,16 +251,20 @@ export function transformSource(source: string, options: TransformOptions): Tran
         ? `{ ${groups[0].specs.join(', ')} }`
         : `[${groups.map((g) => `{ ${g.specs.join(', ')} }`).join(', ')}]`;
 
-    walkAst(result.program, (node) => {
+    const visitor = new Visitor({
       // `const { A, B } = await import('barrel')`
-      if (
-        node.type === 'VariableDeclarator' &&
-        node.id?.type === 'ObjectPattern' &&
-        node.init?.type === 'AwaitExpression' &&
-        node.init.argument?.type === 'ImportExpression' &&
-        node.init.argument.source?.type === 'Literal'
-      ) {
+      VariableDeclarator(node) {
+        if (
+          node.id.type !== 'ObjectPattern' ||
+          node.init?.type !== 'AwaitExpression' ||
+          node.init.argument.type !== 'ImportExpression'
+        ) {
+          return;
+        }
+
         const importExpr = node.init.argument;
+        if (importExpr.source.type !== 'Literal' || typeof importExpr.source.value !== 'string') return;
+
         const descriptor = getModuleDescriptor(importExpr.source.value);
         if (!descriptor) return;
 
@@ -286,28 +273,32 @@ export function transformSource(source: string, options: TransformOptions): Tran
 
         src.overwrite(node.start, node.end, `${patternText(groups)} = await ${importCallText(groups)}`);
         rewrittenImportStarts.add(importExpr.source.start);
-        return;
-      }
+      },
 
       // `import('barrel').then(({ A, B }) => …)`
-      if (
-        node.type === 'CallExpression' &&
-        node.callee?.type === 'MemberExpression' &&
-        !node.callee.computed &&
-        node.callee.property?.type === 'Identifier' &&
-        node.callee.property.name === 'then' &&
-        node.callee.object?.type === 'ImportExpression' &&
-        node.callee.object.source?.type === 'Literal'
-      ) {
+      CallExpression(node) {
+        if (
+          node.callee.type !== 'MemberExpression' ||
+          node.callee.computed ||
+          node.callee.property.type !== 'Identifier' ||
+          node.callee.property.name !== 'then' ||
+          node.callee.object.type !== 'ImportExpression'
+        ) {
+          return;
+        }
+
         const importExpr = node.callee.object;
+        if (importExpr.source.type !== 'Literal' || typeof importExpr.source.value !== 'string') return;
+
         const descriptor = getModuleDescriptor(importExpr.source.value);
         if (!descriptor) return;
 
-        const callback = node.arguments?.[0];
-        if (!callback || (callback.type !== 'ArrowFunctionExpression' && callback.type !== 'FunctionExpression'))
+        const callback = node.arguments[0];
+        if (!callback || (callback.type !== 'ArrowFunctionExpression' && callback.type !== 'FunctionExpression')) {
           return;
+        }
 
-        const param = callback.params?.[0];
+        const param = callback.params[0];
         if (param?.type !== 'ObjectPattern') return;
 
         const groups = buildGroups(param, descriptor);
@@ -320,9 +311,10 @@ export function transformSource(source: string, options: TransformOptions): Tran
           src.overwrite(param.start, param.end, patternText(groups));
         }
         rewrittenImportStarts.add(importExpr.source.start);
-        return;
-      }
+      },
     });
+
+    visitor.visit(result.program);
   }
 
   // Dynamic imports of a barrel (`import('@fluentui/react-icons')`) cannot be

--- a/packages/react-icons-atomic-webpack-loader/src/transform.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/transform.ts
@@ -18,6 +18,12 @@ interface TransformOptions {
   fallbackVariant?: IconVariant;
   /** Resolve to the headless (Griffel-free) build where the module supports it. */
   headless?: boolean;
+  /**
+   * Rewrite a narrow, statically-provable subset of dynamic `import()` barrel
+   * calls into atomic dynamic imports (see {@link rewriteDynamicImports}).
+   * Defaults to `false`. Un-rewritable dynamic barrel imports still warn.
+   */
+  allowDynamicImports?: boolean;
   path: string;
 }
 
@@ -40,8 +46,29 @@ export interface TransformResult {
 /** A module's resolved rewrite target: the icon variant and whether to use its headless build. */
 type ResolvedTarget = { variant: IconVariant; headless: boolean };
 
+/** A minimal AST node view — oxc emits ESTree-shaped nodes with `type` + spans. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AstNode = any;
+
+/** Depth-first walk over the oxc AST, invoking `visit` on every node with a `type`. */
+function walkAst(node: AstNode, visit: (n: AstNode) => void): void {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const child of node) walkAst(child, visit);
+    return;
+  }
+  if (typeof node.type === 'string') visit(node);
+  for (const key in node) {
+    if (key === 'type' || key === 'start' || key === 'end' || key === 'range' || key === 'loc') continue;
+    walkAst(node[key], visit);
+  }
+}
+
+/** One atom's worth of destructured specifiers, e.g. `{ source, specs: ['AddFilled', 'AddRegular'] }`. */
+type RewriteGroup = { source: string; specs: string[] };
+
 export function transformSource(source: string, options: TransformOptions): TransformResult {
-  const { iconVariant, fallbackVariant, headless = false, path } = options;
+  const { iconVariant, fallbackVariant, headless = false, allowDynamicImports = false, path } = options;
 
   const result = parseSync(path, source, {
     sourceType: 'module',
@@ -190,6 +217,114 @@ export function transformSource(source: string, options: TransformOptions): Tran
     src.overwrite(exp.start, exp.end, lines.join('\n'));
   }
 
+  // Source-literal start offsets of dynamic imports that were atomized below.
+  // Used to suppress the "cannot be atomized" warning for imports we rewrote.
+  const rewrittenImportStarts = new Set<number>();
+
+  if (allowDynamicImports) {
+    // Resolve a single destructured name to its atomic subpath, or `null` when
+    // the owning module can't be resolved (an error diagnostic is recorded).
+    const resolveNameSource = (descriptor: ModuleDescriptor, importedName: string): string | null => {
+      const target = targetFor(descriptor, isColorIconName(importedName));
+      if (!target) return null;
+      return descriptor.resolve(importedName, target.variant, target.headless);
+    };
+
+    // Turn an object pattern (`{ AddFilled, ArrowLeftRegular: arrow }`) into atom
+    // groups, or `null` when any property is not a plain, statically-known
+    // name→binding pair (rest, computed, default, nested pattern, string key…).
+    const buildGroups = (objectPattern: AstNode, descriptor: ModuleDescriptor): RewriteGroup[] | null => {
+      const bySource = new Map<string, string[]>();
+      const order: string[] = [];
+
+      for (const prop of objectPattern.properties) {
+        if (prop.type !== 'Property' || prop.computed || prop.kind !== 'init') return null;
+        if (prop.key?.type !== 'Identifier' || prop.value?.type !== 'Identifier') return null;
+
+        const importedName: string = prop.key.name;
+        const localName: string = prop.value.name;
+        const resolvedSource = resolveNameSource(descriptor, importedName);
+        if (resolvedSource === null) return null;
+
+        const spec = importedName === localName ? importedName : `${importedName}: ${localName}`;
+        if (!bySource.has(resolvedSource)) {
+          bySource.set(resolvedSource, []);
+          order.push(resolvedSource);
+        }
+        bySource.get(resolvedSource)!.push(spec);
+      }
+
+      if (order.length === 0) return null;
+      return order.map((groupSource) => ({ source: groupSource, specs: bySource.get(groupSource)! }));
+    };
+
+    const importCallText = (groups: RewriteGroup[]): string =>
+      groups.length === 1
+        ? `import('${groups[0].source}')`
+        : `Promise.all([${groups.map((g) => `import('${g.source}')`).join(', ')}])`;
+
+    const patternText = (groups: RewriteGroup[]): string =>
+      groups.length === 1
+        ? `{ ${groups[0].specs.join(', ')} }`
+        : `[${groups.map((g) => `{ ${g.specs.join(', ')} }`).join(', ')}]`;
+
+    walkAst(result.program, (node) => {
+      // `const { A, B } = await import('barrel')`
+      if (
+        node.type === 'VariableDeclarator' &&
+        node.id?.type === 'ObjectPattern' &&
+        node.init?.type === 'AwaitExpression' &&
+        node.init.argument?.type === 'ImportExpression' &&
+        node.init.argument.source?.type === 'Literal'
+      ) {
+        const importExpr = node.init.argument;
+        const descriptor = getModuleDescriptor(importExpr.source.value);
+        if (!descriptor) return;
+
+        const groups = buildGroups(node.id, descriptor);
+        if (!groups) return;
+
+        src.overwrite(node.start, node.end, `${patternText(groups)} = await ${importCallText(groups)}`);
+        rewrittenImportStarts.add(importExpr.source.start);
+        return;
+      }
+
+      // `import('barrel').then(({ A, B }) => …)`
+      if (
+        node.type === 'CallExpression' &&
+        node.callee?.type === 'MemberExpression' &&
+        !node.callee.computed &&
+        node.callee.property?.type === 'Identifier' &&
+        node.callee.property.name === 'then' &&
+        node.callee.object?.type === 'ImportExpression' &&
+        node.callee.object.source?.type === 'Literal'
+      ) {
+        const importExpr = node.callee.object;
+        const descriptor = getModuleDescriptor(importExpr.source.value);
+        if (!descriptor) return;
+
+        const callback = node.arguments?.[0];
+        if (!callback || (callback.type !== 'ArrowFunctionExpression' && callback.type !== 'FunctionExpression'))
+          return;
+
+        const param = callback.params?.[0];
+        if (param?.type !== 'ObjectPattern') return;
+
+        const groups = buildGroups(param, descriptor);
+        if (!groups) return;
+
+        src.overwrite(importExpr.start, importExpr.end, importCallText(groups));
+        // Multiple atoms resolve to an array, so the callback must destructure by
+        // position instead of by name.
+        if (groups.length > 1) {
+          src.overwrite(param.start, param.end, patternText(groups));
+        }
+        rewrittenImportStarts.add(importExpr.source.start);
+        return;
+      }
+    });
+  }
+
   // Dynamic imports of a barrel (`import('@fluentui/react-icons')`) cannot be
   // atomized: the returned namespace object is a runtime value whose usage is
   // not statically known, so the whole icon set ends up in the async chunk. We
@@ -199,6 +334,9 @@ export function transformSource(source: string, options: TransformOptions): Tran
   for (const dyn of dynamicImports) {
     const request = dyn.moduleRequest;
     if (!request) continue;
+
+    // Skip imports we already atomized above (their usage was statically provable).
+    if (rewrittenImportStarts.has(request.start)) continue;
 
     // Unlike static imports, oxc doesn't resolve a dynamic import's argument to a
     // specifier value — it's an arbitrary expression. Match the raw span against

--- a/packages/react-icons-atomic-webpack-loader/src/transform.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/transform.ts
@@ -205,17 +205,50 @@ export function transformSource(source: string, options: TransformOptions): Tran
   const rewrittenImportStarts = new Set<number>();
 
   if (allowDynamicImports) {
-    // Resolve a single destructured name to its atomic subpath, or `null` when
-    // the owning module can't be resolved (an error diagnostic is recorded).
+    /**
+     * Resolves one destructured binding name to the atomic subpath it should be
+     * imported from, honoring the active `iconVariant` / `headless` / color rules
+     * (same policy as static imports). Returns `null` when the owning module can't
+     * be resolved — `targetFor` has already recorded an error diagnostic — which
+     * signals the caller to bail and leave the dynamic import untouched.
+     *
+     * @example
+     * // iconVariant: 'svg'
+     * resolveNameSource(reactIcons, 'AddFilled')   // → '@fluentui/react-icons/svg/add'
+     * resolveNameSource(reactIcons, 'bundleIcon')  // → '@fluentui/react-icons/utils'
+     * // iconVariant: 'fonts'
+     * resolveNameSource(reactIcons, 'AddFilled')   // → '@fluentui/react-icons/fonts/add'
+     */
     const resolveNameSource = (descriptor: ModuleDescriptor, importedName: string): string | null => {
       const target = targetFor(descriptor, isColorIconName(importedName));
       if (!target) return null;
       return descriptor.resolve(importedName, target.variant, target.headless);
     };
 
-    // Turn an object pattern (`{ AddFilled, ArrowLeftRegular: arrow }`) into atom
-    // groups, or `null` when any property is not a plain, statically-known
-    // name→binding pair (rest, computed, default, nested pattern, string key…).
+    /**
+     * Groups the properties of a destructuring object pattern by the atomic module
+     * each imported name resolves to, preserving first-seen order. Each group's
+     * `specs` are the emit-ready specifier strings (`'AddFilled'`, or
+     * `'ArrowLeftRegular: arrow'` for a rename).
+     *
+     * Returns `null` (bail — leave the dynamic import untouched) when any property
+     * isn't a plain, statically-known `name → binding` pair: rest elements,
+     * computed/string keys, default values, or nested patterns.
+     *
+     * @example
+     * // `{ AddFilled, AddRegular }`  — both live in the `add` atom
+     * // → [{ source: '@fluentui/react-icons/svg/add', specs: ['AddFilled', 'AddRegular'] }]
+     *
+     * @example
+     * // `{ AddFilled, ArrowLeftRegular: arrow }`  — different atoms, one renamed
+     * // → [
+     * //     { source: '@fluentui/react-icons/svg/add',        specs: ['AddFilled'] },
+     * //     { source: '@fluentui/react-icons/svg/arrow-left', specs: ['ArrowLeftRegular: arrow'] },
+     * //   ]
+     *
+     * @example
+     * // `{ AddFilled, ...rest }`  → null   (rest element → bail)
+     */
     const buildGroups = (objectPattern: ObjectPattern, descriptor: ModuleDescriptor): RewriteGroup[] | null => {
       const bySource = new Map<string, string[]>();
       const order: string[] = [];

--- a/packages/react-icons-atomic-webpack-loader/test/src/dynamic-atomize.js
+++ b/packages/react-icons-atomic-webpack-loader/test/src/dynamic-atomize.js
@@ -1,0 +1,8 @@
+// allowDynamicImports: the barrel dynamic import is atomized into per-icon
+// dynamic imports (names from different atoms → positional Promise.all).
+async function load() {
+  const { AddFilled, ArrowLeftRegular } = await import('@fluentui/react-icons');
+  console.log(AddFilled, ArrowLeftRegular);
+}
+
+load();

--- a/packages/react-icons-atomic-webpack-loader/test/transform.test.ts
+++ b/packages/react-icons-atomic-webpack-loader/test/transform.test.ts
@@ -628,22 +628,42 @@ describe('transformSource', () => {
         const source = `const icons = await import('@fluentui/react-icons');`;
         const { code, diagnostics } = rewrite(source);
         expect(code).toBe(source);
-        expect(diagnostics).toHaveLength(1);
-        expect(diagnostics[0].level).toBe('warning');
+        expect(diagnostics).toMatchInlineSnapshot(`
+          [
+            {
+              "level": "warning",
+              "message": "dynamic import of the "@fluentui/react-icons" barrel cannot be atomized, so the entire icon set will be bundled into the async chunk. Import an atomic path directly instead, e.g. import('@fluentui/react-icons/svg/add').",
+            },
+          ]
+        `);
       });
 
       it('does not rewrite a `.then(m => m.X)` namespace access', () => {
         const source = `import('@fluentui/react-icons').then((m) => m.AddFilled);`;
         const { code, diagnostics } = rewrite(source);
         expect(code).toBe(source);
-        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics).toMatchInlineSnapshot(`
+          [
+            {
+              "level": "warning",
+              "message": "dynamic import of the "@fluentui/react-icons" barrel cannot be atomized, so the entire icon set will be bundled into the async chunk. Import an atomic path directly instead, e.g. import('@fluentui/react-icons/svg/add').",
+            },
+          ]
+        `);
       });
 
       it('does not rewrite a rest element', () => {
         const source = `const { AddFilled, ...rest } = await import('@fluentui/react-icons');`;
         const { code, diagnostics } = rewrite(source);
         expect(code).toBe(source);
-        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics).toMatchInlineSnapshot(`
+          [
+            {
+              "level": "warning",
+              "message": "dynamic import of the "@fluentui/react-icons" barrel cannot be atomized, so the entire icon set will be bundled into the async chunk. Import an atomic path directly instead, e.g. import('@fluentui/react-icons/svg/add').",
+            },
+          ]
+        `);
       });
 
       it('does not rewrite a defaulted property', () => {
@@ -664,8 +684,14 @@ describe('transformSource', () => {
       const source = `const { AddFilled } = await import('@fluentui/react-icons');`;
       const { code, diagnostics } = transformSource(source, { iconVariant: 'svg', path: 'input.js' });
       expect(code).toBe(source);
-      expect(diagnostics).toHaveLength(1);
-      expect(diagnostics[0].level).toBe('warning');
+      expect(diagnostics).toMatchInlineSnapshot(`
+        [
+          {
+            "level": "warning",
+            "message": "dynamic import of the "@fluentui/react-icons" barrel cannot be atomized, so the entire icon set will be bundled into the async chunk. Import an atomic path directly instead, e.g. import('@fluentui/react-icons/svg/add').",
+          },
+        ]
+      `);
     });
   });
 });

--- a/packages/react-icons-atomic-webpack-loader/test/transform.test.ts
+++ b/packages/react-icons-atomic-webpack-loader/test/transform.test.ts
@@ -553,4 +553,119 @@ describe('transformSource', () => {
       expect(diagnostics[0].level).toBe('warning');
     });
   });
+
+  describe('allowDynamicImports', () => {
+    const rewrite = (source: string, extra: Partial<Parameters<typeof transformSource>[1]> = {}) =>
+      transformSource(source, { iconVariant: 'svg', allowDynamicImports: true, path: 'input.js', ...extra });
+
+    describe('await destructure', () => {
+      it('rewrites a single-name await destructure to the atomic import', () => {
+        const { code, diagnostics } = rewrite(`const { AddRegular } = await import('@fluentui/react-icons');`);
+        expect(code).toBe(`const { AddRegular } = await import('@fluentui/react-icons/svg/add');`);
+        expect(diagnostics).toEqual([]);
+      });
+
+      it('groups multiple names from the same atom into one import', () => {
+        const { code } = rewrite(`const { AddFilled, AddRegular } = await import('@fluentui/react-icons');`);
+        expect(code).toBe(`const { AddFilled, AddRegular } = await import('@fluentui/react-icons/svg/add');`);
+      });
+
+      it('splits names from different atoms into a positional Promise.all', () => {
+        const { code } = rewrite(`const { AddFilled, ArrowLeftRegular } = await import('@fluentui/react-icons');`);
+        expect(code).toBe(
+          `const [{ AddFilled }, { ArrowLeftRegular }] = await Promise.all([import('@fluentui/react-icons/svg/add'), import('@fluentui/react-icons/svg/arrow-left')]);`,
+        );
+      });
+
+      it('preserves renamed bindings', () => {
+        const { code } = rewrite(`const { AddFilled: myAdd } = await import('@fluentui/react-icons');`);
+        expect(code).toBe(`const { AddFilled: myAdd } = await import('@fluentui/react-icons/svg/add');`);
+      });
+
+      it('routes utility bindings to /utils alongside icons', () => {
+        const { code } = rewrite(`const { AddFilled, bundleIcon } = await import('@fluentui/react-icons');`);
+        expect(code).toBe(
+          `const [{ AddFilled }, { bundleIcon }] = await Promise.all([import('@fluentui/react-icons/svg/add'), import('@fluentui/react-icons/utils')]);`,
+        );
+      });
+
+      it('honors the fonts variant', () => {
+        const { code } = rewrite(`const { AddFilled } = await import('@fluentui/react-icons');`, {
+          iconVariant: 'fonts',
+        });
+        expect(code).toBe(`const { AddFilled } = await import('@fluentui/react-icons/fonts/add');`);
+      });
+
+      it('reroutes color icons off fonts per name', () => {
+        const { code } = rewrite(`const { AddFilled, AddCircleColor } = await import('@fluentui/react-icons');`, {
+          iconVariant: 'fonts',
+        });
+        expect(code).toBe(
+          `const [{ AddFilled }, { AddCircleColor }] = await Promise.all([import('@fluentui/react-icons/fonts/add'), import('@fluentui/react-icons/svg/add-circle')]);`,
+        );
+      });
+    });
+
+    describe('.then destructure', () => {
+      it('rewrites the specifier for a single-atom .then object pattern', () => {
+        const { code, diagnostics } = rewrite(`import('@fluentui/react-icons').then(({ AddFilled }) => AddFilled);`);
+        expect(code).toBe(`import('@fluentui/react-icons/svg/add').then(({ AddFilled }) => AddFilled);`);
+        expect(diagnostics).toEqual([]);
+      });
+
+      it('rewrites a multi-atom .then into Promise.all with a positional param', () => {
+        const { code } = rewrite(
+          `import('@fluentui/react-icons').then(({ AddFilled, ArrowLeftRegular }) => AddFilled);`,
+        );
+        expect(code).toBe(
+          `Promise.all([import('@fluentui/react-icons/svg/add'), import('@fluentui/react-icons/svg/arrow-left')]).then(([{ AddFilled }, { ArrowLeftRegular }]) => AddFilled);`,
+        );
+      });
+    });
+
+    describe('bail cases (left untouched, still warn)', () => {
+      it('does not rewrite a namespace binding', () => {
+        const source = `const icons = await import('@fluentui/react-icons');`;
+        const { code, diagnostics } = rewrite(source);
+        expect(code).toBe(source);
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0].level).toBe('warning');
+      });
+
+      it('does not rewrite a `.then(m => m.X)` namespace access', () => {
+        const source = `import('@fluentui/react-icons').then((m) => m.AddFilled);`;
+        const { code, diagnostics } = rewrite(source);
+        expect(code).toBe(source);
+        expect(diagnostics).toHaveLength(1);
+      });
+
+      it('does not rewrite a rest element', () => {
+        const source = `const { AddFilled, ...rest } = await import('@fluentui/react-icons');`;
+        const { code, diagnostics } = rewrite(source);
+        expect(code).toBe(source);
+        expect(diagnostics).toHaveLength(1);
+      });
+
+      it('does not rewrite a defaulted property', () => {
+        const source = `const { AddFilled = null } = await import('@fluentui/react-icons');`;
+        const { code } = rewrite(source);
+        expect(code).toBe(source);
+      });
+
+      it('leaves atomic dynamic imports untouched (no warning)', () => {
+        const source = `const { AddFilled } = await import('@fluentui/react-icons/svg/add');`;
+        const { code, diagnostics } = rewrite(source);
+        expect(code).toBe(source);
+        expect(diagnostics).toEqual([]);
+      });
+    });
+
+    it('is off by default — barrel dynamic imports only warn', () => {
+      const source = `const { AddFilled } = await import('@fluentui/react-icons');`;
+      const { code, diagnostics } = transformSource(source, { iconVariant: 'svg', path: 'input.js' });
+      expect(code).toBe(source);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0].level).toBe('warning');
+    });
+  });
 });

--- a/packages/react-icons-atomic-webpack-loader/test/webpack.config.js
+++ b/packages/react-icons-atomic-webpack-loader/test/webpack.config.js
@@ -1,6 +1,6 @@
 // @ts-check
 const { resolve } = require('path');
-const { readFileSync } = require('fs');
+const { readdirSync, readFileSync } = require('fs');
 
 /**
  * @typedef {object} EntryConfig
@@ -174,6 +174,15 @@ const entries = {
       'dynamic import of the "@fluentui/react-brand-icons" barrel cannot be atomized',
     ],
   },
+
+  'dynamic-atomize': {
+    src: './src/dynamic-atomize.js',
+    loaderOptions: { allowDynamicImports: true },
+    // With allowDynamicImports the barrel dynamic import is rewritten to atomic
+    // dynamic imports; the bare barrel specifier must be gone.
+    mustInclude: ['@fluentui/react-icons/svg/add', '@fluentui/react-icons/svg/arrow-left'],
+    mustExclude: ['"@fluentui/react-icons"'],
+  },
 };
 
 /**
@@ -229,8 +238,14 @@ function createConfig(name, entry) {
       {
         apply(compiler) {
           compiler.hooks.afterEmit.tap('verify-transforms', (compilation) => {
-            const outputPath = resolve(__dirname, 'dist', name, `${name}.js`);
-            const output = readFileSync(outputPath, 'utf8');
+            // Read every emitted JS chunk from disk (entry chunk + async chunks)
+            // so assertions also cover code split behind a dynamic import().
+            // afterEmit sources are size-only, hence reading the written files.
+            const outDir = resolve(__dirname, 'dist', name);
+            const output = readdirSync(outDir)
+              .filter((file) => file.endsWith('.js'))
+              .map((file) => readFileSync(resolve(outDir, file), 'utf8'))
+              .join('\n');
 
             for (const pattern of entry.mustInclude) {
               if (!output.includes(pattern)) {


### PR DESCRIPTION
## Summary

Follow-up to #1161. Adds an **opt-in** `allowDynamicImports` option that rewrites a **narrow, statically-provable** subset of dynamic barrel `import()` calls into atomic dynamic imports — so `const { AddFilled } = await import('@fluentui/react-icons')` loads only the `add` atom instead of the whole library.

> **Stacked on #1161** (the dynamic-import warning). This branch includes those commits; the net diff narrows once #1161 merges. Please merge #1161 first.

## What it does (`allowDynamicImports: true`, default `false`)

Two call-site shapes qualify — imported names must be literals at the `import()`:

```js
// await + object destructure
const { AddFilled } = await import('@fluentui/react-icons');
// → const { AddFilled } = await import('@fluentui/react-icons/svg/add');

// .then + object-pattern callback param
import('@fluentui/react-icons').then(({ AddFilled }) => …);
// → import('@fluentui/react-icons/svg/add').then(({ AddFilled }) => …);
```

- Names from the **same** atom → one grouped import.
- Names from **different** atoms → positional `Promise.all([...])` (and, for `.then`, the callback param is restructured to `([{…}, {…}]) =>`).
- Honors `iconVariant` / `fallbackVariant` / `headless` and per-name color rerouting, reusing the existing static-import resolution.

Implementation walks the oxc AST (`result.program`) to match the two shapes; everything else falls through to the existing warning. Rewritten imports are tracked so they don't also warn.

## Bail cases (left untouched, still warn)

Namespace binding (`const ns = await import(…)`), `.then(m => m.X)`, rest/computed/default/nested patterns, non-literal specifiers, stored promises.

## Docs

README gains an `allowDynamicImports` row + a dedicated section that spells out the gotchas and **steers users to the preferred pattern**: a dedicated module of static imports that is itself lazy-loaded (`await import('./lazy-icons')`), which atomizes unconditionally and avoids every gotcha.

## Testing

- `nx test react-icons-atomic-webpack-loader` — **70 passing** (15 new covering await/`.then`, single/multi-atom `Promise.all`, rename, utils grouping, fonts + color routing, and all bail cases + default-off).
- Build + existing webpack e2e green.

## Design notes / for review

- Multi-atom rewrites change emitted runtime structure (`Promise.all`, positional destructure) — semantically equivalent for the supported shapes; documented as a caveat.
- Kept opt-in so existing users' output is unchanged.
