### PR TITLE
fix(react-icons): render Light font icons

### DIFF
--- a/packages/react-icons/build-verify.test.js
+++ b/packages/react-icons/build-verify.test.js
@@ -317,10 +317,11 @@ describe('Build Verification', () => {
         const FONT_FAMILY_MAP = {
           [0 /* Filled */]: 'FluentSystemIconsFilled',
           [1 /* Regular */]: 'FluentSystemIconsRegular',
-          [2 /* Resizable */]: 'FluentSystemIcons'
+          [2 /* Resizable */]: 'FluentSystemIcons',
+          [3 /* Light */]: 'FluentSystemIconsLight'
         };
         export const useStaticStyles = __staticStyles({
-          d: [\`@font-face{font-family:FluentSystemIconsFilled;font-display:"block";src:url(\${_asset}) format("woff2"),url(\${_asset2}) format("woff"),url(\${_asset3}) format("truetype");}\`, \`@font-face{font-family:FluentSystemIconsRegular;font-display:"block";src:url(\${_asset4}) format("woff2"),url(\${_asset5}) format("woff"),url(\${_asset6}) format("truetype");}\`, \`@font-face{font-family:undefined;src:url(\${_asset7}) format("woff2"),url(\${_asset8}) format("woff"),url(\${_asset9}) format("truetype");}\`, \`@font-face{font-family:FluentSystemIcons;font-display:"block";src:url(\${_asset0}) format("woff2"),url(\${_asset1}) format("woff"),url(\${_asset10}) format("truetype");}\`]
+          d: [\`@font-face{font-family:FluentSystemIconsFilled;font-display:"block";src:url(\${_asset}) format("woff2"),url(\${_asset2}) format("woff"),url(\${_asset3}) format("truetype");}\`, \`@font-face{font-family:FluentSystemIconsRegular;font-display:"block";src:url(\${_asset4}) format("woff2"),url(\${_asset5}) format("woff"),url(\${_asset6}) format("truetype");}\`, \`@font-face{font-family:FluentSystemIconsLight;font-display:"block";src:url(\${_asset7}) format("woff2"),url(\${_asset8}) format("woff"),url(\${_asset9}) format("truetype");}\`, \`@font-face{font-family:FluentSystemIcons;font-display:"block";src:url(\${_asset0}) format("woff2"),url(\${_asset1}) format("woff"),url(\${_asset10}) format("truetype");}\`]
         });
         export const useRootStyles = __styles({
           "0": {
@@ -370,6 +371,7 @@ describe('Build Verification', () => {
             [0 /* Filled */]: 'FluentSystemIconsFilled',
             [1 /* Regular */]: 'FluentSystemIconsRegular',
             [2 /* Resizable */]: 'FluentSystemIcons',
+            [3 /* Light */]: 'FluentSystemIconsLight',
         };
         export const useStaticStyles = makeStaticStyles(\`
         @font-face {
@@ -389,6 +391,7 @@ describe('Build Verification', () => {
 
         @font-face {
             font-family: \${FONT_FAMILY_MAP[3 /* Light */]};
+            font-display: "block";
             src: url(\${JSON.stringify(fontLightWoff2)}) format("woff2"),
             url(\${JSON.stringify(fontLightWoff)}) format("woff"),
             url(\${JSON.stringify(fontLightTtf)}) format("truetype");

--- a/packages/react-icons/src/headless/fonts/styles.css
+++ b/packages/react-icons/src/headless/fonts/styles.css
@@ -27,6 +27,7 @@
 
 @font-face {
   font-family: 'FluentSystemIconsLight';
+  font-display: block;
   src:
     url('../../utils/fonts/FluentSystemIcons-Light.woff2') format('woff2'),
     url('../../utils/fonts/FluentSystemIcons-Light.woff') format('woff'),

--- a/packages/react-icons/src/utils/fonts/createFluentFontIcon.styles.ts
+++ b/packages/react-icons/src/utils/fonts/createFluentFontIcon.styles.ts
@@ -21,6 +21,7 @@ const FONT_FAMILY_MAP = {
   [FontFile.Filled]: 'FluentSystemIconsFilled',
   [FontFile.Regular]: 'FluentSystemIconsRegular',
   [FontFile.Resizable]: 'FluentSystemIcons',
+  [FontFile.Light]: 'FluentSystemIconsLight',
 } as const;
 
 export const useStaticStyles = makeStaticStyles(`
@@ -41,6 +42,7 @@ export const useStaticStyles = makeStaticStyles(`
 
 @font-face {
     font-family: ${FONT_FAMILY_MAP[FontFile.Light]};
+    font-display: "block";
     src: url(${JSON.stringify(fontLightWoff2)}) format("woff2"),
     url(${JSON.stringify(fontLightWoff)}) format("woff"),
     url(${JSON.stringify(fontLightTtf)}) format("truetype");


### PR DESCRIPTION
## Problem

`FONT_FAMILY_MAP` in `src/utils/fonts/createFluentFontIcon.styles.ts` had no `FontFile.Light` entry, so the emitted `@font-face` was:

```css
@font-face { font-family: undefined; src: url(…FluentSystemIcons-Light.woff2) … }
```

while `useRootStyles` maps the Light enum to `.fgtzeza{font-family:FluentSystemIconsLight}`.

Light font icons **are** generated (e.g. `Settings32Light` → `createFluentFontIcon("Settings32Light", "…", 3, 32)`), so on the non-headless (Griffel) path they rendered with no font loaded. The headless CSS declared the family correctly, so this was non-headless specific.

## Fix

- Add `[FontFile.Light]: 'FluentSystemIconsLight'` to `FONT_FAMILY_MAP`.
- Add the `font-display: block` declaration the Light face was missing, in both the Griffel static styles and `headless/fonts/styles.css` (all other faces already had it).
- Update `build-verify` inline snapshots — output is now `@font-face{font-family:FluentSystemIconsLight;font-display:"block";…}`.

## Follow-up

The root cause is that the family name / file name / data-attribute value / enum value are duplicated across six hand-maintained places. A follow-up PR will generate these font definitions from a single manifest at build time so the headless and non-headless surfaces stay 1:1 by construction.

## Verification

`yarn nx run react-icons:build && yarn nx run react-icons:build-verify` — 139 passed, 8 skipped.