### PR TITLE
feat(react-icons): add opt-in native ESM build behind --enable-native-esm

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -161,6 +161,42 @@ jobs:
   #       accessToken: "placeholder"
   #       refreshToken: "placeholder"
 
+  verify-native-esm:
+    if: ${{ github.repository_owner == 'microsoft' }}
+    name: Verify native ESM output
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      actions: 'read'
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          filter: tree:0
+
+      - run: corepack enable
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.x
+          cache: 'yarn'
+
+      - run: yarn install --immutable
+
+      - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
+
+      # `@fluentui/react-icons` is still published as the historical dual build; native
+      # ESM-first output is opt-in behind `build.js --enable-native-esm`. Building that
+      # variant here keeps it from drifting as icons are added or changed, so flipping
+      # the default later stays a one-line change rather than a rediscovery exercise.
+      #
+      # This runs in its own job on purpose: the native ESM build rewrites
+      # `packages/react-icons/package.json` in place (type/main/exports), which would
+      # otherwise leak into the packaging and bundle-size steps of `build-npm`.
+      - name: Build and verify native ESM output
+        run: yarn nx affected -t verify-native-esm
+
   build-npm:
     if: ${{ github.repository_owner == 'microsoft' }}
     name: Build npm packages

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -161,9 +161,9 @@ jobs:
   #       accessToken: "placeholder"
   #       refreshToken: "placeholder"
 
-  verify-native-esm:
+  build-npm-native-esm:
     if: ${{ github.repository_owner == 'microsoft' }}
-    name: Verify native ESM output
+    name: Build npm packages (native ESM)
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'

