### PR TITLE
chore: pin repo to public npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,11 @@
+# Pin this repo to the public npm registry.
+#
+# Rationale: resolving through a proxy/mirror registry (e.g. a personal
+# `registry=` in ~/.npmrc) makes npm rewrite `resolved` URLs — and in some
+# setups drop `resolved`/`integrity` entirely — producing enormous, noisy
+# package-lock.json diffs and a lockfile CI cannot verify.
+#
+# Keeping the registry pinned here means every contributor regenerates the
+# lockfile against the same source, so lockfile diffs stay minimal and are
+# limited to the dependencies actually changed.
+registry=https://registry.npmjs.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -5260,7 +5260,7 @@
     },
     "node_modules/@fluentui/storybook-llms-extractor/node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cliui/-/cliui-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
       "dev": true,
       "license": "ISC",
@@ -5275,14 +5275,14 @@
     },
     "node_modules/@fluentui/storybook-llms-extractor/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@fluentui/storybook-llms-extractor/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
       "dev": true,
       "license": "MIT",
@@ -5292,7 +5292,7 @@
     },
     "node_modules/@fluentui/storybook-llms-extractor/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "dev": true,
       "license": "MIT",
@@ -5307,7 +5307,7 @@
     },
     "node_modules/@fluentui/storybook-llms-extractor/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "dev": true,
       "license": "MIT",
@@ -5325,7 +5325,7 @@
     },
     "node_modules/@fluentui/storybook-llms-extractor/node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/y18n/-/y18n-5.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
       "dev": true,
       "license": "ISC",
