### PR TITLE
ci: pin 3rd-party gradle action to commit SHA

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -107,7 +107,7 @@ jobs:
           java-version: 11
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           gradle-version: wrapper
           gradle-home-cache-excludes: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -230,7 +230,7 @@ jobs:
           java-version: 11
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           gradle-version: wrapper
           gradle-home-cache-excludes: |


### PR DESCRIPTION
## Summary

SHA-pins 3rd-party GitHub Actions in the release/PR workflows. Non-GitHub actions must be pinned to a full commit SHA; GitHub-native `actions/*` may stay on version tags.

> Note: the fetch-depth / partial-clone change originally bundled here has been split out into its own PR (#1170). This PR is now scoped to SHA-pinning only.

## Changes

- `gradle/actions/setup-gradle@v5` → `@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2` (the commit `v5` currently resolves to) in [pr.yml](.github/workflows/pr.yml) and [publish.yml](.github/workflows/publish.yml).

The other active 3rd-party actions were already pinned (`nrwl/nx-set-shas`, `JS-DevTools/npm-publish`). The grouped Dependabot config keeps these SHA pins up to date with their version comments; no new CI job added.