### PR TITLE
fix: restore public npm registry for yarn installs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,9 @@ android/ @microsoft/react-native-sdk-admins
 flutter/ @nickromano
 ios/ @nickromano
 yarn.lock @microsoft/cxe-prg
+.yarnrc.yml @microsoft/cxe-prg
+.yarn/ @microsoft/cxe-prg
+.npmrc @microsoft/cxe-prg
 package.json @microsoft/cxe-prg
 nx.json @microsoft/cxe-prg
 nano-staged.js @microsoft/cxe-prg

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,13 +1,6 @@
 nodeLinker: node-modules
 
-# npmRegistryServer: 'https://registry.npmjs.org'
-npmRegistryServer: 'https://packagefeedproxy.microsoft.io/npm/'
-
-# The mirrored proxy returns slightly different package metadata (bin paths)
-# than the public registry, which makes hardened-mode's bin-path normalisation
-# non-deterministic across environments.  `--immutable` already protects
-# lockfile integrity; disable hardened mode to avoid spurious CI failures.
-enableHardenedMode: false
+npmRegistryServer: 'https://registry.npmjs.org'
 
 # Yarn quarantines versions published more recently than `npmMinimalAgeGate`
 # (default 3d) as a supply-chain mitigation, failing installs with YN0016.


### PR DESCRIPTION
## Problem

All CI is red on `main`. Every job that runs `yarn install --immutable` fails:

```
YN0035: @andrewbranch/untar.js@npm:1.0.4: Package not found
  Response Code: 404 (Not Found)
  Request URL: https://packagefeedproxy.microsoft.io/npm/@andrewbranch/untar.js/-/untar.js-1.0.4.tgz
YN0035: vite@npm:7.3.6: Package not found
  Request URL: https://packagefeedproxy.microsoft.io/npm/vite/-/vite-7.3.6.tgz
```

Affected: `Bundle Size Baseline`, and `Pull request validation` (Build npm packages, Build Android library) on every open branch.

## Cause

#1206 switched `npmRegistryServer` from public npm to the mirrored proxy `packagefeedproxy.microsoft.io`. The proxy serves **metadata** fine (resolution succeeds) but **404s on tarball downloads** for packages it hasn't backfilled:

| tarball | packagefeedproxy.microsoft.io | registry.npmjs.org |
| --- | --- | --- |
| `vite-7.3.6.tgz` | **404** | 200 |
| `@andrewbranch/untar.js-1.0.4.tgz` | **404** | 200 |

Both are *new* lockfile entries introduced by #1205 (`@arethetypeswrong/cli` pulls in `@andrewbranch/untar.js`). That's why the break surfaced only after #1205 merged rather than immediately after the registry swap — everything already mirrored kept resolving.

## Fix

Revert [.yarnrc.yml](.yarnrc.yml) to its pre-#1206 content (the resulting blob is byte-identical to `7c13291c8f`, so this is an exact revert, not an approximation):

- `npmRegistryServer` → `https://registry.npmjs.org`
- drop `enableHardenedMode: false` — it existed solely to mask the proxy's divergent bin-path metadata, so it goes away with the proxy and we get the supply-chain protection back

No `yarn.lock` changes needed: #1206 touched only `.yarnrc.yml`, and the lockfile entries added since carry normal public-npm checksums.

## Verification

`yarn install --immutable` against public npm with an isolated `HOME`, `YARN_ENABLE_MIRROR=0` and an empty cache — forcing all 1854 packages over the network — completes clean, lockfile unmodified. Cached artifacts match lockfile checksums, e.g. `@andrewbranch-untar.js-npm-1.0.4-...-858acf6771.zip` vs `10c0/858acf6771f14…`.

## Note for reviewers

#1206 described the proxy swap as intentional. If there's an org mandate behind it, the durable fix belongs on the proxy side (backfill / upstream passthrough on tarball misses) — but the repo can't stay red in the meantime.

After merge, re-run **Bundle Size Baseline** on `main` so `monosize-storage-git` gets a fresh baseline artifact; until it succeeds, PR bundle-size comparisons keep using a stale baseline.

## Also: CODEOWNERS gap

`.yarnrc.yml` was not owned by anyone. The yarn 4 migration (#1189) created it but only renamed the existing `package-lock.json` entry to `yarn.lock` in CODEOWNERS:

```diff
-package-lock.json @microsoft/cxe-prg
+yarn.lock @microsoft/cxe-prg
```

So the lockfile stayed owned while the file that controls *where packages come from* was left unowned — which is how a registry swap landed without `@microsoft/cxe-prg` review. Now covering `.yarnrc.yml`, `.yarn/` and `.npmrc` alongside `yarn.lock`.