@@ -5335,7 +5335,7 @@
     },
     "node_modules/@fluentui/storybook-llms-extractor/node_modules/yargs": {
       "version": "17.7.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs/-/yargs-17.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
       "integrity": "sha1-d53/5ryv7FlqcXLpgyiaWIZH+qo=",
       "dev": true,
       "license": "MIT",
@@ -5480,14 +5480,14 @@
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
       "integrity": "sha1-g2iGnctzW+Ln9ct2R9544WeiUfs=",
       "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/topo": {
       "version": "5.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@hapi/topo/-/topo-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
       "integrity": "sha1-3ESOMyxsbjek3AL9hLqNRLmvsBI=",
       "devOptional": true,
       "license": "BSD-3-Clause",
@@ -5747,7 +5747,7 @@
     },
     "node_modules/@jest/types/node_modules/@types/yargs": {
       "version": "17.0.35",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/yargs/-/yargs-17.0.35.tgz",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
       "integrity": "sha1-BwE+RqpNfX1QpJ4VYEwcU0DU6yQ=",
       "license": "MIT",
       "dependencies": {
@@ -6556,7 +6556,7 @@
     },
     "node_modules/@nx/eslint-plugin": {
       "version": "22.7.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nx/eslint-plugin/-/eslint-plugin-22.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/@nx/eslint-plugin/-/eslint-plugin-22.7.7.tgz",
       "integrity": "sha1-VTp9L8ykVu1wFT7dK/f8a9Dyvkw=",
       "dev": true,
       "license": "MIT",
@@ -6585,7 +6585,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@emnapi/core": {
       "version": "1.4.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
       "integrity": "sha1-v7sMu7ufluxOLE/ZF7e75Ulc7Ms=",
       "dev": true,
       "license": "MIT",
@@ -6596,7 +6596,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@emnapi/runtime": {
       "version": "1.4.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
       "integrity": "sha1-xncQ0GYQcPOEGLZHRYTxWd44q6k=",
       "dev": true,
       "license": "MIT",
@@ -6606,7 +6606,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@emnapi/wasi-threads": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
       "integrity": "sha1-cD/AlNlp4nOxtxwpJSOy95KGK/Q=",
       "dev": true,
       "license": "MIT",
@@ -6616,7 +6616,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@jest/diff-sequences": {
       "version": "30.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
       "integrity": "sha1-Dt7erk0HH1yP/jZ40V86G+CRVr4=",
       "dev": true,
       "license": "MIT",
@@ -6626,7 +6626,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@nx/devkit": {
       "version": "22.7.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nx/devkit/-/devkit-22.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.7.7.tgz",
       "integrity": "sha1-08V6dCP79Abw/iFXGid7w8cDsP8=",
       "dev": true,
       "license": "MIT",
@@ -6645,7 +6645,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@nx/js": {
       "version": "22.7.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nx/js/-/js-22.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/@nx/js/-/js-22.7.7.tgz",
       "integrity": "sha1-DXhCohMy3LWyLOb/O+Z6Kq/zlaw=",
       "dev": true,
       "license": "MIT",
@@ -6688,7 +6688,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-darwin-arm64": {
       "version": "22.7.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.7.7.tgz",
       "integrity": "sha1-UFdghdAEcHYuD8QPUdG6b9VsbSQ=",
       "cpu": [
         "arm64"
@@ -6702,7 +6702,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-darwin-x64": {
       "version": "22.7.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nx/nx-darwin-x64/-/nx-darwin-x64-22.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.7.7.tgz",
       "integrity": "sha1-BSVWhfa36A1LSQoeIHwVBBOyddA=",
       "cpu": [
         "x64"
@@ -6716,7 +6716,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-freebsd-x64": {
       "version": "22.7.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.7.7.tgz",
       "integrity": "sha1-CRdoWuIVEt3NsmvX9xB/+9eWRiI=",
       "cpu": [
         "x64"
@@ -6730,7 +6730,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-linux-arm-gnueabihf": {
       "version": "22.7.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.7.7.tgz",
       "integrity": "sha1-b5JRV8h/S/zIPWLawsCa0e7AxnY=",
       "cpu": [
         "arm"
@@ -6744,7 +6744,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-linux-arm64-gnu": {
       "version": "22.7.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.7.tgz",
       "integrity": "sha1-SVXouGttqw5/O/JWR0COoqW0B58=",
       "cpu": [
         "arm64"
@@ -6758,7 +6758,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-linux-arm64-musl": {
       "version": "22.7.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.7.tgz",
       "integrity": "sha1-wiwF4YIqM4nhGxSWes+pKHFjTzo=",
       "cpu": [
         "arm64"
@@ -6772,7 +6772,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-linux-x64-gnu": {
       "version": "22.7.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.7.tgz",
       "integrity": "sha1-1Yh1c+fGwPmlEBDXUAGzFgdkS8Y=",
       "cpu": [
         "x64"
@@ -6786,7 +6786,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-linux-x64-musl": {
       "version": "22.7.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.7.tgz",
       "integrity": "sha1-Lxw1f1xHmgeFF4RplV/6wjG4zW8=",
       "cpu": [
         "x64"
@@ -6800,7 +6800,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-win32-arm64-msvc": {
       "version": "22.7.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.7.tgz",
       "integrity": "sha1-R0DTFR+lLctV60wbO77YjHi565Y=",
       "cpu": [
         "arm64"
@@ -6814,7 +6814,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-win32-x64-msvc": {
       "version": "22.7.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.7.7.tgz",
       "integrity": "sha1-h8wJ3CaeNYIGXYzdeHQfU680Xw4=",
       "cpu": [
         "x64"
@@ -6828,7 +6828,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@nx/workspace": {
       "version": "22.7.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nx/workspace/-/workspace-22.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-22.7.7.tgz",
       "integrity": "sha1-V1XNRp5CARLVUNqLeUqd7NCx6dE=",
       "dev": true,
       "license": "MIT",
@@ -6846,7 +6846,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
       "version": "8.64.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
       "integrity": "sha1-1F8VMEqUyFw52zF7cXsVj7YlmVg=",
       "dev": true,
       "license": "MIT",
@@ -6864,7 +6864,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
       "version": "8.64.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
       "integrity": "sha1-EG+n1Yz5z3dY892OQmrII37OrPM=",
       "dev": true,
       "license": "MIT",
@@ -6889,7 +6889,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@typescript-eslint/types": {
       "version": "8.64.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/types/-/types-8.64.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
       "integrity": "sha1-tB+O9d1AYWkIZYuZEZep1IbNpgs=",
       "dev": true,
       "license": "MIT",
@@ -6903,7 +6903,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.64.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
       "integrity": "sha1-uNUSVeLXJutL2A05ek+0FwwC7sw=",
       "dev": true,
       "license": "MIT",
@@ -6931,7 +6931,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@typescript-eslint/utils": {
       "version": "8.64.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/utils/-/utils-8.64.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
       "integrity": "sha1-mLsgEM+3VLQZhbnJPm6LPc171gA=",
       "dev": true,
       "license": "MIT",
@@ -6955,7 +6955,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.64.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
       "integrity": "sha1-eghCHRDlSWBzM1LNfJX6sXhOhHM=",
       "dev": true,
       "license": "MIT",
@@ -6973,7 +6973,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/address": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/address/-/address-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/address/-/address-2.0.3.tgz",
       "integrity": "sha1-6RCQBhXbPYogwEDUxxBjEGL8S6g=",
       "dev": true,
       "license": "MIT",
@@ -6983,7 +6983,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/axios": {
       "version": "1.16.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/axios/-/axios-1.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
       "integrity": "sha1-+OXdkxzvKl+MMiFtV4Ttovh1Drc=",
       "dev": true,
       "license": "MIT",
@@ -6995,7 +6995,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
       "dev": true,
       "license": "MIT",
@@ -7005,7 +7005,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/brace-expansion": {
       "version": "5.0.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
       "integrity": "sha1-Gw5GlltHna1lr3N7SgJ5CgVJgzc=",
       "dev": true,
       "license": "MIT",
@@ -7018,7 +7018,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cliui/-/cliui-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
       "dev": true,
       "license": "ISC",
@@ -7033,7 +7033,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/detect-port": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/detect-port/-/detect-port-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-2.1.0.tgz",
       "integrity": "sha1-A9cmRIkfpFHKVgm4MQeooOvQP5E=",
       "dev": true,
       "license": "MIT",
@@ -7050,7 +7050,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/dotenv-expand": {
       "version": "12.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
       "integrity": "sha1-YyPOylHKDBsfAFXiq6OceXgXOaY=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -7066,14 +7066,14 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@nx/eslint-plugin/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true,
       "license": "MIT",
@@ -7083,7 +7083,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -7096,7 +7096,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/globals": {
       "version": "17.7.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/globals/-/globals-17.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
       "integrity": "sha1-VT1VCQtN3oIJ7C2kJYDW5+fYsQ0=",
       "dev": true,
       "license": "MIT",
@@ -7109,7 +7109,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/ignore": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore/-/ignore-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
       "integrity": "sha1-aleq70yQ3yesNZCHXSno8RmIyI4=",
       "dev": true,
       "license": "MIT",
@@ -7119,7 +7119,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
       "dev": true,
       "license": "MIT",
@@ -7129,7 +7129,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/minimatch": {
       "version": "10.2.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-10.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha1-vUhoegvjjtKWE5kQVgD4MglYYdE=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -7145,7 +7145,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/nx": {
       "version": "22.7.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nx/-/nx-22.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-22.7.7.tgz",
       "integrity": "sha1-uT3XB6Pw2WYBKqYq0DI+Q94sR+Y=",
       "dev": true,
       "hasInstallScript": true,
@@ -7293,7 +7293,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/nx/node_modules/balanced-match": {
       "version": "4.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
       "integrity": "sha1-Yzei8j4GBKMEgUI0MvmerGA1mfk=",
       "dev": true,
       "license": "MIT",
@@ -7303,7 +7303,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/nx/node_modules/brace-expansion": {
       "version": "5.0.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
       "integrity": "sha1-7Gj+CmQaKdhxFXnK9kHQW64fIoU=",
       "dev": true,
       "license": "MIT",
@@ -7316,7 +7316,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/nx/node_modules/ignore": {
       "version": "7.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore/-/ignore-7.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha1-TLX2zX1MerA2VzjHrqiIuqbX79k=",
       "dev": true,
       "license": "MIT",
@@ -7326,7 +7326,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/nx/node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha1-KEZONgYOmR+noR0CedLT87V6foo=",
       "dev": true,
       "license": "ISC",
@@ -7339,7 +7339,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
@@ -7352,7 +7352,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "dev": true,
       "license": "MIT",
@@ -7367,7 +7367,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/ts-api-utils": {
       "version": "2.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha1-Ss1KFV4ic0mQpe0f6el/ETvLN8E=",
       "dev": true,
       "license": "MIT",
@@ -7380,7 +7380,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "dev": true,
       "license": "MIT",
@@ -7398,7 +7398,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/y18n/-/y18n-5.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
       "dev": true,
       "license": "ISC",
@@ -7408,7 +7408,7 @@
     },
     "node_modules/@nx/eslint-plugin/node_modules/yargs": {
       "version": "17.7.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs/-/yargs-17.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha1-mR3zmspnWhkrgW4eA2P5110qomk=",
       "dev": true,
       "license": "MIT",
@@ -8108,7 +8108,7 @@
     },
     "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/core": {
       "version": "1.9.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
       "integrity": "sha1-OHAmXs/8c1LQHq1i2Ng9g1ii0DQ=",
       "license": "MIT",
       "optional": true,
@@ -8119,7 +8119,7 @@
     },
     "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
       "version": "1.9.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha1-i0aaPbFggXytsd6QUCEanR6oT6I=",
       "license": "MIT",
       "optional": true,
@@ -8373,7 +8373,7 @@
     },
     "node_modules/@phenomnomnominal/tsquery": {
       "version": "6.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@phenomnomnominal/tsquery/-/tsquery-6.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-6.2.0.tgz",
       "integrity": "sha1-KSN6c8sAougOI/9gWcnNAcLxgys=",
       "dev": true,
       "license": "MIT",
@@ -8398,7 +8398,7 @@
     },
     "node_modules/@react-native-community/cli": {
       "version": "20.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@react-native-community/cli/-/cli-20.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-20.2.0.tgz",
       "integrity": "sha1-n5XbHn0noZ8UwH966Xit4KbSOz4=",
       "devOptional": true,
       "license": "MIT",
@@ -8428,7 +8428,7 @@
     },
     "node_modules/@react-native-community/cli-clean": {
       "version": "20.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@react-native-community/cli-clean/-/cli-clean-20.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-20.2.0.tgz",
       "integrity": "sha1-aGlRP2V99YeQacJrzcDo0BYfZic=",
       "devOptional": true,
       "license": "MIT",
@@ -8441,7 +8441,7 @@
     },
     "node_modules/@react-native-community/cli-config": {
       "version": "20.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@react-native-community/cli-config/-/cli-config-20.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-20.2.0.tgz",
       "integrity": "sha1-m32QJ4ZyQjtbWf8GOnR2sXPKNbs=",
       "devOptional": true,
       "license": "MIT",
@@ -8456,7 +8456,7 @@
     },
     "node_modules/@react-native-community/cli-config-android": {
       "version": "20.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@react-native-community/cli-config-android/-/cli-config-android-20.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config-android/-/cli-config-android-20.2.0.tgz",
       "integrity": "sha1-mTFJOWf4riemfBri48+JVPAVTaA=",
       "devOptional": true,
       "license": "MIT",
@@ -8469,7 +8469,7 @@
     },
     "node_modules/@react-native-community/cli-config-apple": {
       "version": "20.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@react-native-community/cli-config-apple/-/cli-config-apple-20.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config-apple/-/cli-config-apple-20.2.0.tgz",
       "integrity": "sha1-IEJLFJYuTP6tFjbN/Ohu/U9qAdA=",
       "devOptional": true,
       "license": "MIT",
@@ -8482,7 +8482,7 @@
     },
     "node_modules/@react-native-community/cli-config/node_modules/cosmiconfig": {
       "version": "9.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
       "integrity": "sha1-nlYVFjvs9qgiEfsz0vaJR8JdDF4=",
       "devOptional": true,
       "license": "MIT",
@@ -8509,7 +8509,7 @@
     },
     "node_modules/@react-native-community/cli-config/node_modules/import-fresh": {
       "version": "3.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/import-fresh/-/import-fresh-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha1-nOy1ZQPAraHydB271lRuSxO1fM8=",
       "devOptional": true,
       "license": "MIT",
@@ -8526,7 +8526,7 @@
     },
     "node_modules/@react-native-community/cli-config/node_modules/js-yaml": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
       "devOptional": true,
       "funding": [
@@ -8549,14 +8549,14 @@
     },
     "node_modules/@react-native-community/cli-config/node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha1-7KKE910pZQeTCdwK2SVauy68FjI=",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@react-native-community/cli-config/node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parse-json/-/parse-json-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
       "devOptional": true,
       "license": "MIT",
@@ -8575,7 +8575,7 @@
     },
     "node_modules/@react-native-community/cli-config/node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/resolve-from/-/resolve-from-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
       "devOptional": true,
       "license": "MIT",
@@ -8585,7 +8585,7 @@
     },
     "node_modules/@react-native-community/cli-doctor": {
       "version": "20.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@react-native-community/cli-doctor/-/cli-doctor-20.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-20.2.0.tgz",
       "integrity": "sha1-knTokvnWyhrZfidv5agnbP4McK8=",
       "devOptional": true,
       "license": "MIT",
@@ -8609,7 +8609,7 @@
     },
     "node_modules/@react-native-community/cli-doctor/node_modules/ora": {
       "version": "5.4.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ora/-/ora-5.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
       "integrity": "sha1-GyZ4Qmr0rEpQkAjl5KyemVnbnhg=",
       "devOptional": true,
       "license": "MIT",
@@ -8633,7 +8633,7 @@
     },
     "node_modules/@react-native-community/cli-doctor/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "devOptional": true,
       "license": "ISC",
@@ -8646,7 +8646,7 @@
     },
     "node_modules/@react-native-community/cli-platform-android": {
       "version": "20.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@react-native-community/cli-platform-android/-/cli-platform-android-20.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-20.2.0.tgz",
       "integrity": "sha1-R2/rPbZKLcdlzZ5AKeEVXGKFcJI=",
       "devOptional": true,
       "license": "MIT",
@@ -8660,7 +8660,7 @@
     },
     "node_modules/@react-native-community/cli-platform-apple": {
       "version": "20.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@react-native-community/cli-platform-apple/-/cli-platform-apple-20.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-apple/-/cli-platform-apple-20.2.0.tgz",
       "integrity": "sha1-lVVPO96egnevbte7chWMvqf8SGM=",
       "devOptional": true,
       "license": "MIT",
@@ -8674,7 +8674,7 @@
     },
     "node_modules/@react-native-community/cli-platform-ios": {
       "version": "20.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@react-native-community/cli-platform-ios/-/cli-platform-ios-20.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-20.2.0.tgz",
       "integrity": "sha1-svPUoAGtx04LcihZ/OVExo/f1eI=",
       "devOptional": true,
       "license": "MIT",
@@ -8684,7 +8684,7 @@
     },
     "node_modules/@react-native-community/cli-server-api": {
       "version": "20.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@react-native-community/cli-server-api/-/cli-server-api-20.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-20.2.0.tgz",
       "integrity": "sha1-mPKSImmxCM30SKuglTZOn3SlwUQ=",
       "devOptional": true,
       "license": "MIT",
@@ -8703,7 +8703,7 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/@jest/schemas": {
       "version": "29.6.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jest/schemas/-/schemas-29.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha1-Qwtc6KTgBEp+OBlmMwWnswkcjgM=",
       "devOptional": true,
       "license": "MIT",
@@ -8716,14 +8716,14 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/@sinclair/typebox": {
       "version": "0.27.12",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
       "integrity": "sha1-DKzTz/BHoyk2sazkfqfIbqq2Cn8=",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
       "devOptional": true,
       "license": "MIT",
@@ -8736,7 +8736,7 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/body-parser": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/body-parser/-/body-parser-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha1-bYZi9NjDNgKLismqJCUbDKZLpDc=",
       "devOptional": true,
       "license": "MIT",
@@ -8761,7 +8761,7 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/content-type": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-type/-/content-type-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha1-L7Pt5p3/oK94ynxM51iWgGOLVt8=",
       "devOptional": true,
       "license": "MIT",
@@ -8775,7 +8775,7 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/iconv-lite": {
       "version": "0.7.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha1-hO4S+WPn3lC8AaE+FgoHizsPQV8=",
       "devOptional": true,
       "license": "MIT",
@@ -8792,7 +8792,7 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/is-wsl": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-wsl/-/is-wsl-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "devOptional": true,
       "license": "MIT",
@@ -8802,7 +8802,7 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/media-typer": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/media-typer/-/media-typer-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha1-ardLjy0zIPIGSyqHo455Mf86VWE=",
       "devOptional": true,
       "license": "MIT",
@@ -8812,7 +8812,7 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/mime-db": {
       "version": "1.54.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-db/-/mime-db-1.54.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha1-zds+5PnGRTDf9kAjZmHULLajFPU=",
       "devOptional": true,
       "license": "MIT",
@@ -8822,7 +8822,7 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/mime-types": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-types/-/mime-types-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha1-OQAtQYJXXVrwNv+hGBAPJSSy4qs=",
       "devOptional": true,
       "license": "MIT",
@@ -8839,7 +8839,7 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/on-finished": {
       "version": "2.4.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/on-finished/-/on-finished-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha1-WMjEQRblSEWtV/FKsQsDUzGErD8=",
       "devOptional": true,
       "license": "MIT",
@@ -8852,7 +8852,7 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/open": {
       "version": "6.4.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/open/-/open-6.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
       "integrity": "sha1-XBPpbQ3IlGhhZPGJZez+iJ7PyKk=",
       "devOptional": true,
       "license": "MIT",
@@ -8865,7 +8865,7 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/pretty-format": {
       "version": "29.7.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pretty-format/-/pretty-format-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha1-ykLHWDEPNlv6caC9oKgHFgt3aBI=",
       "devOptional": true,
       "license": "MIT",
@@ -8880,7 +8880,7 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/raw-body": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/raw-body/-/raw-body-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha1-PjraWuVWj5CV2EN2/TpJuPsAClE=",
       "devOptional": true,
       "license": "MIT",
@@ -8896,7 +8896,7 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/type-is": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/type-is/-/type-is-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha1-cdGnBTKTWC4WrJ8+uvGrmqSeVXA=",
       "devOptional": true,
       "license": "MIT",
@@ -8915,7 +8915,7 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/ws": {
       "version": "6.2.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ws/-/ws-6.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.6.tgz",
       "integrity": "sha1-VFpqkVsAtmCTf38sMITWI/svxZ8=",
       "devOptional": true,
       "license": "MIT",
@@ -8925,7 +8925,7 @@
     },
     "node_modules/@react-native-community/cli-tools": {
       "version": "20.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@react-native-community/cli-tools/-/cli-tools-20.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-20.2.0.tgz",
       "integrity": "sha1-89rXmswUe7WNC4gZa5sRjJRMk8A=",
       "devOptional": true,
       "license": "MIT",
@@ -8944,7 +8944,7 @@
     },
     "node_modules/@react-native-community/cli-tools/node_modules/ora": {
       "version": "5.4.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ora/-/ora-5.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
       "integrity": "sha1-GyZ4Qmr0rEpQkAjl5KyemVnbnhg=",
       "devOptional": true,
       "license": "MIT",
@@ -8968,7 +8968,7 @@
     },
     "node_modules/@react-native-community/cli-tools/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "devOptional": true,
       "license": "ISC",
@@ -8981,7 +8981,7 @@
     },
     "node_modules/@react-native-community/cli-types": {
       "version": "20.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@react-native-community/cli-types/-/cli-types-20.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-20.2.0.tgz",
       "integrity": "sha1-RgMMRXGlUchy2gjir/7fFwxmuIE=",
       "devOptional": true,
       "license": "MIT",
@@ -8991,7 +8991,7 @@
     },
     "node_modules/@react-native-community/cli/node_modules/commander": {
       "version": "9.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-9.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
       "integrity": "sha1-vAjR61zt98y3l6lhmdQce8PmDTA=",
       "devOptional": true,
       "license": "MIT",
@@ -9001,7 +9001,7 @@
     },
     "node_modules/@react-native-community/cli/node_modules/fs-extra": {
       "version": "8.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
       "devOptional": true,
       "license": "MIT",
@@ -9016,7 +9016,7 @@
     },
     "node_modules/@react-native-community/cli/node_modules/jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "devOptional": true,
       "license": "MIT",
@@ -9026,7 +9026,7 @@
     },
     "node_modules/@react-native-community/cli/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "devOptional": true,
       "license": "ISC",
@@ -9039,7 +9039,7 @@
     },
     "node_modules/@react-native-community/cli/node_modules/universalify": {
       "version": "0.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/universalify/-/universalify-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
       "devOptional": true,
       "license": "MIT",
@@ -9141,7 +9141,7 @@
     },
     "node_modules/@react-native/codegen/node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cliui/-/cliui-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
       "license": "ISC",
       "dependencies": {
@@ -9155,13 +9155,13 @@
     },
     "node_modules/@react-native/codegen/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "license": "MIT"
     },
     "node_modules/@react-native/codegen/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
       "license": "MIT",
       "engines": {
@@ -9170,7 +9170,7 @@
     },
     "node_modules/@react-native/codegen/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "license": "MIT",
       "dependencies": {
@@ -9184,7 +9184,7 @@
     },
     "node_modules/@react-native/codegen/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "license": "MIT",
       "dependencies": {
@@ -9201,7 +9201,7 @@
     },
     "node_modules/@react-native/codegen/node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/y18n/-/y18n-5.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
       "license": "ISC",
       "engines": {
@@ -9210,7 +9210,7 @@
     },
     "node_modules/@react-native/codegen/node_modules/yargs": {
       "version": "17.7.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs/-/yargs-17.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
       "integrity": "sha1-d53/5ryv7FlqcXLpgyiaWIZH+qo=",
       "license": "MIT",
       "dependencies": {
@@ -9771,7 +9771,7 @@
     },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@sideway/address/-/address-4.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
       "integrity": "sha1-S8FJoAdmI87ZnKggi6eA1lqZudU=",
       "devOptional": true,
       "license": "BSD-3-Clause",
@@ -9781,14 +9781,14 @@
     },
     "node_modules/@sideway/formula": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@sideway/formula/-/formula-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
       "integrity": "sha1-gPy8uvfOAx4O8t0psb/Hw/WDYR8=",
       "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@sideway/pinpoint": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha1-z/j/rcNyrSn9P3gneusp5jLMcN8=",
       "devOptional": true,
       "license": "BSD-3-Clause"
@@ -9831,7 +9831,7 @@
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
       "integrity": "sha1-cZ33+0F2a8FDNp6qDdVtjch8mVg=",
       "dev": true,
       "license": "MIT",
@@ -9844,7 +9844,7 @@
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha1-p5tV26+GBIEvUtFAssmrQbwVC7g=",
       "dev": true,
       "license": "MIT"
@@ -11199,7 +11199,7 @@
     },
     "node_modules/@types/esquery": {
       "version": "1.5.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/esquery/-/esquery-1.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/esquery/-/esquery-1.5.4.tgz",
       "integrity": "sha1-6/06O8pttQRGaIulWS0Yu5uAfpE=",
       "dev": true,
       "license": "MIT",
@@ -11333,7 +11333,7 @@
     },
     "node_modules/@types/node": {
       "version": "22.20.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-22.20.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
       "integrity": "sha1-hOfN9jzaogwTSqMXzMkBqiHhbw4=",
       "license": "MIT",
       "dependencies": {
@@ -11521,7 +11521,7 @@
     },
     "node_modules/@types/yargs": {
       "version": "15.0.20",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/yargs/-/yargs-15.0.20.tgz",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.20.tgz",
       "integrity": "sha1-bQChJMn3V0J9TKPLyH2up3gFPGg=",
       "dev": true,
       "license": "MIT",
@@ -11600,7 +11600,7 @@
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.64.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
       "integrity": "sha1-FMTik5DXMlp/ihIYwniP1km4XaY=",
       "dev": true,
       "license": "MIT",
@@ -11622,7 +11622,7 @@
     },
     "node_modules/@typescript-eslint/project-service/node_modules/@typescript-eslint/types": {
       "version": "8.64.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/types/-/types-8.64.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
       "integrity": "sha1-tB+O9d1AYWkIZYuZEZep1IbNpgs=",
       "dev": true,
       "license": "MIT",
@@ -11653,7 +11653,7 @@
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.64.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
       "integrity": "sha1-xirI6pFzw8rIs4uOZuMKBGtUiFE=",
       "dev": true,
       "license": "MIT",
@@ -12670,7 +12670,7 @@
     },
     "node_modules/async-limiter": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/async-limiter/-/async-limiter-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha1-3TeelPDbgxCwgpH51kwyCXZmF/0=",
       "devOptional": true,
       "license": "MIT"
@@ -13761,7 +13761,7 @@
     },
     "node_modules/chalk-template": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chalk-template/-/chalk-template-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-1.1.2.tgz",
       "integrity": "sha1-iP8T51ozPSMjBOE6vEjFtb4V8c4=",
       "dev": true,
       "license": "MIT",
@@ -13777,7 +13777,7 @@
     },
     "node_modules/chalk-template/node_modules/chalk": {
       "version": "5.6.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chalk/-/chalk-5.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha1-sSOLbiPqM3r3HH+KKV21rwwViuo=",
       "dev": true,
       "license": "MIT",
@@ -14354,7 +14354,7 @@
     },
     "node_modules/command-exists": {
       "version": "1.2.9",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/command-exists/-/command-exists-1.2.9.tgz",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
       "integrity": "sha1-xQclrzgIyKsCYP1gsB+/oluVT2k=",
       "devOptional": true,
       "license": "MIT"
@@ -14451,7 +14451,7 @@
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
       "integrity": "sha1-rkDptXzdORVAiigF69OlWFYI3IE=",
       "dev": true,
       "license": "MIT"
@@ -15482,7 +15482,7 @@
     },
     "node_modules/effect": {
       "version": "3.22.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/effect/-/effect-3.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.22.0.tgz",
       "integrity": "sha1-dK++51OnhYbnhOQrKZ0tRp3BOzo=",
       "dev": true,
       "license": "MIT",
@@ -15695,7 +15695,7 @@
     },
     "node_modules/errorhandler": {
       "version": "1.5.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/errorhandler/-/errorhandler-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.2.tgz",
       "integrity": "sha1-3QqjlS7KRK/3wphefSRsWTLXBEQ=",
       "devOptional": true,
       "license": "MIT",
@@ -16518,7 +16518,7 @@
     },
     "node_modules/fantasticon/node_modules/glob": {
       "version": "13.0.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob/-/glob-13.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
       "integrity": "sha1-B4ZmVmpCUUfMrPvS4zLetmor5x0=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -16536,7 +16536,7 @@
     },
     "node_modules/fast-check": {
       "version": "3.23.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-check/-/fast-check-3.23.2.tgz",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
       "integrity": "sha1-ASnx635PUA9Y6CkO3IPGcOSldKI=",
       "dev": true,
       "funding": [
@@ -17464,7 +17464,7 @@
     },
     "node_modules/glob": {
       "version": "8.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob/-/glob-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
       "integrity": "sha1-04j2Vlk+9wjuPjRkD9+5mp/Rwz4=",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
@@ -17514,7 +17514,7 @@
     },
     "node_modules/glob/node_modules/minimatch": {
       "version": "5.1.9",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-5.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
       "integrity": "sha1-EpPvFdsAmLOUVA6Pn3RPn9qN7ks=",
       "dev": true,
       "license": "ISC",
@@ -19351,7 +19351,7 @@
     },
     "node_modules/joi": {
       "version": "17.13.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/joi/-/joi-17.13.4.tgz",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
       "integrity": "sha1-rWFT2XzlWOs6O1k+DUPqtR3xxHQ=",
       "devOptional": true,
       "license": "BSD-3-Clause",
@@ -19614,7 +19614,7 @@
     },
     "node_modules/jsonc-eslint-parser": {
       "version": "2.4.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz",
       "integrity": "sha1-8TVFT9NXhOzBuEiQjw0+mKW+lDM=",
       "dev": true,
       "license": "MIT",
@@ -19633,7 +19633,7 @@
     },
     "node_modules/jsonc-eslint-parser/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
@@ -20923,7 +20923,7 @@
     },
     "node_modules/metro/node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cliui/-/cliui-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
       "license": "ISC",
       "dependencies": {
@@ -20937,7 +20937,7 @@
     },
     "node_modules/metro/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "license": "MIT"
     },
@@ -20958,7 +20958,7 @@
     },
     "node_modules/metro/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
       "license": "MIT",
       "engines": {
@@ -21010,7 +21010,7 @@
     },
     "node_modules/metro/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "license": "MIT",
       "dependencies": {
@@ -21024,7 +21024,7 @@
     },
     "node_modules/metro/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "license": "MIT",
       "dependencies": {
@@ -21062,7 +21062,7 @@
     },
     "node_modules/metro/node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/y18n/-/y18n-5.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
       "license": "ISC",
       "engines": {
@@ -21071,7 +21071,7 @@
     },
     "node_modules/metro/node_modules/yargs": {
       "version": "17.7.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs/-/yargs-17.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
       "integrity": "sha1-d53/5ryv7FlqcXLpgyiaWIZH+qo=",
       "license": "MIT",
       "dependencies": {
@@ -21758,7 +21758,7 @@
     },
     "node_modules/mimic-function": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mimic-function/-/mimic-function-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha1-rL4rM0n5m53qyn+3Dki4PpTmcHY=",
       "dev": true,
       "license": "MIT",
@@ -22431,7 +22431,7 @@
     },
     "node_modules/nocache": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nocache/-/nocache-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/nocache/-/nocache-3.0.4.tgz",
       "integrity": "sha1-Wzelbsbgn8fUAdzq7S6rQMi/33k=",
       "devOptional": true,
       "license": "MIT",
@@ -22524,7 +22524,7 @@
     },
     "node_modules/node-stream-zip": {
       "version": "1.15.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
       "integrity": "sha1-FYrbiO2ABMbEmjlrUKal3jvKM+o=",
       "devOptional": true,
       "license": "MIT",
@@ -22593,7 +22593,7 @@
     },
     "node_modules/npm-package-arg": {
       "version": "12.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/npm-package-arg/-/npm-package-arg-12.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-12.0.2.tgz",
       "integrity": "sha1-Ox4E6+ZRzEUCjimGZOjBXOnAykA=",
       "dev": true,
       "license": "ISC",
@@ -22609,7 +22609,7 @@
     },
     "node_modules/npm-package-arg/node_modules/hosted-git-info": {
       "version": "8.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
       "integrity": "sha1-FTzYTAPGchSB4WpXCet0saCrLtA=",
       "dev": true,
       "license": "ISC",
@@ -22622,14 +22622,14 @@
     },
     "node_modules/npm-package-arg/node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/npm-package-arg/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
