### PR TITLE
fix(react-icons): stop headless base CSS from overriding shared data-fui-icon styling

### DIFF
--- a/packages/docsite/stories/Icons/Recipes/TargetIconsFromCss.stories.tsx
+++ b/packages/docsite/stories/Icons/Recipes/TargetIconsFromCss.stories.tsx
@@ -1,10 +1,22 @@
+// Headless icons ship no CSS-in-JS runtime — you opt into styling by importing
+// the shipped vanilla CSS file once. This is the key difference from the standard API.
+import '@fluentui/react-icons/headless/styles.css';
+
 import { makeStyles, mergeClasses, tokens } from '@fluentui/react-components';
-import { AccessTimeFilled, CalendarLtrRegular, SendRegular, SettingsFilled } from '@fluentui/react-icons';
+// SVG icons (Griffel / CSS-in-JS)
+import { AccessTimeFilled } from '@fluentui/react-icons/svg/access-time';
+import { CalendarLtrRegular } from '@fluentui/react-icons/svg/calendar-ltr';
+// Font icons — the same catalogue delivered as an icon font.
+import { SendRegular } from '@fluentui/react-icons/fonts/send';
+import { SettingsFilled } from '@fluentui/react-icons/fonts/settings';
+// Headless icons — vanilla CSS, no Griffel runtime.
+import { AlertRegular } from '@fluentui/react-icons/headless/svg/alert';
+import { StarFilled } from '@fluentui/react-icons/headless/svg/star';
 import * as React from 'react';
 
 const useStyles = makeStyles({
-  // A single rule styles *every* descendant icon at once via the `data-fui-icon`
-  // attribute that all icons render — no per-icon className required.
+  // A single rule styles *every* descendant icon at once — SVG, font, or headless —
+  // via the `data-fui-icon` attribute they all render, no per-icon className required.
   toolbar: {
     display: 'flex',
     gap: '16px',
@@ -26,23 +38,31 @@ const useStyles = makeStyles({
   },
 });
 
+// A mix of all three delivery mechanisms. The rendered markup differs per flavor
+// (Griffel `<svg>`, headless `<svg>`, font `<i>`), but each one emits the same
+// `data-fui-icon` attribute — so the single CSS rule above styles them all.
+const IconMix = () => (
+  <>
+    <AccessTimeFilled aria-label="Access time (SVG)" />
+    <CalendarLtrRegular aria-label="Calendar (SVG)" />
+    <SendRegular aria-label="Send (font)" />
+    <SettingsFilled aria-label="Settings (font)" />
+    <AlertRegular aria-label="Alert (headless)" />
+    <StarFilled aria-label="Star (headless)" />
+  </>
+);
+
 export const TargetIconsFromCss = () => {
   const styles = useStyles();
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', alignItems: 'flex-start' }}>
       <div className={styles.toolbar}>
-        <AccessTimeFilled aria-label="Access time" />
-        <CalendarLtrRegular aria-label="Calendar" />
-        <SendRegular aria-label="Send" />
-        <SettingsFilled aria-label="Settings" />
+        <IconMix />
       </div>
 
       <div className={mergeClasses(styles.toolbar, styles.danger)}>
-        <AccessTimeFilled aria-label="Access time" />
-        <CalendarLtrRegular aria-label="Calendar" />
-        <SendRegular aria-label="Send" />
-        <SettingsFilled aria-label="Settings" />
+        <IconMix />
       </div>
     </div>
   );
@@ -52,12 +72,14 @@ TargetIconsFromCss.parameters = {
   docs: {
     description: {
       story: [
-        'Every icon — SVG or font, `Filled`, `Regular`, sized or resizable — renders a **`data-fui-icon`** attribute.',
+        'Every icon — SVG or font, Griffel or headless, `Filled`, `Regular`, sized or resizable — renders a **`data-fui-icon`** attribute.',
         'That gives you one universal selector, `[data-fui-icon]`, to style *all* icons within a scope from a single CSS rule,',
         'without adding a `className` to each icon.',
         '',
-        'The two toolbars below share the same base rule (`& [data-fui-icon]` sets color + size); the second layers a scoped',
-        'override that recolors its icons — the icon markup is identical in both.',
+        'Each toolbar below mixes all three delivery mechanisms — SVG icons from `@fluentui/react-icons` (Griffel), font icons from',
+        '`@fluentui/react-icons/fonts/*`, and headless icons from `@fluentui/react-icons/headless/svg/*`. Their rendered markup differs',
+        '(`<svg>` vs `<i>`), yet the same base rule (`& [data-fui-icon]` sets color + size) styles them all; the second toolbar layers a',
+        'scoped override that recolors its icons.',
         '',
         'The attribute name is also exported as the `DATA_FUI_ICON` constant. For more specific targeting, icons also carry the',
         'class-name constants (`fui-Icon`, `fui-Icon-filled`, `fui-Icon-regular`, `fui-Icon-light`, `fui-Icon-color`, `fui-Icon-font`).',

--- a/packages/docsite/stories/Icons/Recipes/TargetIconsFromCss.stories.tsx
+++ b/packages/docsite/stories/Icons/Recipes/TargetIconsFromCss.stories.tsx
@@ -1,6 +1,8 @@
 // Headless icons ship no CSS-in-JS runtime — you opt into styling by importing
 // the shipped vanilla CSS file once. This is the key difference from the standard API.
 import '@fluentui/react-icons/headless/styles.css';
+// Headless font icons additionally need their @font-face declarations.
+// import '@fluentui/react-icons/headless/fonts/styles.css';
 
 import { makeStyles, mergeClasses, tokens } from '@fluentui/react-components';
 // SVG icons (Griffel / CSS-in-JS)
@@ -12,6 +14,9 @@ import { SettingsFilled } from '@fluentui/react-icons/fonts/settings';
 // Headless icons — vanilla CSS, no Griffel runtime.
 import { AlertRegular } from '@fluentui/react-icons/headless/svg/alert';
 import { StarFilled } from '@fluentui/react-icons/headless/svg/star';
+// Headless font icons — vanilla CSS + the icon font.
+import { HomeFilled } from '@fluentui/react-icons/headless/fonts/home';
+import { SearchRegular } from '@fluentui/react-icons/headless/fonts/search';
 import * as React from 'react';
 
 const useStyles = makeStyles({
@@ -38,17 +43,20 @@ const useStyles = makeStyles({
   },
 });
 
-// A mix of all three delivery mechanisms. The rendered markup differs per flavor
-// (Griffel `<svg>`, headless `<svg>`, font `<i>`), but each one emits the same
-// `data-fui-icon` attribute — so the single CSS rule above styles them all.
+// A mix of every delivery mechanism. The rendered markup differs per flavor
+// (Griffel `<svg>`, Griffel font `<i>`, headless `<svg>`, headless font `<i>`),
+// but each one emits the same `data-fui-icon` attribute — so the single CSS rule
+// above styles them all.
 const IconMix = () => (
   <>
     <AccessTimeFilled aria-label="Access time (SVG)" />
     <CalendarLtrRegular aria-label="Calendar (SVG)" />
     <SendRegular aria-label="Send (font)" />
     <SettingsFilled aria-label="Settings (font)" />
-    <AlertRegular aria-label="Alert (headless)" />
-    <StarFilled aria-label="Star (headless)" />
+    <AlertRegular aria-label="Alert (headless SVG)" />
+    <StarFilled aria-label="Star (headless SVG)" />
+    <HomeFilled aria-label="Home (headless font)" />
+    <SearchRegular aria-label="Search (headless font)" />
   </>
 );
 
@@ -76,10 +84,10 @@ TargetIconsFromCss.parameters = {
         'That gives you one universal selector, `[data-fui-icon]`, to style *all* icons within a scope from a single CSS rule,',
         'without adding a `className` to each icon.',
         '',
-        'Each toolbar below mixes all three delivery mechanisms — SVG icons from `@fluentui/react-icons` (Griffel), font icons from',
-        '`@fluentui/react-icons/fonts/*`, and headless icons from `@fluentui/react-icons/headless/svg/*`. Their rendered markup differs',
-        '(`<svg>` vs `<i>`), yet the same base rule (`& [data-fui-icon]` sets color + size) styles them all; the second toolbar layers a',
-        'scoped override that recolors its icons.',
+        'Each toolbar below mixes every delivery mechanism — Griffel SVG (`@fluentui/react-icons/svg/*`), Griffel font',
+        '(`@fluentui/react-icons/fonts/*`), headless SVG (`@fluentui/react-icons/headless/svg/*`), and headless font',
+        '(`@fluentui/react-icons/headless/fonts/*`). Their rendered markup differs (`<svg>` vs `<i>`), yet the same base rule',
+        '(`& [data-fui-icon]` sets color + size) styles them all; the second toolbar layers a scoped override that recolors its icons.',
         '',
         'The attribute name is also exported as the `DATA_FUI_ICON` constant. For more specific targeting, icons also carry the',
         'class-name constants (`fui-Icon`, `fui-Icon-filled`, `fui-Icon-regular`, `fui-Icon-light`, `fui-Icon-color`, `fui-Icon-font`).',

--- a/packages/react-icons/src/headless/styles.css
+++ b/packages/react-icons/src/headless/styles.css
@@ -1,7 +1,19 @@
 /* Headless Fluent Icons — attribute-selector based styles (no CSS-in-JS runtime) */
 
 /* ===== SVG Icon Defaults ===== */
-[data-fui-icon] {
+/*
+ * `[data-fui-icon]` is the only selector shared with the Griffel (CSS-in-JS) API —
+ * every icon from both APIs carries this attribute. Wrapping it in `:where()` gives
+ * it ZERO specificity so any class-based styling always wins, regardless of
+ * stylesheet injection order. This is what lets these vanilla-CSS defaults coexist
+ * with Griffel: Griffel's `bundleIcon` hides the inactive variant with a class rule
+ * (`display: none`, specificity 0,1,0) on an element that also has `[data-fui-icon]`.
+ * Without `:where()` the two tie on specificity and source order decides — and since
+ * this file is often injected after Griffel's runtime styles, the default would win
+ * and unhide the variant, rendering BOTH bundled icons. Every other `data-fui-icon-*`
+ * selector below is headless-only, so it never ties with a Griffel class.
+ */
+:where([data-fui-icon]) {
   display: inline;
   line-height: 0;
 }


### PR DESCRIPTION
> Follow-up of #1153 (which introduced the shared `data-fui-icon` attribute + headless vanilla CSS).

## What

Fixes an intermittent bug where, on a page using **both** the headless icons (with their vanilla `styles.css`) **and** the standard Griffel (CSS-in-JS) API, the headless base styles leak onto Griffel-rendered icons and override intended styling. The most visible symptom: a Griffel `bundleIcon` renders **both** the filled and regular variants instead of just one.

**bundle icon clash:**

<img width="1831" height="611" alt="image" src="https://github.com/user-attachments/assets/d2684470-e1e0-4df4-a4af-d1faec41fbdd" />

**multi rendering variant clash:**

<img width="1933" height="607" alt="image" src="https://github.com/user-attachments/assets/bdb88406-74f3-4e70-8a3d-5c1feb07cd22" />


## Why

#1153 gave **every** icon — SVG or font, Griffel or headless — the shared `data-fui-icon` attribute so a single selector can target them all. The headless `styles.css` then styles icons through that attribute, e.g.:

```css
[data-fui-icon] { display: inline; line-height: 0; }
```

The problem: this base rule has normal specificity `(0,1,0)` and matches **Griffel** icons too (they carry the same attribute). So it competes, at equal specificity, with any class-based styling on those same elements — and on a tie, **stylesheet source order wins**. Since the vanilla CSS is typically injected after Griffel's runtime styles, the headless default wins and clobbers the other rule. It's order-dependent, so it surfaces intermittently across dev, prod, HMR, and code-splitting.

This is **not specific to `bundleIcon`** — it's a general hazard of the shared `data-fui-icon` selector across rendering approaches:

- **`bundleIcon`** (most visible): Griffel hides the inactive variant with `.fXXXX { display: none }` `(0,1,0)`; the base `[data-fui-icon] { display: inline }` ties and, injected later, unhides it → both variants show.
- **Cross-rendering `[data-fui-icon]` styling** (demonstrated in the recipe story): any consumer or Griffel styling applied to icons via the shared attribute can be overridden the same way whenever it ties with the headless base defaults.

## Fix

Wrap the shared base rule in `:where()` so it carries **zero specificity**:

```css
:where([data-fui-icon]) {
  display: inline;
  line-height: 0;
}
```

Any real class/attribute styling — Griffel's `display: none`, the headless `[data-fui-icon-hidden]` state, or a consumer's own `[data-fui-icon]` rule — now always wins regardless of injection order. `[data-fui-icon]` is the **only** selector shared with Griffel (Griffel handles hiding/rtl/font-family via its own classes and never emits the other `data-fui-icon-*` attributes), so this is the only rule that needs changing.

## Verification

- Reproduced deterministically and confirmed the fix in a live Storybook: the hidden Griffel variant goes from `display: block` (both visible, buggy) to `display: none` (correctly hidden) once the base rule is zero-specificity.
- `react-icons` headless unit tests: 23/23 pass.

## Also

Extends the **"Target every icon from CSS"** docsite recipe to render Griffel SVG, font (`/fonts/*`), and headless (`/headless/svg/*`) icons together — demonstrating the universal `[data-fui-icon]` selector across all three delivery mechanisms, which is exactly the cross-rendering scenario this fix protects.