### PR TITLE
ci: use full-history partial clone (tree:0) for nx release workflows

### DIFF
--- a/.github/workflows/publish-standalone.yml
+++ b/.github/workflows/publish-standalone.yml
@@ -47,8 +47,14 @@ jobs:
       - uses: actions/checkout@v7
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          filter: blob:none
-          fetch-depth: 50
+          # Nx (release changelog / affected) needs the full commit history to resolve
+          # ranges between release tags. On this gigantic repo we keep the checkout cheap
+          # via a `tree:0` partial clone: full history is present, but trees/blobs are
+          # fetched on demand instead of a fragile `fetch-depth: 50` window that breaks
+          # once more than 50 commits land between releases.
+          # See https://github.com/nrwl/nx-set-shas#usage (fetch-depth: 0 + filter: tree:0).
+          filter: tree:0
+          fetch-depth: 0
           fetch-tags: true
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,12 +43,14 @@ jobs:
       - uses: actions/checkout@v7
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          #  Git knows file names/paths for history, but blobs (file contents) are fetched on demand.
-          filter: blob:none
-          # NOTE: This is needed for nx release changelog to detect all commits between releases
-          #  - temporarily increasing fetch-depth to 50 to get commit history for changelog generation
-          #  - we should consider switching to fetch-depth: 0 if we run into issues or switching to Nx Version plans instead conventional commits
-          fetch-depth: 50
+          # Nx (release changelog / affected) needs the full commit history to resolve
+          # ranges between release tags. On this gigantic repo we keep the checkout cheap
+          # via a `tree:0` partial clone: full history is present, but trees/blobs are
+          # fetched on demand instead of a fragile `fetch-depth: 50` window that breaks
+          # once more than 50 commits land between releases.
+          # See https://github.com/nrwl/nx-set-shas#usage (fetch-depth: 0 + filter: tree:0).
+          filter: tree:0
+          fetch-depth: 0
           fetch-tags: true
 
       - name: Bump version patch


### PR DESCRIPTION
## Summary

This PR contains only the release-checkout fetch strategy change.

Nx needs the full commit history to resolve ranges between release tags. The previous `fetch-depth: 50` window silently breaks once more than 50 commits land between releases. Switched the release checkouts to the Nx-recommended pattern for large repos — `fetch-depth: 0` + `filter: tree:0` — which keeps full history while fetching trees/blobs on demand, so it stays cheap on this gigantic repo.

## Changes

- [publish.yml](.github/workflows/publish.yml): `filter: blob:none` + `fetch-depth: 50` → `filter: tree:0` + `fetch-depth: 0`.
- [publish-standalone.yml](.github/workflows/publish-standalone.yml): same.

`pr.yml` already uses `nrwl/nx-set-shas` with `fetch-depth: 0` + `filter: tree:0`, so no change was needed there. See https://github.com/nrwl/nx-set-shas#usage.