@@ -22835,7 +22835,7 @@
     },
     "node_modules/nx/node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/y18n/-/y18n-5.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
       "dev": true,
       "license": "ISC",
@@ -22845,7 +22845,7 @@
     },
     "node_modules/nx/node_modules/yargs": {
       "version": "17.7.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs/-/yargs-17.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
       "integrity": "sha1-d53/5ryv7FlqcXLpgyiaWIZH+qo=",
       "dev": true,
       "license": "MIT",
@@ -23947,7 +23947,7 @@
     },
     "node_modules/proc-log": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/proc-log/-/proc-log-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
       "integrity": "sha1-5sk883rvM/g1xTSF8xT1DqkGqdg=",
       "dev": true,
       "license": "ISC",
@@ -24044,7 +24044,7 @@
     },
     "node_modules/pure-rand": {
       "version": "6.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pure-rand/-/pure-rand-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha1-0XPPIyWCMZdsy9sFJHyXh5V2BPI=",
       "dev": true,
       "funding": [
@@ -24408,7 +24408,7 @@
     },
     "node_modules/react-native/node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cliui/-/cliui-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
       "license": "ISC",
       "dependencies": {
@@ -24431,13 +24431,13 @@
     },
     "node_modules/react-native/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "license": "MIT"
     },
     "node_modules/react-native/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
       "license": "MIT",
       "engines": {
@@ -24472,7 +24472,7 @@
     },
     "node_modules/react-native/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "license": "MIT",
       "dependencies": {
@@ -24486,7 +24486,7 @@
     },
     "node_modules/react-native/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "license": "MIT",
       "dependencies": {
@@ -24503,7 +24503,7 @@
     },
     "node_modules/react-native/node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "license": "MIT",
       "dependencies": {
@@ -24539,7 +24539,7 @@
     },
     "node_modules/react-native/node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/y18n/-/y18n-5.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
       "license": "ISC",
       "engines": {
@@ -24548,7 +24548,7 @@
     },
     "node_modules/react-native/node_modules/yargs": {
       "version": "17.7.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs/-/yargs-17.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
       "integrity": "sha1-d53/5ryv7FlqcXLpgyiaWIZH+qo=",
       "license": "MIT",
       "dependencies": {
@@ -24682,7 +24682,7 @@
     },
     "node_modules/read-yaml-file": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/read-yaml-file/-/read-yaml-file-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-2.1.0.tgz",
       "integrity": "sha1-xYZnEtue9TQ7TQLCQTutpTxBxKk=",
       "dev": true,
       "license": "MIT",
@@ -24696,7 +24696,7 @@
     },
     "node_modules/read-yaml-file/node_modules/js-yaml": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
       "dev": true,
       "funding": [
@@ -24719,7 +24719,7 @@
     },
     "node_modules/read-yaml-file/node_modules/strip-bom": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-bom/-/strip-bom-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha1-nDUFwdtFvO3KPZz3oW9cWqOQGHg=",
       "dev": true,
       "license": "MIT",
