### PR TITLE
feat(svg-sprites): add grouped sprite bundles

### DIFF
--- a/packages/svg-sprites/README.md
+++ b/packages/svg-sprites/README.md
@@ -42,8 +42,8 @@ export const Icon = (props: IconProps) => {
 The package also emits grouped sprite files following the local bundle format, for example:
 
 ```text
-fluent-regular-20.sprite.svg
-fluent-filled-20.sprite.svg
+fluent_icons_20_regular.sprite.svg
+fluent_icons_20_filled.sprite.svg
 ```
 
 Those files contain all symbols for a given size/style pairing, with ids like `access_time`, `add`, and `alert` instead of repeating the size/style suffix inside each id.

--- a/packages/svg-sprites/README.md
+++ b/packages/svg-sprites/README.md
@@ -39,6 +39,15 @@ export const Icon = (props: IconProps) => {
 };
 ```
 
+The package also emits grouped sprite files following the local bundle format, for example:
+
+```text
+fluent-regular-20.sprite.svg
+fluent-filled-20.sprite.svg
+```
+
+Those files contain all symbols for a given size/style pairing, with ids like `access_time`, `add`, and `alert` instead of repeating the size/style suffix inside each id.
+
 ## Development
 
 ### Building Sprites

--- a/packages/svg-sprites/build-verify.test.js
+++ b/packages/svg-sprites/build-verify.test.js
@@ -10,10 +10,7 @@ const SPRITES_DIR = path.join(__dirname, 'sprites');
 const ICONS_DIR = path.join(__dirname, 'icons');
 
 /** @param {string} name */
-const isSpriteSvg = (name) =>
-  /^(?:[a-z][a-z0-9_]*_\d+_(regular|filled|light|color)|fluent-(regular|filled|light|color)-\d+)\.sprite\.svg$/.test(
-    name,
-  );
+const isSpriteSvg = (name) => /^[a-z][a-z0-9_]*_\d+_(regular|filled|light|color)\.sprite\.svg$/.test(name);
 
 describe('Build Verification', () => {
   it('should have sprites directory with sprite SVG files', async () => {
@@ -52,7 +49,7 @@ describe('Build Verification', () => {
       expect(content, `${file} should contain <svg`).toMatch(/<svg\b/);
 
       const expectedId = path.basename(file, '.sprite.svg');
-      const isGroupedSprite = /^fluent-(regular|filled|light|color)-\d+\.sprite\.svg$/.test(file);
+      const isGroupedSprite = /^fluent_icons_\d+_(regular|filled|light|color)\.sprite\.svg$/.test(file);
 
       if (isGroupedSprite) {
         expect(content, `${file} should contain <symbol> elements`).toMatch(/<symbol\b/);
@@ -66,6 +63,17 @@ describe('Build Verification', () => {
       // Symbol should have viewBox
       expect(content, `${file} symbol should have viewBox`).toMatch(/<symbol[^>]+viewBox="/);
     }
+  });
+
+  it('should group all icons for a size and style into one sprite', async () => {
+    const file = 'fluent_icons_20_regular.sprite.svg';
+    const content = await readFile(path.join(SPRITES_DIR, file), 'utf8');
+    const symbolIds = [...content.matchAll(/<symbol[^>]+id="([^"]+)"/g)].map((match) => match[1]);
+
+    expect(symbolIds.length, `${file} should contain multiple symbols`).toBeGreaterThan(1);
+    expect(new Set(symbolIds).size, `${file} should contain unique symbol ids`).toBe(symbolIds.length);
+    expect(symbolIds).toContain('access_time');
+    expect(symbolIds).toContain('add');
   });
 
   // TODO: to enable this we would need to update snapshot during release - lets avoid that for now

--- a/packages/svg-sprites/build-verify.test.js
+++ b/packages/svg-sprites/build-verify.test.js
@@ -10,7 +10,10 @@ const SPRITES_DIR = path.join(__dirname, 'sprites');
 const ICONS_DIR = path.join(__dirname, 'icons');
 
 /** @param {string} name */
-const isSpriteSvg = (name) => /^[a-z][a-z0-9_]*_\d+_(regular|filled|light|color)\.sprite\.svg$/.test(name);
+const isSpriteSvg = (name) =>
+  /^(?:[a-z][a-z0-9_]*_\d+_(regular|filled|light|color)|fluent-(regular|filled|light|color)-\d+)\.sprite\.svg$/.test(
+    name,
+  );
 
 describe('Build Verification', () => {
   it('should have sprites directory with sprite SVG files', async () => {
@@ -48,11 +51,17 @@ describe('Build Verification', () => {
       // Sprite should be a valid SVG
       expect(content, `${file} should contain <svg`).toMatch(/<svg\b/);
 
-      // Should contain a <symbol> with matching id
       const expectedId = path.basename(file, '.sprite.svg');
-      expect(content, `${file} should contain <symbol> with id="${expectedId}"`).toMatch(
-        new RegExp(`<symbol[^>]+id="${expectedId}"`),
-      );
+      const isGroupedSprite = /^fluent-(regular|filled|light|color)-\d+\.sprite\.svg$/.test(file);
+
+      if (isGroupedSprite) {
+        expect(content, `${file} should contain <symbol> elements`).toMatch(/<symbol\b/);
+      } else {
+        // Should contain a <symbol> with matching id
+        expect(content, `${file} should contain <symbol> with id="${expectedId}"`).toMatch(
+          new RegExp(`<symbol[^>]+id="${expectedId}"`),
+        );
+      }
 
       // Symbol should have viewBox
       expect(content, `${file} symbol should have viewBox`).toMatch(/<symbol[^>]+viewBox="/);

--- a/packages/svg-sprites/generate-sprites.js
+++ b/packages/svg-sprites/generate-sprites.js
@@ -50,6 +50,43 @@ function processArgs() {
 }
 
 /**
+ * Parses an icon filename into its semantic id + variant metadata.
+ * @param {string} fileName
+ * @returns {{ iconId: string, size?: string, style?: string, fileName: string }}
+ */
+function parseIconMeta(fileName) {
+  const withoutExt = path.basename(fileName, '.svg');
+  const match = withoutExt.match(/^(.*)_(\d+)_(regular|filled|light|color)$/);
+
+  if (match) {
+    return {
+      iconId: match[1],
+      size: match[2],
+      style: match[3],
+      fileName: withoutExt,
+    };
+  }
+
+  return { iconId: withoutExt, fileName: withoutExt };
+}
+
+/**
+ * Builds a combined sprite file containing multiple symbols.
+ * @param {{ iconId: string, iconPath: string }[]} entries
+ * @returns {Promise<string>}
+ */
+async function createCombinedSprite(entries) {
+  const sprites = svgstore();
+
+  for (const entry of entries) {
+    const iconContent = await fs.readFile(entry.iconPath, 'utf-8');
+    sprites.add(entry.iconId, iconContent);
+  }
+
+  return sprites.toString();
+}
+
+/**
  * Creates a sprite SVG file from a single icon SVG using svgstore
  * @param {string} iconPath - Path to the icon file
  * @param {string} iconId - ID for the icon
@@ -140,7 +177,7 @@ async function main() {
 
   console.log(`📊 Processing ${svgFiles.length} icons with ${NUM_WORKERS} workers...`);
 
-  // Split work into batches (one per CPU core)
+  // Build the existing one-icon-per-file sprite set.
   const batchSize = Math.ceil(svgFiles.length / NUM_WORKERS);
   const batches = [];
 
@@ -152,18 +189,44 @@ async function main() {
     }
   }
 
-  // Process all batches in parallel
   const results = await Promise.all(batches);
-
-  // Flatten results
   const allResults = results.flat();
   const successful = allResults.filter((r) => r.success).length;
   const failed = allResults.filter((r) => !r.success);
 
+  // Also generate combined files grouped by size and style, matching the local bundle layout.
+  const groupedBySizeAndStyle = new Map();
+
+  for (const file of svgFiles) {
+    const meta = parseIconMeta(file);
+    if (!meta.size || !meta.style) {
+      continue;
+    }
+
+    const key = `${meta.style}-${meta.size}`;
+    const bucket = groupedBySizeAndStyle.get(key) ?? [];
+    bucket.push({
+      iconId: meta.iconId,
+      iconPath: path.join(ICONS_DIR, file),
+    });
+    groupedBySizeAndStyle.set(key, bucket);
+  }
+
+  const combinedFiles = [];
+
+  for (const [key, entries] of groupedBySizeAndStyle) {
+    const spriteContent = await createCombinedSprite(entries);
+    const [style, size] = key.split('-');
+    const outputFile = `fluent-${style}-${size}.sprite.svg`;
+    const outputPath = path.join(SPRITES_DIR, outputFile);
+    await fs.writeFile(outputPath, spriteContent, 'utf-8');
+    combinedFiles.push(outputFile);
+  }
+
   const duration = ((Date.now() - startTime) / 1000).toFixed(2);
   const durationNum = parseFloat(duration);
 
-  console.log(`\n✅ Generated ${successful} sprites in ${duration}s`);
+  console.log(`\n✅ Generated ${successful} per-icon sprites and ${combinedFiles.length} grouped sprites in ${duration}s`);
   console.log(`⚡ Performance: ${(svgFiles.length / durationNum).toFixed(0)} sprites/second`);
 
   if (failed.length > 0) {

--- a/packages/svg-sprites/generate-sprites.js
+++ b/packages/svg-sprites/generate-sprites.js
@@ -203,7 +203,7 @@ async function main() {
       continue;
     }
 
-    const key = `${meta.style}-${meta.size}`;
+    const key = `${meta.size}_${meta.style}`;
     const bucket = groupedBySizeAndStyle.get(key) ?? [];
     bucket.push({
       iconId: meta.iconId,
@@ -216,8 +216,7 @@ async function main() {
 
   for (const [key, entries] of groupedBySizeAndStyle) {
     const spriteContent = await createCombinedSprite(entries);
-    const [style, size] = key.split('-');
-    const outputFile = `fluent-${style}-${size}.sprite.svg`;
+    const outputFile = `fluent_icons_${key}.sprite.svg`;
     const outputPath = path.join(SPRITES_DIR, outputFile);
     await fs.writeFile(outputPath, spriteContent, 'utf-8');
     combinedFiles.push(outputFile);
@@ -226,7 +225,9 @@ async function main() {
   const duration = ((Date.now() - startTime) / 1000).toFixed(2);
   const durationNum = parseFloat(duration);
 
-  console.log(`\n✅ Generated ${successful} per-icon sprites and ${combinedFiles.length} grouped sprites in ${duration}s`);
+  console.log(
+    `\n✅ Generated ${successful} per-icon sprites and ${combinedFiles.length} grouped sprites in ${duration}s`,
+  );
   console.log(`⚡ Performance: ${(svgFiles.length / durationNum).toFixed(0)} sprites/second`);
 
   if (failed.length > 0) {

--- a/packages/svg-sprites/package.json
+++ b/packages/svg-sprites/package.json
@@ -17,7 +17,7 @@
     "optimize": "yarn run -T svgo --config svgo.config.js --folder=./icons --precision=2",
     "unfill": "node unfill.js --path=./icons/",
     "sprites": "node generate-sprites.js && rm -rf ./icons",
-    "build": "yarn copy && yarn rename && yarn unfill && yarn optimize && yarn sprites",
+    "build": "yarn clean && yarn copy && yarn rename && yarn unfill && yarn optimize && yarn sprites",
     "build-verify": "yarn run -T vitest run build-verify.test.js"
   }
 }


### PR DESCRIPTION
Adds grouped sprite bundles by size/style while keeping the existing per-icon sprite output.

The user can then bundle them as static assets and use any icon they'd like without having to install each icon:
```html
<svg>
  <use href="/assets/fluent_icons_20_regular.sprites.svg#add" />
</svg>
```

This change creates files like `fluent_icons_20_regular.sprite.svg` and `fluent_icons_20_filled.sprite.svg` with ids like `access_time`, `add`, and `alert` so the bundle can be used as a single symbols sheet per size/style without repeating the suffix in every id.

It also updates the sprite build verification to accept the new bundle naming format and documents the grouped bundle output in the SVG sprites README.