### PR TITLE
chore: add pre-push hook guarding yarn.lock drift

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,11 @@
+# Keeps yarn.lock honest, mirroring the `yarn install --immutable` gate in CI.
+
+# Catches a lockfile that was regenerated locally but never committed; `--immutable`
+# alone cannot see this, because it only ever inspects the working tree.
+if ! git diff --quiet HEAD -- yarn.lock; then
+  echo "pre-push: yarn.lock differs from HEAD. Commit it before pushing." >&2
+  exit 1
+fi
+
+# Catches a manifest change (including peerDependencies) with no matching lockfile update.
+yarn install --immutable


### PR DESCRIPTION
## Problem

CI runs `yarn install --immutable`, but that check only ever inspects the **working tree**.
A lockfile that was regenerated locally and never committed therefore passes locally and
fails on CI.

That is exactly what happened in #1219: `peerDependencies` were edited after `yarn add`,
the lockfile was regenerated at some later point but the commit kept the stale copy, and
a local `yarn install --immutable` still reported success because it was validating the
repaired working tree rather than the commit.

## The gap

Two distinct failure modes exist, and `--immutable` only covers one:

| Failure mode | Caught by `--immutable`? |
| --- | --- |
| Manifest changed, lockfile not regenerated | yes |
| Lockfile regenerated, but not committed | **no** |

## Change

A `.husky/pre-push` hook covering both:

```sh
if ! git diff --quiet HEAD -- yarn.lock; then
  echo "pre-push: yarn.lock differs from HEAD. Commit it before pushing." >&2
  exit 1
fi

yarn install --immutable
```

The git check runs first because it is essentially free; `--immutable` is a read-only
no-op when the tree is already in sync, so the hook adds no meaningful cost to a normal push.

Note that `git status --porcelain` is unsuitable here: it exits `0` even when it prints
output, so it cannot gate a hook. `git diff --quiet HEAD` returns non-zero and covers both
staged and unstaged drift.

## Verification

| Scenario | Expected | Actual |
| --- | --- | --- |
| Clean, in-sync tree | pass | exit 0 |
| `yarn.lock` modified but uncommitted | block | exit 1, `yarn.lock differs from HEAD` |
| `peerDependencies` added with stale lock | block | exit 1, `YN0028` |

This PR's own push exercised the hook.