@@ -26305,7 +26305,7 @@
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
       "integrity": "sha1-OQA39ExK4aGuU1xf443Dq6jZl74=",
       "dev": true,
       "license": "MIT",
@@ -27031,7 +27031,7 @@
     },
     "node_modules/syncpack": {
       "version": "13.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/syncpack/-/syncpack-13.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/syncpack/-/syncpack-13.0.4.tgz",
       "integrity": "sha1-zdCpQS/AwCVDGRTl6GZyStdknyw=",
       "dev": true,
       "license": "MIT",
@@ -27072,7 +27072,7 @@
     },
     "node_modules/syncpack/node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
       "dev": true,
       "license": "MIT",
@@ -27085,7 +27085,7 @@
     },
     "node_modules/syncpack/node_modules/chalk": {
       "version": "5.6.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chalk/-/chalk-5.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha1-sSOLbiPqM3r3HH+KKV21rwwViuo=",
       "dev": true,
       "license": "MIT",
@@ -27098,7 +27098,7 @@
     },
     "node_modules/syncpack/node_modules/cli-cursor": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
       "integrity": "sha1-JKSDHs9aawHd6zL7caSyCIsNzjg=",
       "dev": true,
       "license": "MIT",
@@ -27114,7 +27114,7 @@
     },
     "node_modules/syncpack/node_modules/cli-spinners": {
       "version": "2.9.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha1-F3Oo9LnE1qwxVj31Oz/B15Ri/kE=",
       "dev": true,
       "license": "MIT",
@@ -27127,7 +27127,7 @@
     },
     "node_modules/syncpack/node_modules/commander": {
       "version": "13.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-13.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
       "integrity": "sha1-d2Fn22jHjzjczh+bjXuLmkiKv0Y=",
       "dev": true,
       "license": "MIT",
@@ -27137,7 +27137,7 @@
     },
     "node_modules/syncpack/node_modules/cosmiconfig": {
       "version": "9.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
       "integrity": "sha1-nlYVFjvs9qgiEfsz0vaJR8JdDF4=",
       "dev": true,
       "license": "MIT",
@@ -27164,14 +27164,14 @@
     },
     "node_modules/syncpack/node_modules/emoji-regex": {
       "version": "10.6.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha1-vz1uj3+P0ipl2XA0dbwBRzV6aw0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/syncpack/node_modules/enquirer": {
       "version": "2.4.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/enquirer/-/enquirer-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
       "integrity": "sha1-kzNLP710/HCXsiSrSo+35Av0rlY=",
       "dev": true,
       "license": "MIT",
@@ -27185,7 +27185,7 @@
     },
     "node_modules/syncpack/node_modules/globby": {
       "version": "14.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/globby/-/globby-14.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
       "integrity": "sha1-E4t453z1qNeU4yexXc6Avx+wpz4=",
       "dev": true,
       "license": "MIT",
@@ -27206,7 +27206,7 @@
     },
     "node_modules/syncpack/node_modules/ignore": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore/-/ignore-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
       "integrity": "sha1-aleq70yQ3yesNZCHXSno8RmIyI4=",
       "dev": true,
       "license": "MIT",
@@ -27216,7 +27216,7 @@
     },
     "node_modules/syncpack/node_modules/import-fresh": {
       "version": "3.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/import-fresh/-/import-fresh-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha1-nOy1ZQPAraHydB271lRuSxO1fM8=",
       "dev": true,
       "license": "MIT",
@@ -27233,7 +27233,7 @@
     },
     "node_modules/syncpack/node_modules/is-interactive": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-interactive/-/is-interactive-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
       "integrity": "sha1-QMV2FFk4JtoRAK3mBZd41ZfxbpA=",
       "dev": true,
       "license": "MIT",
