### PR TITLE
chore: generalize .github CODEOWNERS ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,10 @@
+## .github — default ownership
+/.github/ @microsoft/cxe-prg
+
+## .github — team co-ownership overrides
 /.github/CODEOWNERS @microsoft/cxe-prg @microsoft/react-native-sdk-admins
-/.github/ISSUE_TEMPLATE/01-react-icons-bug-report.yml @microsoft/cxe-prg
-/.github/ISSUE_TEMPLATE/02-react-icons-feature-request.yml @microsoft/cxe-prg
-/.github/react-icons.instructions.md @microsoft/cxe-prg
-/.github/workflows/copilot-setup-steps.yml @microsoft/cxe-prg
-/.github/workflows/pr.yml @microsoft/cxe-prg @microsoft/react-native-sdk-admins @spencer-nelson
-/.github/workflows/pr-summary-comment.yml @microsoft/cxe-prg
-/.github/workflows/publish.yml @microsoft/cxe-prg @microsoft/react-native-sdk-admins @spencer-nelson
-/.github/workflows/publish-standalone.yml @microsoft/cxe-prg
-/.github/workflows/publish-prerelease.yml @microsoft/cxe-prg
-/.github/workflows/bundle-size.baseline.yml @microsoft/cxe-prg
-/.github/workflows/deploy-docsite.yml @microsoft/cxe-prg
-/.github/scripts @microsoft/cxe-prg
+/.github/workflows/pr.yml @microsoft/cxe-prg @microsoft/react-native-sdk-admins
+/.github/workflows/publish.yml @microsoft/cxe-prg @microsoft/react-native-sdk-admins
 AGENTS.md @microsoft/cxe-prg
 
 ## packages


### PR DESCRIPTION
## What

Generalizes ownership of `.github` in CODEOWNERS.

- Default: the whole `.github/` directory is owned by `@microsoft/cxe-prg` via a single rule.
- Team co-ownership is kept as separate override rules (last-match-wins) for the files that need extra owners:
  - `.github/CODEOWNERS` → + `@microsoft/react-native-sdk-admins`
  - `.github/workflows/pr.yml` → + `@microsoft/react-native-sdk-admins`
  - `.github/workflows/publish.yml` → + `@microsoft/react-native-sdk-admins`

## Why

Previous per-file listing was brittle — every new `.github` file required a CODEOWNERS edit. The default rule now covers all files automatically.

## Notes

- `@spencer-nelson` removed from the `pr.yml` / `publish.yml` overrides.