### PR TITLE
chore(eslint-plugin-react-icons): prepare for release

### DIFF
--- a/packages/eslint-plugin-react-icons/package.json
+++ b/packages/eslint-plugin-react-icons/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluentui/eslint-plugin-react-icons",
   "version": "0.0.0",
-  "private": true,
   "description": "ESLint plugin for @fluentui/react-icons and @fluentui/react-brand-icons",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
## Summary

Drops `private: true` from `packages/eslint-plugin-react-icons/package.json` so `@fluentui/eslint-plugin-react-icons` is picked up by the release pipeline and published to npm.

## Details

The plugin was introduced in #1165 as a private workspace package. It now has a stable rule (`prefer-resizable`), build (`tsconfig.lib.json` → `lib/`), `exports`/`typings` map and a `files` allowlist, so it is ready to ship to consumers.

No other changes are required — versioning and publishing are handled by the existing nx release setup.

## Verification

- [x] CI green