@@ -27246,7 +27246,7 @@
     },
     "node_modules/syncpack/node_modules/is-unicode-supported": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
       "integrity": "sha1-CfCrDebTdE1I0mXruY9l0R8qmzo=",
       "dev": true,
       "license": "MIT",
@@ -27259,7 +27259,7 @@
     },
     "node_modules/syncpack/node_modules/js-yaml": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
       "dev": true,
       "funding": [
@@ -27282,21 +27282,21 @@
     },
     "node_modules/syncpack/node_modules/jsonc-parser": {
       "version": "3.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha1-8qUktPf9EePXkeVZl3rWC5i3mLQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/syncpack/node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha1-7KKE910pZQeTCdwK2SVauy68FjI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/syncpack/node_modules/log-symbols": {
       "version": "6.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/log-symbols/-/log-symbols-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
       "integrity": "sha1-u5Xl8FMiZRysMMD+tkBPnyqKlDk=",
       "dev": true,
       "license": "MIT",
@@ -27313,7 +27313,7 @@
     },
     "node_modules/syncpack/node_modules/log-symbols/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
       "integrity": "sha1-2CSYS2FsKSouGYIH1KYJmDhC9xQ=",
       "dev": true,
       "license": "MIT",
@@ -27326,7 +27326,7 @@
     },
     "node_modules/syncpack/node_modules/minimatch": {
       "version": "9.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-9.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha1-10+d1rV9g9jpjPuCEzsDl4vJKeU=",
       "dev": true,
       "license": "ISC",
@@ -27342,7 +27342,7 @@
     },
     "node_modules/syncpack/node_modules/onetime": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/onetime/-/onetime-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
       "integrity": "sha1-nxbJLYye9RIOOs2d2ZV8zuzBq2A=",
       "dev": true,
       "license": "MIT",
