### PR TITLE
ci: publish npm packages via nx release publish instead of JS-DevTools/npm-publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,6 +99,9 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22.x
+          # Required so setup-node writes an .npmrc that wires npm auth to NODE_AUTH_TOKEN,
+          # which `nx release publish` (npm publish under the hood) relies on.
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
@@ -177,51 +180,19 @@ jobs:
       - name: Update lockfile
         run: npm install --package-lock-only
 
-      - name: Publish svg-icons to npm
-        if: ${{ !inputs.dry-run }}
-        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4.1.5
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          access: public
-          package: packages/svg-icons/package.json
-
-      - name: Publish svg-sprites to npm
-        if: ${{ !inputs.dry-run }}
-        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4.1.5
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          access: public
-          package: packages/svg-sprites/package.json
-
-      - name: Publish react-icons to npm
-        if: ${{ !inputs.dry-run }}
-        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4.1.5
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          access: public
-          package: packages/react-icons/package.json
-
-      - name: Publish react-icons-font-subsetting-webpack-plugin to npm
-        if: ${{ !inputs.dry-run }}
-        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4.1.5
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          access: public
-          package: packages/react-icons-font-subsetting-webpack-plugin/package.json
-
-      - name: Publish react-native-icons to npm
-        if: ${{ !inputs.dry-run }}
-        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4.1.5
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          access: public
-          package: packages/react-native-icons/package.json
+      # Publishes the `react` + `native` release groups (svg-icons, svg-sprites, react-icons,
+      # react-icons-font-subsetting-webpack-plugin, react-native-icons) via Nx Release, which
+      # reads npm auth from NODE_AUTH_TOKEN (see setup-node registry-url above). On dry-run we
+      # still exercise the publish path with `--dry-run` instead of skipping it entirely.
+      - name: Publish to npm (Nx Release)
+        run: |
+          npx nx release publish --group=react --access public ${{ inputs.dry-run && '--dry-run' || '' }} --verbose
+          npx nx release publish --group=native --access public ${{ inputs.dry-run && '--dry-run' || '' }} --verbose
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Android
       - name: Run Android generate script
-        env:
-          # see https://github.com/JS-DevTools/npm-publish/issues/15
-          INPUT_TOKEN: ''
         run: npm run deploy:android
         working-directory: importer
 


### PR DESCRIPTION
## Summary

Follow-up to the GHA hardening work. Removes the 3rd-party `JS-DevTools/npm-publish` action from the main publish workflow and publishes via `nx release publish` instead — the same mechanism already used by [publish-standalone.yml](.github/workflows/publish-standalone.yml).

## Why

- Drops a 3rd-party action from the release supply chain (one fewer thing to SHA-pin/audit).
- `nx release publish` is release-group-aware and has native `--dry-run` support, so dry-run now **exercises the publish path** instead of skipping it entirely.
- Consistent with the standalone workflow, which already uses `nx release publish`.

## Changes ([publish.yml](.github/workflows/publish.yml))

- Added `registry-url: 'https://registry.npmjs.org'` to `setup-node` so it writes an `.npmrc` wiring npm auth to `NODE_AUTH_TOKEN` (required by `nx release publish`; the old action took the token as a direct input and didn't need this).
- Replaced the **5** `JS-DevTools/npm-publish` steps with a single step running `nx release publish` for the `react` and `native` groups (covers `svg-icons`, `svg-sprites`, `react-icons`, `react-icons-font-subsetting-webpack-plugin`, `react-native-icons`).
- On dry-run, appends `--dry-run` instead of using `if: !inputs.dry-run` to skip.
- Removed the now-obsolete `INPUT_TOKEN: ''` workaround in the Android step (it existed solely to neutralize a leftover env var from `JS-DevTools/npm-publish`).

## Verification

`nx release publish --help` confirms `--group`/`--groups`, `--dry-run`, and `--access` are supported on the installed Nx.

## Note for reviewers

Worth a careful look at auth: this relies on `setup-node`'s `registry-url` + `NODE_AUTH_TOKEN` (proven in the standalone workflow) rather than passing the token directly. Recommend a `dry-run` execution of the workflow before merge to validate the publish path end-to-end.