### PR TITLE
docs(docsite): reorganize Color variant guidance into runnable recipes, provide valid HCM workaround

### DIFF
--- a/packages/docsite/stories/Icons/ColorVariants/ColorVariantsDescription.md
+++ b/packages/docsite/stories/Icons/ColorVariants/ColorVariantsDescription.md
@@ -8,42 +8,7 @@ A handful of icons ship a `Color` variant (e.g. `CalendarColor`) that renders wi
 
 Color variants do not work in Windows High Contrast Mode, making them inaccessible for users who depend on high-contrast settings ([#951](https://github.com/microsoft/fluentui-system-icons/issues/951)).
 
-**Workaround:** If you must keep color variants during migration, bundle them with `Filled` variants and switch using a `forced-colors` media query:
-
-```tsx
-import { makeStyles } from '@griffel/react';
-import { bundleIcon, iconFilledClassName, iconRegularClassName } from '@fluentui/react-icons';
-import { CodeBlock48Color, CodeBlock48Filled } from '@fluentui/react-icons';
-
-const CodeBlock48ColorFixed = bundleIcon(CodeBlock48Filled, CodeBlock48Color);
-
-const useStyles = makeStyles({
-  icon: {
-    [`& .${iconFilledClassName}`]: {
-      display: 'none',
-    },
-    [`& .${iconRegularClassName}`]: {
-      display: 'inline',
-    },
-
-    '@media (forced-colors: active)': {
-      [`& .${iconFilledClassName}`]: {
-        display: 'inline',
-      },
-      [`& .${iconRegularClassName}`]: {
-        display: 'none',
-      },
-    },
-  },
-});
-
-function MyComponent() {
-  const styles = useStyles();
-  return <CodeBlock48ColorFixed className={styles.icon} />;
-}
-```
-
-**Note:** This approach increases bundle size as both variants are included.
+**Workaround:** If you must keep color variants during migration, bundle them with their `Filled` variant and swap on a `forced-colors` media query. See the runnable [Keeping Color icons usable in High Contrast Mode](?path=/docs/icons-recipes--docs#keeping-color-icons-usable-in-high-contrast-mode) recipe.
 
 ### 2. SVG gradient ID collision
 
@@ -51,7 +16,7 @@ Color icons with gradients use non-scoped `id` attributes. When multiple instanc
 
 **Workarounds:**
 
-- **Scoped IDs via `idPrefix`** (recommended): see [Scoping gradient IDs with `idPrefix`](#scoping-gradient-ids-with-idprefix) below.
+- **Scoped IDs via `idPrefix`** (recommended): pass a unique `idPrefix` per rendered instance so each icon owns its gradient ids. See the runnable [Rendering the same Color icon multiple times](?path=/docs/icons-recipes--docs#rendering-the-same-color-icon-multiple-times) recipe.
 - **SVG sprites**: Wrap the icon in a `<symbol>` and reference it via `<use>`, avoiding duplicate gradient IDs.
 - **Absolute positioning off-screen**: Use `position: 'absolute', top: '-9999px'` instead of `display: 'none'`.
 - **`visibility: 'hidden'`**: Hides the icon while keeping the gradient definition accessible (maintains layout space).
@@ -65,34 +30,11 @@ Color variants have insufficient contrast ratios in dark themes, failing WCAG ac
 
 Most color icons contain small visual details that could be treated as text-equivalent elements requiring 4.5:1 contrast, making them non-compliant in dark themes.
 
-## Scoping gradient IDs with `idPrefix`
-
-`Color` variants render their gradients, clip paths, and filters using locally-defined SVG `id`s. Because SVG IDs live in the **global DOM namespace**, rendering the same color icon multiple times produces duplicate IDs — and hiding one instance with `display: none` can break the gradients of the others ([#936](https://github.com/microsoft/fluentui-system-icons/issues/936)).
-
-Pass a unique **`idPrefix`** per rendered instance to scope every `id` and its `url(#…)` reference, eliminating the collision:
-
-```tsx
-<CalendarColor idPrefix="cal-a-" />
-<CalendarColor idPrefix="cal-b-" />
-```
-
-The example below renders the same icon twice per column with the first instance hidden via `display: none`. **Without** `idPrefix` (left) the visible icon loses its gradients because both instances share the same IDs; **with** a unique `idPrefix` per instance (right) it renders correctly.
-
-> **Notes**
->
-> - `idPrefix` only applies to `Color` variants; mono-color icons ignore it.
-> - **On React 18+, `React.useId()` is the recommended source** — it's stable across re-renders and SSR-safe:
->
->   ```tsx
->   const id = React.useId();
->   return <CalendarColor idPrefix={id} />;
->   ```
->
->   Use **one `useId()` per component instance**. If a component renders several color icons, append a discriminator so they don't collide with each other (e.g. ``idPrefix={`${id}-${i}`}``). The colons in `useId()` output are fine — `url(#…)` resolves via `getElementById`, not CSS selectors.
->
-> - On React 16.8–17 (no `useId`), derive a **stable, unique** value from your data/key instead. Either way, avoid regenerating it on every render so the icon's memoized output stays cached.
-> - For color-icon-heavy trees that re-render frequently, also consider wrapping icons in `React.memo` to skip renders when props are unchanged — it is complementary to the built-in `idPrefix` memoization.
-
 ## Migration path
 
-Replace `Color` variants with `Filled` or `Regular` variants. If you need multi-color effects, use the layering technique described in the [Recipes](?path=/docs/icons-recipes--docs) page.
+**1. Preferred — migrate away from `Color` variants.** Replace each `Color` icon with a `Filled` or `Regular` variant. If you need a multi-color look, layer monochrome variants instead of reaching for a `Color` icon — see the [Using multiple colors for single-color icons](?path=/docs/icons-recipes--docs#using-multiple-colors-for-single-color-icons) recipe.
+
+**2. Only if you cannot migrate yet — keep `Color` variants safely.** Address both known pitfalls:
+
+- **High Contrast Mode:** bundle the icon with its `Filled` variant and swap on a `forced-colors` media query — see [Keeping Color icons usable in High Contrast Mode](?path=/docs/icons-recipes--docs#keeping-color-icons-usable-in-high-contrast-mode).
+- **Gradient ID collisions:** pass a unique `idPrefix` per rendered instance — see [Rendering the same Color icon multiple times](?path=/docs/icons-recipes--docs#rendering-the-same-color-icon-multiple-times).

--- a/packages/docsite/stories/Icons/ColorVariants/ColorVariantsGallery.stories.tsx
+++ b/packages/docsite/stories/Icons/ColorVariants/ColorVariantsGallery.stories.tsx
@@ -1,0 +1,36 @@
+import { makeStyles, tokens } from '@fluentui/react-components';
+import { CalendarColor, CameraColor, MailColor, PersonColor, VideoColor } from '@fluentui/react-icons';
+import * as React from 'react';
+
+const useStyles = makeStyles({
+  gallery: {
+    display: 'flex',
+    gap: '24px',
+    fontSize: '48px',
+    color: tokens.colorNeutralForeground1,
+  },
+});
+
+// A small visual reference of what `Color` variants look like. The concept page
+// is documentation-focused; the runnable patterns live in Icons/Recipes.
+export const Gallery = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.gallery}>
+      <CalendarColor aria-label="Calendar" />
+      <MailColor aria-label="Mail" />
+      <PersonColor aria-label="Person" />
+      <CameraColor aria-label="Camera" />
+      <VideoColor aria-label="Video" />
+    </div>
+  );
+};
+Gallery.storyName = 'Color variants at a glance';
+Gallery.parameters = {
+  docs: {
+    description: {
+      story: 'A few `Color` variants shown for reference. See the notes above for why they are deprecated.',
+    },
+  },
+};

--- a/packages/docsite/stories/Icons/ColorVariants/index.stories.tsx
+++ b/packages/docsite/stories/Icons/ColorVariants/index.stories.tsx
@@ -2,7 +2,7 @@ import { CalendarColor } from '@fluentui/react-icons';
 
 import descriptionMd from './ColorVariantsDescription.md';
 
-export { ColorIdPrefix } from './ColorIdPrefix.stories';
+export { Gallery } from './ColorVariantsGallery.stories';
 
 export default {
   title: 'Icons/Color Variants',
@@ -12,10 +12,10 @@ export default {
       description: {
         component: descriptionMd,
       },
-      // Drop the duplicate Primary hero and the auto Args table: the `idPrefix`
-      // prop is already documented in the description ("Scoping gradient IDs with
-      // idPrefix"), and the table would otherwise render above the demo. Keeps
-      // the Fluent addon chrome (TOC, theme/RTL/copy toggles).
+      // The concept page explains *why* Color variants are deprecated and links
+      // to Icons/Recipes for the runnable `idPrefix` and High Contrast Mode
+      // patterns. It keeps only a small visual gallery. Drop the Primary hero
+      // and Args table.
       skipPrimaryStory: true,
       hideArgsTable: true,
     },

--- a/packages/docsite/stories/Icons/Recipes/ColorHcmForcedColors.stories.tsx
+++ b/packages/docsite/stories/Icons/Recipes/ColorHcmForcedColors.stories.tsx
@@ -1,0 +1,57 @@
+import { makeStyles } from '@fluentui/react-components';
+import {
+  bundleIcon,
+  CodeBlock48Color,
+  CodeBlock48Filled,
+  iconFilledClassName,
+  iconRegularClassName,
+} from '@fluentui/react-icons';
+import * as React from 'react';
+
+// `bundleIcon(Filled, Color)` puts the Filled variant in the "filled" slot and
+// the Color variant in the "regular" slot. Out of the box it already shows the
+// Color variant and hides Filled, so we only need to flip them under
+// `forced-colors: active` (Windows High Contrast Mode) — a Color variant
+// collapses to a solid CanvasText block in HCM.
+const CodeBlock48ColorHcm = bundleIcon(CodeBlock48Filled, CodeBlock48Color);
+
+const useStyles = makeStyles({
+  // `bundleIcon` spreads `className` onto BOTH svgs, so we target each icon with
+  // a compound-self selector (`&.` — no space), not a descendant one (`& .`).
+  // That matches the svg directly (no wrapper needed) and wins over bundleIcon's
+  // internal single-class display rules.
+  icon: {
+    fontSize: '48px',
+
+    '@media (forced-colors: active)': {
+      [`&.${iconFilledClassName}`]: {
+        display: 'inline',
+      },
+      [`&.${iconRegularClassName}`]: {
+        display: 'none',
+      },
+    },
+  },
+});
+
+export const ColorHcmForcedColors = () => {
+  const styles = useStyles();
+
+  return <CodeBlock48ColorHcm className={styles.icon} aria-label="Code block" />;
+};
+ColorHcmForcedColors.storyName = 'Keeping Color icons usable in High Contrast Mode';
+ColorHcmForcedColors.parameters = {
+  docs: {
+    description: {
+      story: [
+        'Color variants do not render in Windows High Contrast Mode (HCM). If you must keep a `Color` icon during migration,',
+        'bundle it with its `Filled` variant via `bundleIcon(Filled, Color)` and swap between them with a `forced-colors` media query.',
+        '',
+        'By default the `Color` variant shows; when `forced-colors: active` the `Filled` variant takes over so the icon stays visible',
+        'and HCM-compliant. Toggle High Contrast Mode (or emulate `forced-colors` in DevTools) to see the swap.',
+        '',
+        '**Note:** this ships both variants, so it increases bundle size. Prefer migrating to `Filled`/`Regular` outright when you can.',
+      ].join('\n'),
+    },
+  },
+};

--- a/packages/docsite/stories/Icons/Recipes/ColorIdPrefix.md
+++ b/packages/docsite/stories/Icons/Recipes/ColorIdPrefix.md
@@ -1,0 +1,23 @@
+Rendering the same `Color` variant more than once can break its gradients because SVG `id`s live in the global DOM namespace. Click the button to hide the first instance with `display: none`: **without** `idPrefix` (left) the remaining visible icon loses its gradients — its shared `<defs>` were removed with the hidden instance; **with** a unique `idPrefix` per instance (right) each icon owns its ids, so it keeps rendering correctly.
+
+Pass a unique **`idPrefix`** per rendered instance to scope every `id` and its `url(#…)` reference:
+
+```tsx
+<CalendarColor idPrefix="cal-a-" />
+<CalendarColor idPrefix="cal-b-" />
+```
+
+**Notes**
+
+- `idPrefix` only applies to `Color` variants; mono-color icons ignore it.
+- **On React 18+, `React.useId()` is the recommended source** — stable across re-renders and SSR-safe:
+
+  ```tsx
+  const id = React.useId();
+  return <CalendarColor idPrefix={id} />;
+  ```
+
+  Use **one `useId()` per component instance**. If a component renders several color icons, append a discriminator (e.g. ``idPrefix={`${id}-${i}`}``). The colons in `useId()` output are fine — `url(#…)` resolves via `getElementById`, not CSS selectors.
+
+- On React 16.8–17 (no `useId`), derive a **stable, unique** value from your data/key instead. Avoid regenerating it on every render so the memoized output stays cached.
+- For color-icon-heavy trees that re-render frequently, also consider wrapping icons in `React.memo` — complementary to the built-in `idPrefix` memoization.

--- a/packages/docsite/stories/Icons/Recipes/ColorIdPrefix.stories.tsx
+++ b/packages/docsite/stories/Icons/Recipes/ColorIdPrefix.stories.tsx
@@ -2,6 +2,8 @@ import { Body1Stronger, Button, makeStyles, tokens } from '@fluentui/react-compo
 import { CalendarColor } from '@fluentui/react-icons';
 import * as React from 'react';
 
+import description from './ColorIdPrefix.md';
+
 const useClasses = makeStyles({
   root: {
     display: 'flex',
@@ -77,34 +79,7 @@ ColorIdPrefix.storyName = 'Rendering the same Color icon multiple times';
 ColorIdPrefix.parameters = {
   docs: {
     description: {
-      story: [
-        'Rendering the same `Color` variant more than once can break its gradients because SVG `id`s live in the global DOM namespace.',
-        'Click the button to hide the first instance with `display: none`: **without** `idPrefix` (left) the remaining visible icon',
-        'loses its gradients — its shared `<defs>` were removed with the hidden instance; **with** a unique `idPrefix` per instance',
-        '(right) each icon owns its ids, so it keeps rendering correctly.',
-        '',
-        'Pass a unique **`idPrefix`** per rendered instance to scope every `id` and its `url(#…)` reference:',
-        '',
-        '```tsx',
-        '<CalendarColor idPrefix="cal-a-" />',
-        '<CalendarColor idPrefix="cal-b-" />',
-        '```',
-        '',
-        '**Notes**',
-        '',
-        '- `idPrefix` only applies to `Color` variants; mono-color icons ignore it.',
-        '- **On React 18+, `React.useId()` is the recommended source** — stable across re-renders and SSR-safe:',
-        '',
-        '  ```tsx',
-        '  const id = React.useId();',
-        '  return <CalendarColor idPrefix={id} />;',
-        '  ```',
-        '',
-        '  Use **one `useId()` per component instance**. If a component renders several color icons, append a discriminator',
-        '  (e.g. ``idPrefix={`${id}-${i}`}``). The colons in `useId()` output are fine — `url(#…)` resolves via `getElementById`, not CSS selectors.',
-        '- On React 16.8–17 (no `useId`), derive a **stable, unique** value from your data/key instead. Avoid regenerating it on every render so the memoized output stays cached.',
-        '- For color-icon-heavy trees that re-render frequently, also consider wrapping icons in `React.memo` — complementary to the built-in `idPrefix` memoization.',
-      ].join('\n'),
+      story: description,
     },
   },
 };

--- a/packages/docsite/stories/Icons/Recipes/ColorIdPrefix.stories.tsx
+++ b/packages/docsite/stories/Icons/Recipes/ColorIdPrefix.stories.tsx
@@ -29,8 +29,9 @@ const useClasses = makeStyles({
   },
 });
 
-// Canonical `idPrefix` demo — re-exported by both the Color Variants page and the
-// Recipes page so the demo stays defined in a single place (1:1, no duplication).
+// `idPrefix` recipe: scope a Color icon's gradient/clip-path/filter ids so the
+// same icon can render multiple times without id collisions. The Color Variants
+// concept page links here rather than duplicating the demo.
 export const ColorIdPrefix = () => {
   const classes = useClasses();
   // Toggling `display: none` on one instance is what triggers the gradient ID
@@ -76,8 +77,34 @@ ColorIdPrefix.storyName = 'Rendering the same Color icon multiple times';
 ColorIdPrefix.parameters = {
   docs: {
     description: {
-      story:
-        'Rendering the same `Color` variant more than once can break its gradients because SVG `id`s live in the global DOM namespace. Click the button to hide the first instance with `display: none`: **without** `idPrefix` (left) the remaining visible icon loses its gradients — its shared `<defs>` were removed with the hidden instance; **with** a unique `idPrefix` per instance (right) each icon owns its ids, so it keeps rendering correctly.',
+      story: [
+        'Rendering the same `Color` variant more than once can break its gradients because SVG `id`s live in the global DOM namespace.',
+        'Click the button to hide the first instance with `display: none`: **without** `idPrefix` (left) the remaining visible icon',
+        'loses its gradients — its shared `<defs>` were removed with the hidden instance; **with** a unique `idPrefix` per instance',
+        '(right) each icon owns its ids, so it keeps rendering correctly.',
+        '',
+        'Pass a unique **`idPrefix`** per rendered instance to scope every `id` and its `url(#…)` reference:',
+        '',
+        '```tsx',
+        '<CalendarColor idPrefix="cal-a-" />',
+        '<CalendarColor idPrefix="cal-b-" />',
+        '```',
+        '',
+        '**Notes**',
+        '',
+        '- `idPrefix` only applies to `Color` variants; mono-color icons ignore it.',
+        '- **On React 18+, `React.useId()` is the recommended source** — stable across re-renders and SSR-safe:',
+        '',
+        '  ```tsx',
+        '  const id = React.useId();',
+        '  return <CalendarColor idPrefix={id} />;',
+        '  ```',
+        '',
+        '  Use **one `useId()` per component instance**. If a component renders several color icons, append a discriminator',
+        '  (e.g. ``idPrefix={`${id}-${i}`}``). The colons in `useId()` output are fine — `url(#…)` resolves via `getElementById`, not CSS selectors.',
+        '- On React 16.8–17 (no `useId`), derive a **stable, unique** value from your data/key instead. Avoid regenerating it on every render so the memoized output stays cached.',
+        '- For color-icon-heavy trees that re-render frequently, also consider wrapping icons in `React.memo` — complementary to the built-in `idPrefix` memoization.',
+      ].join('\n'),
     },
   },
 };

--- a/packages/docsite/stories/Icons/Recipes/index.stories.tsx
+++ b/packages/docsite/stories/Icons/Recipes/index.stories.tsx
@@ -4,7 +4,8 @@ import descriptionMd from './RecipesDescription.md';
 
 export { TargetIconsFromCss } from './TargetIconsFromCss.stories';
 export { MultipleColors } from './MultipleColors.stories';
-export { ColorIdPrefix } from '../ColorVariants/ColorIdPrefix.stories';
+export { ColorIdPrefix } from './ColorIdPrefix.stories';
+export { ColorHcmForcedColors } from './ColorHcmForcedColors.stories';
 
 export default {
   title: 'Icons/Recipes',


### PR DESCRIPTION
## Summary

Reorganizes the docsite `Color` variant documentation so the **concept page** explains *why* Color variants are deprecated, while the **Icons/Recipes** page hosts the runnable how-to patterns. Also fixes a real bug in the High Contrast Mode workaround.

## Changes

- **Move the `idPrefix` demo** from the Color Variants page into `Icons/Recipes` and fold the `React.useId()` / React 16–17 guidance into the recipe description.
- **New HCM recipe** (`ColorHcmForcedColors`): bundles `Filled` + `Color` and swaps on a `forced-colors` media query so a Color icon stays usable in Windows High Contrast Mode.

https://github.com/user-attachments/assets/44c04cda-bf98-4d44-8d7a-1bc99fb7757f



- **Trim the Color Variants concept page**: keep the deprecation rationale (HCM / gradient-ID collision / dark-theme contrast) and link out to the recipes instead of inlining implementations. Add a small visual gallery so the autodocs page keeps its entry.
- **Polish the Migration path** into a two-step priority ladder: (1) migrate away from Color → stacked-monochrome recipe; (2) only if you can't yet → support HCM + `idPrefix`.

## The HCM bug fix (worth a look)

The original inline workaround applied the `forced-colors` display-swap styles **directly to the bundled icon**. Because `bundleIcon` spreads `className` onto both svgs, the atomic classes and `fui-Icon-*` classes end up on the **same element** — so the Griffel-generated `& .fui-Icon-*` **descendant** selector never matched. The swap did nothing, `bundleIcon` kept the Color variant visible, and `forced-color-adjust: auto` collapsed its gradient into a solid CanvasText block (a "black box").

Fix: use a **compound-self** selector `&.${iconFilledClassName}` (no space) instead of the descendant `& .${iconFilledClassName}`. It matches the svg directly (specificity 0,2,0, beating `bundleIcon`'s single-class 0,1,0 defaults) — **no wrapper required**, and only the `@media (forced-colors: active)` block is needed since `bundleIcon` already hides `Filled` in normal mode.

## Verification

Verified live in Storybook via emulated `forced-colors`:
- **Normal:** Color (gradient) variant shown, Filled hidden.
- **Forced-colors:** Filled CanvasText glyph shown, Color hidden.

All cross-page recipe anchor links resolve correctly.

## Notes

- Docs/story-only changes; no shipped package code touched.