@@ -27358,7 +27358,7 @@
     },
     "node_modules/syncpack/node_modules/ora": {
       "version": "8.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ora/-/ora-8.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
       "integrity": "sha1-j7u3FRr+M7VA3RU/Fx/6i9OOmGE=",
       "dev": true,
       "license": "MIT",
@@ -27382,7 +27382,7 @@
     },
     "node_modules/syncpack/node_modules/ora/node_modules/strip-ansi": {
       "version": "7.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha1-0iomlSKDamJ6+NBLXD/Sx/o+MuM=",
       "dev": true,
       "license": "MIT",
@@ -27398,7 +27398,7 @@
     },
     "node_modules/syncpack/node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parse-json/-/parse-json-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
       "dev": true,
       "license": "MIT",
@@ -27417,7 +27417,7 @@
     },
     "node_modules/syncpack/node_modules/path-type": {
       "version": "6.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-type/-/path-type-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
       "integrity": "sha1-Lxu2eRqRzpkZTK7eXWxZIO2B61E=",
       "dev": true,
       "license": "MIT",
@@ -27430,7 +27430,7 @@
     },
     "node_modules/syncpack/node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/resolve-from/-/resolve-from-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
       "dev": true,
       "license": "MIT",
@@ -27440,7 +27440,7 @@
     },
     "node_modules/syncpack/node_modules/restore-cursor": {
       "version": "5.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
       "integrity": "sha1-B2bZVpnvrLFBUJk/VbrwlT6h6+c=",
       "dev": true,
       "license": "MIT",
@@ -27457,7 +27457,7 @@
     },
     "node_modules/syncpack/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