--- a/packages/react-icons/esm-exports.smoke.test.js
+++ b/packages/react-icons/esm-exports.smoke.test.js
@@ -1,0 +1,48 @@
+// @ts-check
+import { describe, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Runs a verifier script in a **real, separate Node process** so the check exercises
+ * Node's native module resolver against the built output — not vitest's transform/
+ * resolver. A non-zero exit throws and fails the test.
+ * @param {string[]} args
+ */
+function runNode(args) {
+  execFileSync(process.execPath, args, { cwd: __dirname, stdio: 'inherit' });
+}
+
+// These checks only apply to the native ESM-first output (`build --enable-native-esm`).
+// In the default dual build the package has no `"type": "module"`, so Node parses
+// `lib/index.js` as CommonJS and a bare-Node `import` of the package legitimately
+// fails — that is the very limitation ESM-first packaging removes, not a regression.
+const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'));
+const isNativeEsmBuild = pkg.type === 'module';
+const describeNativeEsm = isNativeEsmBuild ? describe : describe.skip;
+
+// End-to-end proof that the published `exports` map loads under bare Node, for the
+// `import` and `require` conditions, in both the default (SVG) and `fluentIconFont`
+// (font) resolutions. See verify-esm-exports.{mjs,cjs} for what "loaded" vs
+// "resolve-only" means per entry.
+describeNativeEsm('export map — real Node e2e loading', () => {
+  it('ESM `import` condition (bare Node)', () => {
+    runNode(['verify-esm-exports.mjs']);
+  });
+
+  it('ESM `import` condition under `fluentIconFont`', () => {
+    runNode(['--conditions=fluentIconFont', 'verify-esm-exports.mjs', '--font']);
+  });
+
+  it('CJS `require` condition (bare Node)', () => {
+    runNode(['verify-esm-exports.cjs']);
+  });
+
+  it('CJS `require` condition under `fluentIconFont`', () => {
+    runNode(['--conditions=fluentIconFont', 'verify-esm-exports.cjs', '--font']);
+  });
+});

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -25,11 +25,14 @@
     "build:fonts-and-svg": "yarn generate:base-svg && yarn generate:font && yarn generate:rtl",
     "build:generate-chunks-and-atoms": "yarn convert:svg && yarn convert:fonts && yarn convert:merge-metadata",
     "build:js": "node scripts/build.js",
+    "build:js:native-esm": "node scripts/build.js --enable-native-esm",
     "build": "yarn clean && yarn build:fonts-and-svg && yarn build:generate-chunks-and-atoms && yarn build:js",
-    "build-verify": "yarn run -T vitest run build-verify.test.js build-transforms.test.js build-color-render.test.js",
+    "build-native-esm": "yarn clean && yarn build:fonts-and-svg && yarn build:generate-chunks-and-atoms && yarn build:js:native-esm",
+    "build-verify": "yarn run -T vitest run build-verify.test.js build-transforms.test.js build-color-render.test.js esm-exports.smoke.test.js",
+    "verify-native-esm": "yarn run -T vitest run esm-exports.smoke.test.js",
     "bundle-size": "yarn run -T monosize measure",
     "lint": "yarn run -T eslint src package.json",
-    "test": "yarn run -T vitest --exclude build-verify.test.js --exclude build-transforms.test.js --exclude build-color-render.test.js",
+    "test": "yarn run -T vitest --exclude build-verify.test.js --exclude build-transforms.test.js --exclude build-color-render.test.js --exclude esm-exports.smoke.test.js",
     "type-check:infra": "yarn run -T tsc -p tsconfig.utils.json"
   },
   "devDependencies": {

--- a/packages/react-icons/project.json
+++ b/packages/react-icons/project.json
@@ -23,6 +23,16 @@
     "build-verify": {
       "dependsOn": ["build"]
     },
+    "build-native-esm": {
+      "//": "Opt-in native ESM-first build (see scripts/module-format.js). Not cached: it rewrites package.json in place, which is not expressible as an nx output.",
+      "cache": false,
+      "dependsOn": ["^build"]
+    },
+    "verify-native-esm": {
+      "//": "Keeps the native ESM path honest as icons change, ahead of it becoming the default.",
+      "cache": false,
+      "dependsOn": ["build-native-esm"]
+    },
     "bundle-size": {
       "dependsOn": ["build"]
     }

--- a/packages/react-icons/scripts/build.js
+++ b/packages/react-icons/scripts/build.js
@@ -32,7 +32,10 @@ const { values: cliOptions } = parseArgs({
   allowPositionals: true,
 });
 
-main({ root: join(__dirname, '..'), enableNativeEsm: cliOptions['enable-native-esm'] });
+main({ root: join(__dirname, '..'), enableNativeEsm: cliOptions['enable-native-esm'] }).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
 
 /**
  * Builds source TypeScript and copys assets to the output directories.
@@ -43,7 +46,7 @@ main({ root: join(__dirname, '..'), enableNativeEsm: cliOptions['enable-native-e
  *
  * @param {{ root: string; enableNativeEsm?: boolean; }} options
  */
-function main(options) {
+async function main(options) {
   const projectRoot = options.root;
 
   transpileTsc({ moduleFormat: 'esnext', outDir: 'lib' }, projectRoot);
@@ -81,7 +84,7 @@ function main(options) {
   applyBabelTransform('lib-cjs', projectRoot);
 
   if (options.enableNativeEsm) {
-    convertToNativeEsm(projectRoot);
+    await convertToNativeEsm(projectRoot);
   }
 }
 
@@ -95,9 +98,9 @@ function main(options) {
  *
  * @param {string} projectRoot
  */
-function convertToNativeEsm(projectRoot) {
-  fullySpecifyEsm(join(projectRoot, 'lib'));
-  finalizeCjs(join(projectRoot, 'lib-cjs'));
+async function convertToNativeEsm(projectRoot) {
+  await fullySpecifyEsm(join(projectRoot, 'lib'));
+  await finalizeCjs(join(projectRoot, 'lib-cjs'));
 
   const pkgPath = join(projectRoot, 'package.json');
   const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));

--- a/packages/react-icons/scripts/build.js
+++ b/packages/react-icons/scripts/build.js
@@ -9,6 +9,21 @@ const { join, basename } = require('node:path');
 const glob = require('glob');
 const { transformSync } = require('@babel/core');
 
+const { fullySpecifyEsm, finalizeCjs, applyEsmFirstManifest } = require('./module-format');
+
+/**
+ * Opt-in switch for native ESM-first packaging.
+ *
+ * Off (the default) the build is byte-for-byte the historical dual output:
+ * extensionless specifiers in `lib/`, plain `.js` in `lib-cjs/`, manifest untouched.
+ *
+ * On, the emitted output becomes valid bare-Node ESM and the manifest is flipped to
+ * match. This flag exists so the tooling can live on `main` — and stay in sync as
+ * icons change — before the format is switched on for real. It is temporary: once
+ * ESM-first becomes the default, the flag and these branches get deleted.
+ */
+const enableNativeEsm = process.argv.includes('--enable-native-esm');
+
 main({ root: join(__dirname, '..') });
 
 /**
@@ -56,6 +71,29 @@ function main(options) {
 
   applyBabelTransform('lib', projectRoot);
   applyBabelTransform('lib-cjs', projectRoot);
+
+  if (enableNativeEsm) {
+    convertToNativeEsm(projectRoot);
+  }
+}
+
+/**
+ * Converts the freshly built dual output into native ESM-first output.
+ *
+ * Runs last on purpose: rewriting the manifest to `"type": "module"` changes how Node
+ * interprets every `.js` file in this package, so nothing may be `require`d after it.
+ * It also has to follow the sprite/headless export-map emitters, whose (format-agnostic)
+ * entries are picked up and converted along with the rest of the map.
+ *
+ * @param {string} projectRoot
+ */
+function convertToNativeEsm(projectRoot) {
+  fullySpecifyEsm(join(projectRoot, 'lib'));
+  finalizeCjs(join(projectRoot, 'lib-cjs'));
+
+  const pkgPath = join(projectRoot, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  writeFileSync(pkgPath, JSON.stringify(applyEsmFirstManifest(pkg), null, 2) + '\n');
 }
 
 // =================================================================================================

--- a/packages/react-icons/scripts/build.js
+++ b/packages/react-icons/scripts/build.js
@@ -5,6 +5,7 @@
 const { execSync } = require('node:child_process');
 const { copyFileSync, existsSync, readFileSync, writeFileSync } = require('node:fs');
 const { join, basename } = require('node:path');
+const { parseArgs } = require('node:util');
 
 const glob = require('glob');
 const { transformSync } = require('@babel/core');
@@ -22,7 +23,16 @@ const { fullySpecifyEsm, finalizeCjs, applyEsmFirstManifest } = require('./modul
  * icons change — before the format is switched on for real. It is temporary: once
  * ESM-first becomes the default, the flag and these branches get deleted.
  */
-const enableNativeEsm = process.argv.includes('--enable-native-esm');
+const { values: cliOptions } = parseArgs({
+  options: {
+    'enable-native-esm': { type: 'boolean', default: false },
+  },
+  // Fail loudly on a mistyped flag rather than silently doing a dual build.
+  strict: true,
+  allowPositionals: true,
+});
+
+const enableNativeEsm = cliOptions['enable-native-esm'];
 
 main({ root: join(__dirname, '..') });
 

--- a/packages/react-icons/scripts/build.js
+++ b/packages/react-icons/scripts/build.js
@@ -32,9 +32,7 @@ const { values: cliOptions } = parseArgs({
   allowPositionals: true,
 });
 
-const enableNativeEsm = cliOptions['enable-native-esm'];
-
-main({ root: join(__dirname, '..') });
+main({ root: join(__dirname, '..'), enableNativeEsm: cliOptions['enable-native-esm'] });
 
 /**
  * Builds source TypeScript and copys assets to the output directories.
@@ -43,7 +41,7 @@ main({ root: join(__dirname, '..') });
  * applies Babel transformations, and copies font assets.
  * It also creates raw style copies for .styles.js files.
  *
- * @param {{ root: string; }} options
+ * @param {{ root: string; enableNativeEsm?: boolean; }} options
  */
 function main(options) {
   const projectRoot = options.root;
@@ -82,7 +80,7 @@ function main(options) {
   applyBabelTransform('lib', projectRoot);
   applyBabelTransform('lib-cjs', projectRoot);
 
-  if (enableNativeEsm) {
+  if (options.enableNativeEsm) {
     convertToNativeEsm(projectRoot);
   }
 }

--- a/packages/react-icons/scripts/module-format.js
+++ b/packages/react-icons/scripts/module-format.js
@@ -1,0 +1,245 @@
+// @ts-check
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @fileoverview
+ * Post-`tsc` codemods that turn the default dual-format output into **native
+ * ESM-first** output. All of this is opt-in behind `build.js --enable-native-esm`;
+ * with the flag off none of these functions run and the build is unchanged.
+ *
+ * - `fullySpecifyEsm(dir)` rewrites every relative import/export specifier in the
+ *   ESM output (`lib/`) to be *fully specified* (`./x` -> `./x.js`, directory ->
+ *   `./x/index.js`). TypeScript 4.x cannot emit extensions, so bare-Node ESM
+ *   (and strict bundler resolution) would otherwise reject the output.
+ * - `finalizeCjs(dir)` turns the CommonJS output (`lib-cjs/`) into `.cjs`/`.d.cts`
+ *   files (required once the package is `"type": "module"`, where a bare `.js`
+ *   would be interpreted as ESM) and rewrites its relative `require()`/type
+ *   specifiers to point at the renamed files.
+ * - `applyEsmFirstManifest(pkg)` flips the manifest to match that output:
+ *   `type: module`, a `.cjs` `main`, and per-condition `import`/`require` exports
+ *   with `.d.ts`/`.d.cts` types.
+ */
+
+const { readdirSync, readFileSync, writeFileSync, existsSync, renameSync } = require('node:fs');
+const { join, dirname } = require('node:path');
+
+/**
+ * Recursively collect files under `dir` whose basename matches `predicate`.
+ * @param {string} dir
+ * @param {(name: string) => boolean} predicate
+ * @returns {string[]}
+ */
+function collectFiles(dir, predicate) {
+  /** @type {string[]} */
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectFiles(full, predicate));
+    } else if (predicate(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// Relative specifiers that already carry a resolvable extension must be left alone.
+const HAS_KNOWN_EXT = /\.(c?js|mjs|json|css|svg|ttf|woff2?|node)$/;
+
+/**
+ * Resolve an extensionless relative specifier to a fully-specified one by probing disk.
+ * @param {string} fileDir - absolute directory of the importing file
+ * @param {string} spec - relative specifier (starts with `./` or `../`)
+ * @param {string} ext - extension to append (`.js` | `.cjs`)
+ * @returns {string | null} fully-specified specifier, or `null` if it can't be resolved
+ */
+function specify(fileDir, spec, ext) {
+  if (HAS_KNOWN_EXT.test(spec)) {
+    return spec;
+  }
+  const target = join(fileDir, spec);
+  if (existsSync(target + ext)) {
+    return spec + ext;
+  }
+  if (existsSync(join(target, `index${ext}`))) {
+    return `${spec}/index${ext}`;
+  }
+  return null;
+}
+
+/**
+ * Rewrite every relative module specifier in `code` to be fully specified.
+ * Handles `import ... from`, `export ... from`, side-effect `import '...'`,
+ * dynamic `import('...')` and CommonJS `require('...')`.
+ * @param {string} code
+ * @param {string} fileDir - absolute directory of the file being processed
+ * @param {string} ext - extension to append (`.js` | `.cjs`)
+ * @param {string} filePath - for warnings
+ * @returns {string}
+ */
+function rewriteSpecifiers(code, fileDir, ext, filePath) {
+  /** @param {string} spec */
+  const map = (spec) => {
+    const resolved = specify(fileDir, spec, ext);
+    if (resolved === null) {
+      console.warn(`  ! [module-format] could not resolve '${spec}' in ${filePath}`);
+      return spec;
+    }
+    return resolved;
+  };
+
+  return (
+    code
+      // import/export ... from '<relative>'
+      .replace(/(\bfrom\s*)(['"])(\.\.?\/[^'"]*)\2/g, (_m, pre, q, spec) => `${pre}${q}${map(spec)}${q}`)
+      // dynamic import('<relative>')
+      .replace(/(\bimport\s*\(\s*)(['"])(\.\.?\/[^'"]*)\2/g, (_m, pre, q, spec) => `${pre}${q}${map(spec)}${q}`)
+      // side-effect import '<relative>'
+      .replace(/(\bimport\s+)(['"])(\.\.?\/[^'"]*)\2/g, (_m, pre, q, spec) => `${pre}${q}${map(spec)}${q}`)
+      // CommonJS require('<relative>')
+      .replace(/(\brequire\s*\(\s*)(['"])(\.\.?\/[^'"]*)\2/g, (_m, pre, q, spec) => `${pre}${q}${map(spec)}${q}`)
+  );
+}
+
+/**
+ * Make the ESM output in `dir` valid native ESM by fully specifying every
+ * relative import/export specifier in `*.js` and `*.d.ts` files.
+ * @param {string} dir - absolute path to the ESM output directory (e.g. `lib`)
+ */
+function fullySpecifyEsm(dir) {
+  const files = collectFiles(dir, (name) => name.endsWith('.js') || name.endsWith('.d.ts'));
+  let changed = 0;
+  for (const file of files) {
+    const code = readFileSync(file, 'utf8');
+    const next = rewriteSpecifiers(code, dirname(file), '.js', file);
+    if (next !== code) {
+      writeFileSync(file, next);
+      changed++;
+    }
+  }
+  console.log(`  ✓ [module-format] fully-specified ESM specifiers in ${dir} (${changed}/${files.length} files)`);
+}
+
+/**
+ * Finalize the CommonJS output in `dir` for a `"type": "module"` package:
+ * rename `*.js` -> `*.cjs` and `*.d.ts` -> `*.d.cts`, then rewrite relative
+ * `require()`/type specifiers to point at the renamed siblings.
+ * @param {string} dir - absolute path to the CJS output directory (e.g. `lib-cjs`)
+ */
+function finalizeCjs(dir) {
+  const jsFiles = collectFiles(dir, (name) => name.endsWith('.js'));
+  for (const file of jsFiles) {
+    renameSync(file, `${file.slice(0, -'.js'.length)}.cjs`);
+  }
+
+  const dtsFiles = collectFiles(dir, (name) => name.endsWith('.d.ts'));
+  for (const file of dtsFiles) {
+    renameSync(file, `${file.slice(0, -'.d.ts'.length)}.d.cts`);
+  }
+
+  const outFiles = collectFiles(dir, (name) => name.endsWith('.cjs') || name.endsWith('.d.cts'));
+  for (const file of outFiles) {
+    const code = readFileSync(file, 'utf8');
+    const next = rewriteSpecifiers(code, dirname(file), '.cjs', file);
+    if (next !== code) {
+      writeFileSync(file, next);
+    }
+  }
+
+  console.log(
+    `  ✓ [module-format] finalized CJS output in ${dir} (${jsFiles.length} js -> cjs, ${dtsFiles.length} d.ts -> d.cts)`,
+  );
+}
+
+/**
+ * Is this a flat export entry of the shape `{ types, import, require }`?
+ * @param {any} value
+ * @returns {value is { types: string; import: string; require: string }}
+ */
+function isFlatConditions(value) {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof value.types === 'string' &&
+    typeof value.import === 'string' &&
+    typeof value.require === 'string'
+  );
+}
+
+/**
+ * Rewrite a `lib-cjs/*.js` target to its finalized counterpart produced by `finalizeCjs`.
+ * Works for concrete paths and `*` wildcard patterns alike.
+ * @param {string} p
+ * @param {'.cjs' | '.d.cts'} ext
+ */
+const toCjsTarget = (p, ext) => p.replace(/\.js$/, ext);
+
+/**
+ * Recursively convert the *flat* export conditions used by the dual build into the
+ * nested, per-condition form required by ESM-first packaging:
+ *
+ * ```
+ * { types, import, require }
+ *   -> { import:  { types, default: <import> },
+ *        require: { types: <require>.d.cts, default: <require>.cjs } }
+ * ```
+ *
+ * Because this transforms whatever is already in the map, subpaths appended at build
+ * time (sprite / headless) are converted too — those emitters stay format-agnostic.
+ * String targets (e.g. `.css` side-effect entries) are left untouched.
+ *
+ * @param {any} node
+ * @returns {any}
+ */
+function toNestedConditions(node) {
+  if (typeof node === 'string' || node == null) {
+    return node;
+  }
+
+  if (isFlatConditions(node)) {
+    return {
+      import: { types: node.types, default: node.import },
+      require: {
+        types: toCjsTarget(node.require, '.d.cts'),
+        default: toCjsTarget(node.require, '.cjs'),
+      },
+    };
+  }
+
+  // Nested condition object (e.g. the `fluentIconFont` / `default` split on ".").
+  /** @type {Record<string, unknown>} */
+  const out = {};
+  for (const [key, value] of Object.entries(node)) {
+    out[key] = toNestedConditions(value);
+  }
+  return out;
+}
+
+/**
+ * Flip the manifest to the ESM-first shape so it matches the output produced by
+ * `fullySpecifyEsm` + `finalizeCjs`.
+ *
+ * Mutates and returns `pkg`; the caller persists it. The build only does this when
+ * `--enable-native-esm` is passed.
+ *
+ * @param {Record<string, any>} pkg - parsed package.json
+ * @returns {Record<string, any>} the same object, mutated
+ */
+function applyEsmFirstManifest(pkg) {
+  pkg.type = 'module';
+
+  // Under `type: module` the CommonJS entry must carry the `.cjs` extension.
+  if (typeof pkg.main === 'string') {
+    pkg.main = toCjsTarget(pkg.main, '.cjs');
+  }
+
+  if (pkg.exports) {
+    pkg.exports = toNestedConditions(pkg.exports);
+  }
+
+  console.log(`  ✓ [module-format] applied ESM-first manifest (type=module, main=${pkg.main})`);
+  return pkg;
+}
+
+module.exports = { fullySpecifyEsm, finalizeCjs, applyEsmFirstManifest };

--- a/packages/react-icons/scripts/module-format.js
+++ b/packages/react-icons/scripts/module-format.js
@@ -99,6 +99,22 @@ const HAS_KNOWN_EXT = /\.(c?js|mjs|json|css|svg|ttf|woff2?|node)$/;
 const SPECIFIER_RE = /(\bfrom\s*|\bimport\s*\(\s*|\bimport\s+|\brequire\s*\(\s*)(['"])(\.\.?\/[^'"]*)\2/g;
 
 /**
+ * Is the match at `offset` on a line that is entirely commented out?
+ *
+ * `tsc` preserves commented-out imports into the output, and the scanner works on raw
+ * text, so those would otherwise be reported as unresolvable — noise that hides the real
+ * warnings. Deliberately narrow: only a line whose first non-space characters are `//`
+ * counts, so a trailing comment after a live import still gets rewritten.
+ *
+ * @param {string} code
+ * @param {number} offset
+ */
+function isCommentedOut(code, offset) {
+  const lineStart = code.lastIndexOf('\n', offset - 1) + 1;
+  return code.slice(lineStart, offset).trimStart().startsWith('//');
+}
+
+/**
  * Builds a specifier rewriter bound to a known set of emitted files.
  *
  * Resolution is answered from `fileSet` instead of `existsSync`, and memoised per
@@ -149,7 +165,11 @@ function createRewriter(fileSet, ext) {
    * @returns {string}
    */
   return function rewriteSpecifiers(code, fileDir, filePath) {
-    return code.replace(SPECIFIER_RE, (match, pre, quote, spec) => {
+    return code.replace(SPECIFIER_RE, (match, pre, quote, spec, offset) => {
+      if (isCommentedOut(code, offset)) {
+        return match;
+      }
+
       const resolved = resolve(fileDir, spec);
       if (resolved === null) {
         console.warn(`  ! [module-format] could not resolve '${spec}' in ${filePath}`);

--- a/packages/react-icons/scripts/module-format.js
+++ b/packages/react-icons/scripts/module-format.js
@@ -21,26 +21,66 @@
  *   with `.d.ts`/`.d.cts` types.
  */
 
-const { readdirSync, readFileSync, writeFileSync, existsSync, renameSync } = require('node:fs');
+const { readdirSync } = require('node:fs');
+const { readFile, writeFile, rename } = require('node:fs/promises');
 const { join, dirname } = require('node:path');
 
 /**
- * Recursively collect files under `dir` whose basename matches `predicate`.
- * @param {string} dir
- * @param {(name: string) => boolean} predicate
- * @returns {string[]}
+ * How many file operations to keep in flight.
+ *
+ * The conversion touches ~23k emitted files and is almost entirely I/O bound — profiling
+ * puts the regex and resolution work at well under a tenth of the runtime. Queuing work
+ * against libuv's threadpool instead of blocking on each file measures ~1.8x faster;
+ * gains flatten out past this point.
  */
-function collectFiles(dir, predicate) {
-  /** @type {string[]} */
-  const out = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      out.push(...collectFiles(full, predicate));
-    } else if (predicate(entry.name)) {
-      out.push(full);
+const IO_CONCURRENCY = 64;
+
+/**
+ * Run `task` over `items` with at most `IO_CONCURRENCY` in flight.
+ * @template T
+ * @param {T[]} items
+ * @param {(item: T) => Promise<void>} task
+ */
+async function forEachConcurrent(items, task) {
+  let cursor = 0;
+
+  async function worker() {
+    while (cursor < items.length) {
+      await task(items[cursor++]);
     }
   }
+
+  await Promise.all(Array.from({ length: Math.min(IO_CONCURRENCY, items.length) }, worker));
+}
+
+/**
+ * Recursively collect every file under `dir`.
+ *
+ * Iterative rather than recursive: the recursive form concatenated child results with
+ * `push(...children)`, which recopies the array at each level. The full listing doubles as
+ * the existence oracle below, so the whole conversion needs exactly one walk per directory.
+ *
+ * @param {string} dir
+ * @returns {string[]} absolute paths
+ */
+function collectFiles(dir) {
+  /** @type {string[]} */
+  const out = [];
+  /** @type {string[]} */
+  const stack = [dir];
+
+  while (stack.length > 0) {
+    const current = /** @type {string} */ (stack.pop());
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else {
+        out.push(full);
+      }
+    }
+  }
+
   return out;
 }
 
@@ -48,58 +88,76 @@ function collectFiles(dir, predicate) {
 const HAS_KNOWN_EXT = /\.(c?js|mjs|json|css|svg|ttf|woff2?|node)$/;
 
 /**
- * Resolve an extensionless relative specifier to a fully-specified one by probing disk.
- * @param {string} fileDir - absolute directory of the importing file
- * @param {string} spec - relative specifier (starts with `./` or `../`)
- * @param {string} ext - extension to append (`.js` | `.cjs`)
- * @returns {string | null} fully-specified specifier, or `null` if it can't be resolved
+ * Every relative specifier form the emitted output can contain: `import ... from`,
+ * `export ... from`, side-effect `import '...'`, dynamic `import('...')` and
+ * `require('...')`.
+ *
+ * One combined pattern instead of four sequential `replace` passes, so each file's
+ * contents are scanned once. `import\s*\(` precedes `import\s+` so dynamic imports win
+ * at a given position.
  */
-function specify(fileDir, spec, ext) {
-  if (HAS_KNOWN_EXT.test(spec)) {
-    return spec;
-  }
-  const target = join(fileDir, spec);
-  if (existsSync(target + ext)) {
-    return spec + ext;
-  }
-  if (existsSync(join(target, `index${ext}`))) {
-    return `${spec}/index${ext}`;
-  }
-  return null;
-}
+const SPECIFIER_RE = /(\bfrom\s*|\bimport\s*\(\s*|\bimport\s+|\brequire\s*\(\s*)(['"])(\.\.?\/[^'"]*)\2/g;
 
 /**
- * Rewrite every relative module specifier in `code` to be fully specified.
- * Handles `import ... from`, `export ... from`, side-effect `import '...'`,
- * dynamic `import('...')` and CommonJS `require('...')`.
- * @param {string} code
- * @param {string} fileDir - absolute directory of the file being processed
- * @param {string} ext - extension to append (`.js` | `.cjs`)
- * @param {string} filePath - for warnings
- * @returns {string}
+ * Builds a specifier rewriter bound to a known set of emitted files.
+ *
+ * Resolution is answered from `fileSet` instead of `existsSync`, and memoised per
+ * `(dir, specifier)` pair. The emitted tree is extremely repetitive — thousands of atoms
+ * import the very same factory — so this turns hundreds of thousands of stat calls into a
+ * handful of map lookups.
+ *
+ * @param {Set<string>} fileSet - absolute paths of all emitted files
+ * @param {'.js' | '.cjs'} ext - extension to append
  */
-function rewriteSpecifiers(code, fileDir, ext, filePath) {
-  /** @param {string} spec */
-  const map = (spec) => {
-    const resolved = specify(fileDir, spec, ext);
-    if (resolved === null) {
-      console.warn(`  ! [module-format] could not resolve '${spec}' in ${filePath}`);
+function createRewriter(fileSet, ext) {
+  /** @type {Map<string, string | null>} */
+  const cache = new Map();
+
+  /**
+   * @param {string} fileDir - absolute directory of the importing file
+   * @param {string} spec - relative specifier
+   * @returns {string | null} fully-specified specifier, or `null` when unresolvable
+   */
+  function resolve(fileDir, spec) {
+    if (HAS_KNOWN_EXT.test(spec)) {
       return spec;
     }
-    return resolved;
-  };
 
-  return (
-    code
-      // import/export ... from '<relative>'
-      .replace(/(\bfrom\s*)(['"])(\.\.?\/[^'"]*)\2/g, (_m, pre, q, spec) => `${pre}${q}${map(spec)}${q}`)
-      // dynamic import('<relative>')
-      .replace(/(\bimport\s*\(\s*)(['"])(\.\.?\/[^'"]*)\2/g, (_m, pre, q, spec) => `${pre}${q}${map(spec)}${q}`)
-      // side-effect import '<relative>'
-      .replace(/(\bimport\s+)(['"])(\.\.?\/[^'"]*)\2/g, (_m, pre, q, spec) => `${pre}${q}${map(spec)}${q}`)
-      // CommonJS require('<relative>')
-      .replace(/(\brequire\s*\(\s*)(['"])(\.\.?\/[^'"]*)\2/g, (_m, pre, q, spec) => `${pre}${q}${map(spec)}${q}`)
-  );
+    const key = `${fileDir}\0${spec}`;
+    const cached = cache.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const target = join(fileDir, spec);
+    /** @type {string | null} */
+    let resolved = null;
+    if (fileSet.has(target + ext)) {
+      resolved = spec + ext;
+    } else if (fileSet.has(join(target, `index${ext}`))) {
+      resolved = `${spec}/index${ext}`;
+    }
+
+    cache.set(key, resolved);
+    return resolved;
+  }
+
+  /**
+   * @param {string} code
+   * @param {string} fileDir - absolute directory of the file being processed
+   * @param {string} filePath - for warnings
+   * @returns {string}
+   */
+  return function rewriteSpecifiers(code, fileDir, filePath) {
+    return code.replace(SPECIFIER_RE, (match, pre, quote, spec) => {
+      const resolved = resolve(fileDir, spec);
+      if (resolved === null) {
+        console.warn(`  ! [module-format] could not resolve '${spec}' in ${filePath}`);
+        return match;
+      }
+      return `${pre}${quote}${resolved}${quote}`;
+    });
+  };
 }
 
 /**
@@ -107,18 +165,23 @@ function rewriteSpecifiers(code, fileDir, ext, filePath) {
  * relative import/export specifier in `*.js` and `*.d.ts` files.
  * @param {string} dir - absolute path to the ESM output directory (e.g. `lib`)
  */
-function fullySpecifyEsm(dir) {
-  const files = collectFiles(dir, (name) => name.endsWith('.js') || name.endsWith('.d.ts'));
+async function fullySpecifyEsm(dir) {
+  const allFiles = collectFiles(dir);
+  const rewrite = createRewriter(new Set(allFiles), '.js');
+  const targets = allFiles.filter((file) => file.endsWith('.js') || file.endsWith('.d.ts'));
+
   let changed = 0;
-  for (const file of files) {
-    const code = readFileSync(file, 'utf8');
-    const next = rewriteSpecifiers(code, dirname(file), '.js', file);
+
+  await forEachConcurrent(targets, async (file) => {
+    const code = await readFile(file, 'utf8');
+    const next = rewrite(code, dirname(file), file);
     if (next !== code) {
-      writeFileSync(file, next);
+      await writeFile(file, next);
       changed++;
     }
-  }
-  console.log(`  ✓ [module-format] fully-specified ESM specifiers in ${dir} (${changed}/${files.length} files)`);
+  });
+
+  console.log(`  ✓ [module-format] fully-specified ESM specifiers in ${dir} (${changed}/${targets.length} files)`);
 }
 
 /**
@@ -127,29 +190,51 @@ function fullySpecifyEsm(dir) {
  * `require()`/type specifiers to point at the renamed siblings.
  * @param {string} dir - absolute path to the CJS output directory (e.g. `lib-cjs`)
  */
-function finalizeCjs(dir) {
-  const jsFiles = collectFiles(dir, (name) => name.endsWith('.js'));
-  for (const file of jsFiles) {
-    renameSync(file, `${file.slice(0, -'.js'.length)}.cjs`);
-  }
+async function finalizeCjs(dir) {
+  /** Post-rename paths, so resolution below sees the tree as it will finally exist. */
+  const fileSet = new Set();
+  /** @type {Array<{ from: string, to: string }>} */
+  const renames = [];
+  /** @type {string[]} */
+  const toRewrite = [];
+  let jsCount = 0;
+  let dtsCount = 0;
 
-  const dtsFiles = collectFiles(dir, (name) => name.endsWith('.d.ts'));
-  for (const file of dtsFiles) {
-    renameSync(file, `${file.slice(0, -'.d.ts'.length)}.d.cts`);
-  }
+  for (const file of collectFiles(dir)) {
+    let target = file;
 
-  const outFiles = collectFiles(dir, (name) => name.endsWith('.cjs') || name.endsWith('.d.cts'));
-  for (const file of outFiles) {
-    const code = readFileSync(file, 'utf8');
-    const next = rewriteSpecifiers(code, dirname(file), '.cjs', file);
-    if (next !== code) {
-      writeFileSync(file, next);
+    if (file.endsWith('.d.ts')) {
+      target = `${file.slice(0, -'.d.ts'.length)}.d.cts`;
+      dtsCount++;
+    } else if (file.endsWith('.js')) {
+      target = `${file.slice(0, -'.js'.length)}.cjs`;
+      jsCount++;
+    }
+
+    if (target !== file) {
+      renames.push({ from: file, to: target });
+    }
+
+    fileSet.add(target);
+    if (target.endsWith('.cjs') || target.endsWith('.d.cts')) {
+      toRewrite.push(target);
     }
   }
 
-  console.log(
-    `  ✓ [module-format] finalized CJS output in ${dir} (${jsFiles.length} js -> cjs, ${dtsFiles.length} d.ts -> d.cts)`,
-  );
+  // Rename first: the rewrite pass below reads from the renamed paths.
+  await forEachConcurrent(renames, ({ from, to }) => rename(from, to));
+
+  const rewrite = createRewriter(fileSet, '.cjs');
+
+  await forEachConcurrent(toRewrite, async (file) => {
+    const code = await readFile(file, 'utf8');
+    const next = rewrite(code, dirname(file), file);
+    if (next !== code) {
+      await writeFile(file, next);
+    }
+  });
+
+  console.log(`  ✓ [module-format] finalized CJS output in ${dir} (${jsCount} js -> cjs, ${dtsCount} d.ts -> d.cts)`);
 }
 
 /**

--- a/packages/react-icons/scripts/module-format.test.js
+++ b/packages/react-icons/scripts/module-format.test.js
@@ -1,0 +1,362 @@
+// @ts-check
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fullySpecifyEsm, finalizeCjs, applyEsmFirstManifest } from './module-format';
+
+/** @type {string[]} */
+const tempRoots = [];
+
+/**
+ * Materialises a fixture tree and returns its root.
+ * @param {Record<string, string>} files - path (relative to root) -> contents
+ */
+function createTree(files) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'module-format-'));
+  tempRoots.push(root);
+
+  for (const [relative, contents] of Object.entries(files)) {
+    const absolute = path.join(root, relative);
+    fs.mkdirSync(path.dirname(absolute), { recursive: true });
+    fs.writeFileSync(absolute, contents);
+  }
+
+  return root;
+}
+
+/**
+ * @param {string} root
+ * @param {string} relative
+ */
+const read = (root, relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+
+/**
+ * Every file under `root`, relative and sorted — used to assert renames.
+ * @param {string} root
+ */
+function listFiles(root) {
+  /** @type {string[]} */
+  const out = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true, recursive: true })) {
+    if (entry.isFile()) {
+      out.push(path.relative(root, path.join(entry.parentPath ?? entry.path, entry.name)));
+    }
+  }
+  return out.sort();
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  while (tempRoots.length > 0) {
+    fs.rmSync(/** @type {string} */ (tempRoots.pop()), { recursive: true, force: true });
+  }
+});
+
+describe('module-format', () => {
+  describe('fullySpecifyEsm', () => {
+    it('appends .js to specifiers that resolve to a sibling file', async () => {
+      const root = createTree({
+        'index.js': `export { a } from './a';\nimport { b } from './nested/b';\n`,
+        'a.js': 'export const a = 1;',
+        'nested/b.js': 'export const b = 2;',
+      });
+
+      await fullySpecifyEsm(root);
+
+      expect(read(root, 'index.js')).toBe(`export { a } from './a.js';\nimport { b } from './nested/b.js';\n`);
+    });
+
+    it('resolves a directory specifier to its index file', async () => {
+      const root = createTree({
+        'index.js': `export * from './contexts';\n`,
+        'contexts/index.js': 'export const ctx = 1;',
+      });
+
+      await fullySpecifyEsm(root);
+
+      expect(read(root, 'index.js')).toBe(`export * from './contexts/index.js';\n`);
+    });
+
+    it('resolves parent-relative specifiers', async () => {
+      const root = createTree({
+        'atoms/svg/icon.js': `import { createFluentIcon } from '../../utils/createFluentIcon';\n`,
+        'utils/createFluentIcon.js': 'export const createFluentIcon = () => {};',
+      });
+
+      await fullySpecifyEsm(root);
+
+      expect(read(root, 'atoms/svg/icon.js')).toBe(
+        `import { createFluentIcon } from '../../utils/createFluentIcon.js';\n`,
+      );
+    });
+
+    it('rewrites every specifier form the emitted output can contain', async () => {
+      const root = createTree({
+        'index.js': [
+          `import a from './a';`,
+          `export { b } from './b';`,
+          `import './side-effect';`,
+          `const c = await import('./c');`,
+          `const d = require('./d');`,
+        ].join('\n'),
+        'a.js': '',
+        'b.js': '',
+        'side-effect.js': '',
+        'c.js': '',
+        'd.js': '',
+      });
+
+      await fullySpecifyEsm(root);
+
+      expect(read(root, 'index.js')).toBe(
+        [
+          `import a from './a.js';`,
+          `export { b } from './b.js';`,
+          `import './side-effect.js';`,
+          `const c = await import('./c.js');`,
+          `const d = require('./d.js');`,
+        ].join('\n'),
+      );
+    });
+
+    it('leaves specifiers that already carry a resolvable extension untouched', async () => {
+      const root = createTree({
+        'index.js': [
+          `import './already.js';`,
+          `import styles from './styles.css';`,
+          `import map from './codepoints.json';`,
+          `import font from './font.woff2';`,
+        ].join('\n'),
+        'already.js': '',
+        'styles.css': '',
+        'codepoints.json': '{}',
+        'font.woff2': '',
+      });
+
+      await fullySpecifyEsm(root);
+
+      expect(read(root, 'index.js')).toBe(
+        [
+          `import './already.js';`,
+          `import styles from './styles.css';`,
+          `import map from './codepoints.json';`,
+          `import font from './font.woff2';`,
+        ].join('\n'),
+      );
+    });
+
+    it('leaves bare package specifiers untouched', async () => {
+      const root = createTree({
+        'index.js': `import * as React from 'react';\nimport { mergeClasses } from '@griffel/react';\n`,
+      });
+
+      await fullySpecifyEsm(root);
+
+      expect(read(root, 'index.js')).toBe(
+        `import * as React from 'react';\nimport { mergeClasses } from '@griffel/react';\n`,
+      );
+    });
+
+    it('rewrites declaration files as well, pointing at the .js sibling', async () => {
+      const root = createTree({
+        'index.d.ts': `export * from './icons/chunk-0';\nexport type { X } from './types';\n`,
+        'icons/chunk-0.js': '',
+        'icons/chunk-0.d.ts': '',
+        'types.js': '',
+        'types.d.ts': '',
+      });
+
+      await fullySpecifyEsm(root);
+
+      expect(read(root, 'index.d.ts')).toBe(
+        `export * from './icons/chunk-0.js';\nexport type { X } from './types.js';\n`,
+      );
+    });
+
+    it('warns and leaves the specifier alone when it cannot be resolved', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const root = createTree({ 'index.js': `export { wrapIcon } from './missing';\n` });
+
+      await fullySpecifyEsm(root);
+
+      expect(read(root, 'index.js')).toBe(`export { wrapIcon } from './missing';\n`);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(`could not resolve './missing'`));
+    });
+
+    it('ignores files that are not JavaScript or declarations', async () => {
+      const root = createTree({
+        'sprite.svg': `<svg data-from="./a" />`,
+        'a.js': '',
+      });
+
+      await fullySpecifyEsm(root);
+
+      expect(read(root, 'sprite.svg')).toBe(`<svg data-from="./a" />`);
+    });
+  });
+
+  describe('finalizeCjs', () => {
+    it('renames output to .cjs / .d.cts and repoints relative requires', async () => {
+      const root = createTree({
+        'index.js': `const a = require("./a");\nconst nested = require("./nested/b");\n`,
+        'index.d.ts': `export * from './a';\n`,
+        'a.js': '',
+        'a.d.ts': '',
+        'nested/b.js': '',
+      });
+
+      await finalizeCjs(root);
+
+      expect(listFiles(root)).toEqual(['a.cjs', 'a.d.cts', 'index.cjs', 'index.d.cts', 'nested/b.cjs']);
+      expect(read(root, 'index.cjs')).toBe(
+        `const a = require("./a.cjs");\nconst nested = require("./nested/b.cjs");\n`,
+      );
+      expect(read(root, 'index.d.cts')).toBe(`export * from './a.cjs';\n`);
+    });
+
+    it('resolves directory requires to the renamed index', async () => {
+      const root = createTree({
+        'index.js': `const ctx = require("./contexts");\n`,
+        'contexts/index.js': '',
+      });
+
+      await finalizeCjs(root);
+
+      expect(read(root, 'index.cjs')).toBe(`const ctx = require("./contexts/index.cjs");\n`);
+    });
+
+    it('leaves non-module assets in place', async () => {
+      const root = createTree({
+        'index.js': `require("./a");`,
+        'a.js': '',
+        'utils/fonts/icons.woff2': 'binary',
+        'headless/styles.css': '.a{}',
+      });
+
+      await finalizeCjs(root);
+
+      expect(listFiles(root)).toEqual(['a.cjs', 'headless/styles.css', 'index.cjs', 'utils/fonts/icons.woff2']);
+    });
+  });
+
+  describe('applyEsmFirstManifest', () => {
+    it('flips type, main and the export conditions to the ESM-first shape', () => {
+      const pkg = applyEsmFirstManifest({
+        type: undefined,
+        main: 'lib-cjs/index.js',
+        module: 'lib/index.js',
+        exports: {
+          './utils': {
+            types: './lib/utils.d.ts',
+            import: './lib/utils.js',
+            require: './lib-cjs/utils.js',
+          },
+        },
+      });
+
+      expect(pkg.type).toBe('module');
+      expect(pkg.main).toBe('lib-cjs/index.cjs');
+      // the ESM entry is untouched — only the CommonJS side gains an extension
+      expect(pkg.module).toBe('lib/index.js');
+      expect(pkg.exports['./utils']).toEqual({
+        import: { types: './lib/utils.d.ts', default: './lib/utils.js' },
+        require: { types: './lib-cjs/utils.d.cts', default: './lib-cjs/utils.cjs' },
+      });
+    });
+
+    it('recurses into nested conditions such as the fluentIconFont split', () => {
+      const pkg = applyEsmFirstManifest({
+        main: 'lib-cjs/index.js',
+        exports: {
+          '.': {
+            fluentIconFont: {
+              types: './lib/fonts/index.d.ts',
+              import: './lib/fonts/index.js',
+              require: './lib-cjs/fonts/index.js',
+            },
+            default: {
+              types: './lib/index.d.ts',
+              import: './lib/index.js',
+              require: './lib-cjs/index.js',
+            },
+          },
+        },
+      });
+
+      expect(pkg.exports['.']).toEqual({
+        fluentIconFont: {
+          import: { types: './lib/fonts/index.d.ts', default: './lib/fonts/index.js' },
+          require: { types: './lib-cjs/fonts/index.d.cts', default: './lib-cjs/fonts/index.cjs' },
+        },
+        default: {
+          import: { types: './lib/index.d.ts', default: './lib/index.js' },
+          require: { types: './lib-cjs/index.d.cts', default: './lib-cjs/index.cjs' },
+        },
+      });
+    });
+
+    it('converts wildcard subpaths, including ones appended at build time', () => {
+      const pkg = applyEsmFirstManifest({
+        main: 'lib-cjs/index.js',
+        exports: {
+          './svg/*': {
+            types: './lib/atoms/svg/*.d.ts',
+            import: './lib/atoms/svg/*.js',
+            require: './lib-cjs/atoms/svg/*.js',
+          },
+          './headless/svg-sprite/*': {
+            types: './lib/atoms/headless-svg-sprite/*.d.ts',
+            import: './lib/atoms/headless-svg-sprite/*.js',
+            require: './lib-cjs/atoms/headless-svg-sprite/*.js',
+          },
+        },
+      });
+
+      expect(pkg.exports['./svg/*'].require).toEqual({
+        types: './lib-cjs/atoms/svg/*.d.cts',
+        default: './lib-cjs/atoms/svg/*.cjs',
+      });
+      expect(pkg.exports['./headless/svg-sprite/*'].require).toEqual({
+        types: './lib-cjs/atoms/headless-svg-sprite/*.d.cts',
+        default: './lib-cjs/atoms/headless-svg-sprite/*.cjs',
+      });
+    });
+
+    it('leaves plain string targets such as CSS side effects untouched', () => {
+      const pkg = applyEsmFirstManifest({
+        main: 'lib-cjs/index.js',
+        exports: {
+          './headless/styles.css': './lib/headless/styles.css',
+          './headless/fonts/styles.css': './lib/headless/fonts/styles.css',
+        },
+      });
+
+      expect(pkg.exports).toEqual({
+        './headless/styles.css': './lib/headless/styles.css',
+        './headless/fonts/styles.css': './lib/headless/fonts/styles.css',
+      });
+    });
+
+    it('is idempotent, so a rebuilt package is not double-converted', () => {
+      /** @type {Record<string, any>} */
+      const original = {
+        main: 'lib-cjs/index.js',
+        exports: {
+          './utils': {
+            types: './lib/utils.d.ts',
+            import: './lib/utils.js',
+            require: './lib-cjs/utils.js',
+          },
+          './headless/styles.css': './lib/headless/styles.css',
+        },
+      };
+
+      const once = applyEsmFirstManifest(JSON.parse(JSON.stringify(original)));
+      const twice = applyEsmFirstManifest(JSON.parse(JSON.stringify(once)));
+
+      expect(twice).toEqual(once);
+    });
+  });
+});

--- a/packages/react-icons/scripts/module-format.test.js
+++ b/packages/react-icons/scripts/module-format.test.js
@@ -185,6 +185,39 @@ describe('module-format', () => {
       expect(warn).toHaveBeenCalledWith(expect.stringContaining(`could not resolve './missing'`));
     });
 
+    it('ignores commented-out imports, which tsc preserves into the output', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const root = createTree({
+        'index.js': [
+          `// TODO: export this once it exists`,
+          `// export { wrapIcon } from './wrapIcon';`,
+          `  // export { other } from './other';`,
+        ].join('\n'),
+      });
+
+      await fullySpecifyEsm(root);
+
+      expect(read(root, 'index.js')).toBe(
+        [
+          `// TODO: export this once it exists`,
+          `// export { wrapIcon } from './wrapIcon';`,
+          `  // export { other } from './other';`,
+        ].join('\n'),
+      );
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('still rewrites a live import that carries a trailing comment', async () => {
+      const root = createTree({
+        'index.js': `export { a } from './a'; // keep ./b in mind\n`,
+        'a.js': '',
+      });
+
+      await fullySpecifyEsm(root);
+
+      expect(read(root, 'index.js')).toBe(`export { a } from './a.js'; // keep ./b in mind\n`);
+    });
+
     it('ignores files that are not JavaScript or declarations', async () => {
       const root = createTree({
         'sprite.svg': `<svg data-from="./a" />`,

--- a/packages/react-icons/scripts/package.json
+++ b/packages/react-icons/scripts/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/packages/react-icons/verify-esm-exports.cjs
+++ b/packages/react-icons/verify-esm-exports.cjs
@@ -1,0 +1,82 @@
+// @ts-check
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @fileoverview
+ * CommonJS counterpart of `verify-esm-exports.mjs`: end-to-end verification that
+ * every `@fluentui/react-icons` `exports` subpath resolves and loads via real
+ * `require()` (the `require` condition → `lib-cjs/*.cjs`) in a bare Node process.
+ *
+ * Same two tiers as the ESM verifier: SVG/utility/provider/headless(non-font)
+ * entries are actually `require()`-ed and asserted to expose exports; font and
+ * `.css` entries are resolve-only (font graphs pull in binary `.ttf`/`.woff`
+ * assets, `.css` is not JavaScript). Pass `--font` with
+ * `node --conditions=fluentIconFont` to verify condition routing to the font build.
+ */
+
+'use strict';
+
+const { existsSync } = require('node:fs');
+
+const pkg = require('./package.json');
+const name = pkg.name;
+const fontMode = process.argv.includes('--font');
+
+/** @returns {Array<{ key: string, spec: string, isCss: boolean }>} */
+function deriveEntries() {
+  return Object.keys(pkg.exports).map((key) => {
+    const sub = key === '.' ? '' : key.slice(1);
+    const spec = name + (key.includes('*') ? sub.replace('*', 'access-time') : sub);
+    return { key, spec, isCss: key.endsWith('.css') };
+  });
+}
+
+/** Font module graphs require binary `.ttf`/`.woff` assets → bundler-only, not bare-Node loadable. */
+const isFontTarget = (/** @type {string} */ p) => /fonts/i.test(p);
+
+let failures = 0;
+
+for (const { key, spec, isCss } of deriveEntries()) {
+  try {
+    // Real CJS resolution through the package `exports` map (honors --conditions).
+    const resolvedPath = require.resolve(spec);
+    if (!existsSync(resolvedPath)) {
+      throw new Error(`export map resolved to a missing file: ${resolvedPath}`);
+    }
+
+    if (isCss) {
+      console.log(`  ✓ resolve-only  ${key}  ->  ${spec}  (css asset)`);
+    } else if (isFontTarget(resolvedPath)) {
+      console.log(`  ✓ resolve-only  ${key}  ->  ${spec}  (font/binary-asset graph)`);
+    } else {
+      // True bare-Node CJS load — no bundler, no shims.
+      const mod = require(spec);
+      const names = Object.keys(mod);
+      if (names.length === 0) {
+        throw new Error('module required but exposed no exports');
+      }
+      console.log(`  ✓ loaded        ${key}  ->  ${spec}  (${names.length} exports)`);
+    }
+  } catch (err) {
+    failures++;
+    console.error(`  ✗ FAIL          ${key}  ->  ${spec}\n       ${err && err.message ? err.message : err}`);
+  }
+}
+
+// Prove the `fluentIconFont` condition routes the barrel to the font build.
+try {
+  const rootPath = require.resolve(name);
+  const routedToFont = isFontTarget(rootPath);
+  if (routedToFont !== fontMode) {
+    throw new Error(`"." resolved to ${rootPath} (fonts=${routedToFont}); expected fonts=${fontMode}`);
+  }
+  console.log(`  ✓ condition     "."  ->  ${routedToFont ? 'font' : 'svg'} build (fontMode=${fontMode})`);
+} catch (err) {
+  failures++;
+  console.error(`  ✗ FAIL          condition routing\n       ${err && err.message ? err.message : err}`);
+}
+
+const label = fontMode ? '[cjs · fluentIconFont]' : '[cjs · default]';
+console.log(`${label} ${failures === 0 ? 'ALL OK' : `${failures} FAILED`}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/packages/react-icons/verify-esm-exports.mjs
+++ b/packages/react-icons/verify-esm-exports.mjs
@@ -1,0 +1,101 @@
+// @ts-check
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @fileoverview
+ * End-to-end verification that every `@fluentui/react-icons` `exports` subpath
+ * resolves and loads under **real, bare Node ESM** (no bundler, no vitest resolver).
+ *
+ * Run directly by a spawned `node` process (see `esm-exports.smoke.test.js`), so a
+ * pass proves the published export map + fully-specified ESM output genuinely work
+ * for Node's native ESM resolver — the core guarantee of the ESM-first packaging.
+ *
+ * Two tiers, derived automatically from `package.json#exports` (so new/dynamic
+ * subpaths like the sprite entries are covered without editing this file):
+ *
+ * - **loaded**: SVG/utility/provider/headless(non-font) entries are actually
+ *   `import()`-ed and asserted to expose named exports. This is the true bare-Node
+ *   ESM proof for the surface the ESM-first change targets.
+ * - **resolve-only**: font entries and `.css` entries are only *resolved* (not
+ *   imported). Font modules transitively `import './*.ttf'|'*.woff'` (binary assets
+ *   that only a bundler can load), and `.css` is not JavaScript — neither is meant
+ *   to load in bare Node. We still assert their export-map target is a real,
+ *   fully-specified file on disk.
+ *
+ * Pass `--font` (together with `node --conditions=fluentIconFont`) to verify the
+ * custom condition routes the barrel to the font build.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+/** @type {{ name: string, exports: Record<string, unknown> }} */
+const pkg = JSON.parse(readFileSync(join(here, 'package.json'), 'utf8'));
+const name = pkg.name;
+const fontMode = process.argv.includes('--font');
+
+/**
+ * Derive a concrete import specifier for each `exports` subpath key. Wildcards are
+ * substituted with a known icon group that exists in every atom flavor.
+ * @returns {Array<{ key: string, spec: string, isCss: boolean }>}
+ */
+function deriveEntries() {
+  return Object.keys(pkg.exports).map((key) => {
+    const sub = key === '.' ? '' : key.slice(1); // drop leading '.'
+    const spec = name + (key.includes('*') ? sub.replace('*', 'access-time') : sub);
+    return { key, spec, isCss: key.endsWith('.css') };
+  });
+}
+
+/** Font module graphs import binary `.ttf`/`.woff` assets → bundler-only, not bare-Node loadable. */
+const isFontTarget = (/** @type {string} */ p) => /fonts/i.test(p);
+
+let failures = 0;
+
+for (const { key, spec, isCss } of deriveEntries()) {
+  try {
+    // Real ESM resolution through the package `exports` map (honors --conditions).
+    const resolvedPath = fileURLToPath(import.meta.resolve(spec));
+    if (!existsSync(resolvedPath)) {
+      throw new Error(`export map resolved to a missing file: ${resolvedPath}`);
+    }
+
+    if (isCss) {
+      console.log(`  ✓ resolve-only  ${key}  ->  ${spec}  (css asset)`);
+    } else if (isFontTarget(resolvedPath)) {
+      console.log(`  ✓ resolve-only  ${key}  ->  ${spec}  (font/binary-asset graph)`);
+    } else {
+      // True bare-Node ESM load — no bundler, no shims.
+      const mod = await import(spec);
+      const names = Object.keys(mod);
+      if (names.length === 0) {
+        throw new Error('module loaded but exposed no named exports');
+      }
+      console.log(`  ✓ loaded        ${key}  ->  ${spec}  (${names.length} exports)`);
+    }
+  } catch (/** @type {any} */ err) {
+    failures++;
+    console.error(`  ✗ FAIL          ${key}  ->  ${spec}\n       ${err?.message ?? err}`);
+  }
+}
+
+// Prove the `fluentIconFont` condition routes the barrel to the font build (and the
+// default condition to the SVG build). Resolution honors the active `--conditions`.
+try {
+  const rootPath = fileURLToPath(import.meta.resolve(name));
+  const routedToFont = isFontTarget(rootPath);
+  if (routedToFont !== fontMode) {
+    throw new Error(`"." resolved to ${rootPath} (fonts=${routedToFont}); expected fonts=${fontMode}`);
+  }
+  console.log(`  ✓ condition     "."  ->  ${routedToFont ? 'font' : 'svg'} build (fontMode=${fontMode})`);
+} catch (/** @type {any} */ err) {
+  failures++;
+  console.error(`  ✗ FAIL          condition routing\n       ${err?.message ?? err}`);
+}
+
+const label = fontMode ? '[esm · fluentIconFont]' : '[esm · default]';
+console.log(`${label} ${failures === 0 ? 'ALL OK' : `${failures} FAILED`}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Lands the tooling that turns the dual build into valid **bare-Node ESM**, without changing anything the package ships.

`node scripts/build.js --enable-native-esm` is **off by default**. With the flag off, `lib/` and `lib-cjs/` are byte-for-byte identical to `main` and the manifest keeps its current `type`/`main`/`exports`. A follow-up PR flips the default.

Landing it now — rather than parking it on a branch until the format is switched on — means the codemod is exercised on **every icon change** instead of silently drifting away from the generated output. That drift is the actual risk: the codemod rewrites ~23k emitted files derived from `assets/`.

## What the flag does

| | default (off) | `--enable-native-esm` |
|---|---|---|
| `lib/` specifiers | extensionless | fully specified (`./x.js`, `/index.js`) |
| `lib-cjs/` | `.js` + `.d.ts` | `.cjs` + `.d.cts` |
| manifest | untouched | `type: module`, `.cjs` main, `import`/`require` exports |

- **`fullySpecifyEsm`** — Node's ESM resolver requires extensions; tsc 4.x cannot emit them.
- **`finalizeCjs`** — renames `lib-cjs/` output, required once the package is `type: module`, where a bare `.js` would be read as ESM.
- **`applyEsmFirstManifest`** — flips the manifest to match. It transforms *whatever is already in* `exports`, so the subpaths appended at build time (sprite, headless) convert too and their emitters stay format-agnostic. Verified to reproduce the previously hand-written ESM-first map **exactly**.

## Two non-obvious constraints (both encoded in the code)

1. **The conversion runs last in the build.** Rewriting the manifest to `type: module` changes how Node interprets every `.js` file in the package, so nothing may be `require`d after it.
2. **`scripts/package.json` pins the build scripts to CommonJS.** A no-op today; without it a *second* `--enable-native-esm` run fails, because the build scripts get re-read as ESM. (This was one of the "hygiene bits" originally deferred — it turns out to be load-bearing for the flag to be re-runnable.)

## Verification

Real e2e, not a resolver simulation: `verify-esm-exports.{mjs,cjs}` derive every specifier from `exports` and load them in **spawned Node processes**, covering the `import`/`require` conditions and `fluentIconFont` routing.

Font and `.css` entries are resolve-only — font modules pull in binary `.ttf`/`.woff` assets that only a bundler can load. The smoke test **skips unless the build is `type: module`**: a bare-Node `import` failing in the dual build is the limitation being removed, not a regression.

Evidence from this branch:

- **Acceptance gate — flag off ⇒ zero change:** `diff -r` vs a pristine `main` build → `lib/` and `lib-cjs/` **identical**; manifest diff is scripts-only.
- `build-verify.test.js` has **zero diff** vs `main` (135 passed / 12 skipped), so the default path's assertions are provably unweakened.
- Flag on: build + all 4 e2e checks green (`esm · default`, `esm · fluentIconFont`, `cjs · default`, `cjs · fluentIconFont`); re-runnable.
- `lint`, `type-check:infra`, `scripts:check`, unit tests (90) all pass.

## CI

New `verify-native-esm` job runs `nx affected -t verify-native-esm`, so it triggers whenever react-icons or the icon assets change. It's a **separate job on purpose**: the native ESM build rewrites `packages/react-icons/package.json` in place, which would otherwise leak into the packaging and bundle-size steps of `build-npm`.

## Follow-up

A subsequent PR flips the default and deletes the flag (existing draft #1143 carries the manifest work).