@@ -27470,7 +27470,7 @@
     },
     "node_modules/syncpack/node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
       "dev": true,
       "license": "ISC",
@@ -27483,7 +27483,7 @@
     },
     "node_modules/syncpack/node_modules/slash": {
       "version": "5.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/slash/-/slash-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
       "integrity": "sha1-vjrd3N8JrDjuvo3Nx7GlenWwlc4=",
       "dev": true,
       "license": "MIT",
@@ -27496,7 +27496,7 @@
     },
     "node_modules/syncpack/node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha1-tbuOIWXOJ11NQ0dt0nAK2Qkdttw=",
       "dev": true,
       "license": "MIT",
@@ -27514,7 +27514,7 @@
     },
     "node_modules/syncpack/node_modules/string-width/node_modules/strip-ansi": {
       "version": "7.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha1-0iomlSKDamJ6+NBLXD/Sx/o+MuM=",
       "dev": true,
       "license": "MIT",
@@ -27530,7 +27530,7 @@
     },
     "node_modules/syncpack/node_modules/unicorn-magic": {
       "version": "0.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
       "integrity": "sha1-Tv1FyFpp4N1XbSVTL7+iKqXIoQQ=",
       "dev": true,
       "license": "MIT",
@@ -27810,7 +27810,7 @@
     },
     "node_modules/tightrope": {
       "version": "0.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tightrope/-/tightrope-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/tightrope/-/tightrope-0.2.0.tgz",
       "integrity": "sha1-Wiodg5HYab43a5Fg3QOWW1MkOik=",
       "dev": true,
       "license": "MIT",
@@ -28114,7 +28114,7 @@
     },
     "node_modules/ts-toolbelt": {
       "version": "9.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
       "integrity": "sha1-UKJUJs/tUA1KCb0bOvtvKIee39U=",
       "dev": true,
       "license": "Apache-2.0"
@@ -28434,7 +28434,7 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-6.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha1-aR0ArzkJvpOn+qE75hs6W1DvEss=",
       "license": "MIT"
     },
@@ -28764,7 +28764,7 @@
     },
     "node_modules/validate-npm-package-name": {
       "version": "6.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/validate-npm-package-name/-/validate-npm-package-name-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-6.0.2.tgz",
       "integrity": "sha1-To0sTZOZdac90bemXo8I1EyF35Y=",
       "dev": true,
       "license": "ISC",
@@ -30558,7 +30558,7 @@
     },
     "node_modules/yaml": {
       "version": "2.9.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yaml/-/yaml-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha1-eCdK/ZNZih391hMN9qVm3vy/mqQ=",
       "license": "ISC",
       "bin": {
@@ -30573,7 +30573,7 @@
     },
     "node_modules/yargs": {
       "version": "14.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs/-/yargs-14.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
       "integrity": "sha1-Ghw+3O0a+yov6jNgS8bR2NaIpBQ=",
       "dev": true,
       "license": "MIT",
@@ -30602,7 +30602,7 @@
     },
     "node_modules/yargs/node_modules/find-up": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/find-up/-/find-up-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "dev": true,
       "license": "MIT",
@@ -30615,7 +30615,7 @@
     },
     "node_modules/yargs/node_modules/locate-path": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/locate-path/-/locate-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "dev": true,
       "license": "MIT",
@@ -30629,7 +30629,7 @@
     },
     "node_modules/yargs/node_modules/p-locate": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-locate/-/p-locate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "dev": true,
       "license": "MIT",
@@ -30642,7 +30642,7 @@
     },
     "node_modules/yargs/node_modules/path-exists": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true,
       "license": "MIT",
@@ -30652,7 +30652,7 @@
     },
     "node_modules/yargs/node_modules/yargs-parser": {
       "version": "15.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs-parser/-/yargs-parser-15.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
       "integrity": "sha1-MW4mPV/r6LOO72GsCSsz38ybERU=",
       "dev": true,
       "license": "ISC",


### PR DESCRIPTION
## Summary

Pins the repo to the **public npm registry** via a repo-level `.npmrc`, and normalizes the lockfile entries that still resolved to a Microsoft mirror.

## Why

A contributor whose personal `~/.npmrc` sets a proxy/mirror `registry=` makes npm rewrite `resolved` URLs when regenerating the lockfile — and in some setups drop `resolved`/`integrity` **entirely**. This produced enormous, misleading diffs: a recent PR adding a *single* devDependency generated a **17,283-line** lockfile diff, with 2,019 of 2,094 entries losing their integrity hashes.

npm resolves config as **project `.npmrc` > user `~/.npmrc`**, so committing this file makes every contributor regenerate against the same source regardless of local setup.

## Changes

- **`.npmrc`** (new) — `registry=https://registry.npmjs.org/`
- **`package-lock.json`** — normalized the **211** entries still pointing at the 1ES `npm-public` mirror (`ms-feed-{2,12,25}.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/`) back to `registry.npmjs.org`

## Lockfile audit

| | before | after |
|---|---|---|
| `registry.npmjs.org` | 1,922 | **2,133** |
| `*.pkgs.visualstudio.com` | 211 | **0** |
| missing `resolved`/`integrity` | 14 (all workspace pkgs — expected) | 14 |
| platform-specific native entries | 131 | 131 |

## Validation

- The lockfile diff is **211 insertions / 211 deletions, 100% `"resolved":` lines** — zero changes to versions, integrity hashes, or dependency graph.
- **`npm ci` passes** (2,019 packages) — this verifies every integrity hash against the public tarballs, proving the mirror served byte-identical tarballs.
- `npm config get registry` inside the repo returns the public registry, confirming the override works over a proxy-configured `~/.npmrc`.
- Lockfile is stable — a follow-up `npm install` produces no drift.
- Native optional deps intact (131 platform entries), including the `linux-x64-gnu` bindings CI depends on.

## Follow-up benefit

Combined with the root `optionalDependencies` pins, this should stop the recurring CI failures caused by [npm/cli#4828](https://github.com/npm/cli/issues/4828) (`Cannot find native binding`, `WorkspaceContext is not a constructor`) that stem from locally-regenerated lockfiles.
