### PR TITLE
test(react-icons-atomic-webpack-loader): verify fixtures against rspack

### DIFF
--- a/packages/react-icons-atomic-webpack-loader/README.md
+++ b/packages/react-icons-atomic-webpack-loader/README.md
@@ -27,7 +27,7 @@ Add the loader to your webpack config as an [`enforce: 'pre'`](https://webpack.j
 
 NOTE: Unlike most loaders, this one should NOT exclude `node_modules`. It needs to process files inside `node_modules` as well to transform barrel imports from `@fluentui/react-icons` and `@fluentui/react-brand-icons` in your third-party dependencies. Files that don't reference a supported module are skipped via a fast pre-check, so there is no meaningful overhead.
 
-The loader also works unchanged with [rspack](https://rspack.rs) — the same rule shape applies, and every fixture in this package's test suite is verified against both bundlers. `webpack` and `@rspack/core` are declared as **optional** peer dependencies, so you only need to install the one you use.
+The loader also works unchanged with [rspack](https://rspack.rs) (`>=2.1.0`) — the same rule shape applies, and every fixture in this package's test suite is verified against both bundlers. `webpack` and `@rspack/core` are declared as **optional** peer dependencies, so you only need to install the one you use.
 
 ```js
 // webpack.config.js

--- a/packages/react-icons-atomic-webpack-loader/README.md
+++ b/packages/react-icons-atomic-webpack-loader/README.md
@@ -27,6 +27,8 @@ Add the loader to your webpack config as an [`enforce: 'pre'`](https://webpack.j
 
 NOTE: Unlike most loaders, this one should NOT exclude `node_modules`. It needs to process files inside `node_modules` as well to transform barrel imports from `@fluentui/react-icons` and `@fluentui/react-brand-icons` in your third-party dependencies. Files that don't reference a supported module are skipped via a fast pre-check, so there is no meaningful overhead.
 
+The loader also works unchanged with [rspack](https://rspack.rs) — the same rule shape applies, and every fixture in this package's test suite is verified against both bundlers. `webpack` and `@rspack/core` are declared as **optional** peer dependencies, so you only need to install the one you use.
+
 ```js
 // webpack.config.js
 module.exports = {

--- a/packages/react-icons-atomic-webpack-loader/eslint.config.mjs
+++ b/packages/react-icons-atomic-webpack-loader/eslint.config.mjs
@@ -1,4 +1,6 @@
 // @ts-check
 import { dependencyChecks } from '../../eslint.config.base.mjs';
 
-export default [dependencyChecks()];
+// Both bundlers are optional peers that invoke the loader; neither is imported, not even for
+// types, so the public `.d.ts` stays usable with only one of them installed.
+export default [dependencyChecks({ ignoredDependencies: ['@rspack/core', 'webpack'] })];

--- a/packages/react-icons-atomic-webpack-loader/package.json
+++ b/packages/react-icons-atomic-webpack-loader/package.json
@@ -31,7 +31,7 @@
     "@fluentui/react-icons": "*"
   },
   "peerDependencies": {
-    "@rspack/core": ">=1.0.0",
+    "@rspack/core": ">=2.1.0",
     "webpack": ">=5.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/react-icons-atomic-webpack-loader/package.json
+++ b/packages/react-icons-atomic-webpack-loader/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "build": "yarn run -T tsc -p .",
     "lint": "yarn run -T eslint package.json",
-    "test": "yarn run -T vitest run && yarn run -T webpack -c test/webpack.config.js"
+    "test": "yarn run -T vitest run && yarn run test:types && node test/run.js --bundler all",
+    "test:types": "yarn run -T tsc -p test/tsconfig.conformance.json",
+    "test:webpack": "node test/run.js --bundler webpack",
+    "test:rspack": "node test/run.js --bundler rspack"
   },
   "engines": {
     "node": ">=20.0.0"
@@ -28,7 +31,16 @@
     "@fluentui/react-icons": "*"
   },
   "peerDependencies": {
+    "@rspack/core": ">=1.0.0",
     "webpack": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    },
+    "webpack": {
+      "optional": true
+    }
   },
   "files": [
     "lib/*"

--- a/packages/react-icons-atomic-webpack-loader/src/index.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/index.ts
@@ -1,9 +1,10 @@
 import { transformSource } from './transform';
 import { SUPPORTED_MODULE_NAMES } from './modules';
 import type { IconVariant } from './modules';
-import type { LoaderContext } from 'webpack';
+import type { AtomicLoaderContext } from './loader-context';
 
 export type { IconVariant };
+export type { AtomicLoaderContext };
 
 export interface FluentIconsAtomicImportLoaderOptions {
   /**
@@ -63,10 +64,7 @@ export interface FluentIconsAtomicImportLoaderOptions {
   allowDynamicImports?: boolean;
 }
 
-export default function fluentIconsAtomicImportLoader(
-  this: LoaderContext<FluentIconsAtomicImportLoaderOptions>,
-  sourceCode: string,
-): void {
+export default function fluentIconsAtomicImportLoader(this: AtomicLoaderContext, sourceCode: string): void {
   const { resourcePath } = this;
 
   // Cheap pre-skip only: a false positive here just means we parse the file and

--- a/packages/react-icons-atomic-webpack-loader/src/loader-context.ts
+++ b/packages/react-icons-atomic-webpack-loader/src/loader-context.ts
@@ -1,0 +1,18 @@
+import type { FluentIconsAtomicImportLoaderOptions } from './index';
+
+/**
+ * Hand-maintained description of the loader context members this loader uses.
+ *
+ * Deliberately not `import type { LoaderContext } from 'webpack'`: both bundlers are optional
+ * peers, so referencing webpack's types here would leak into the generated `.d.ts` and break
+ * type-checking for consumers who only installed `@rspack/core`.
+ *
+ * Members are intentionally wider than webpack's and rspack's, so both real loader contexts remain
+ * assignable. `test/types.conformance.ts` fails to compile if either bundler drifts out of bounds.
+ */
+export interface AtomicLoaderContext {
+  readonly resourcePath: string;
+  getOptions(): FluentIconsAtomicImportLoaderOptions;
+  callback(err: Error | null | undefined, content?: string | Buffer, sourceMap?: any, additionalData?: any): void;
+  emitWarning(warning: Error): void;
+}

--- a/packages/react-icons-atomic-webpack-loader/test/make-configs.js
+++ b/packages/react-icons-atomic-webpack-loader/test/make-configs.js
@@ -1,0 +1,333 @@
+// @ts-check
+/**
+ * Shared test configuration factory for the atomic import loader.
+ *
+ * The same fixtures and assertions run against both webpack and rspack. Bundler-specific pieces are
+ * supplied by the adapter, and an entry may declare `overrides.<bundler>` when a bundler's emitted
+ * output legitimately differs.
+ */
+const { resolve } = require('path');
+const { readdirSync, readFileSync } = require('fs');
+
+/**
+ * @typedef {object} EntryAssertions
+ * @property {string[]} [mustInclude] Substrings the emitted bundle must contain.
+ * @property {string[]} [mustExclude] Substrings the emitted bundle must NOT contain.
+ * @property {string[]} [mustWarn] Substrings each of which must appear in at least
+ *   one emitted build warning. When set, all warnings are also printed so they are
+ *   directly visible in the test output.
+ */
+
+/**
+ * @typedef {object} EntryConfig
+ * @property {string} src Entry source file, relative to this config.
+ * @property {object} loaderOptions Options passed to the atomic import loader.
+ * @property {string[]} mustInclude
+ * @property {string[]} mustExclude
+ * @property {string[]} [mustWarn]
+ * @property {Record<string, EntryAssertions>} [overrides] Per-bundler assertion overrides,
+ *   keyed by bundler name. Only present where a bundler's output legitimately differs.
+ */
+
+/** @type {Record<string, EntryConfig>} */
+const entries = {
+  'svg-imports': {
+    src: './src/svg-imports.js',
+    loaderOptions: {},
+    mustInclude: [
+      '@fluentui/react-icons/svg/add',
+      '@fluentui/react-icons/svg/arrow-left',
+      '@fluentui/react-icons/svg/arrow-circle-down',
+      '@fluentui/react-icons/svg/people',
+      '@fluentui/react-icons/providers',
+      '@fluentui/react-icons/utils',
+    ],
+    mustExclude: ['"@fluentui/react-icons"'],
+  },
+  'svg-reexports': {
+    src: './src/svg-reexports.js',
+    loaderOptions: {},
+    mustInclude: [
+      '@fluentui/react-icons/svg/add',
+      '@fluentui/react-icons/svg/arrow-left',
+      '@fluentui/react-icons/svg/arrow-circle-down',
+      '@fluentui/react-icons/svg/add-circle',
+      '@fluentui/react-icons/providers',
+      '@fluentui/react-icons/utils',
+    ],
+    mustExclude: ['"@fluentui/react-icons"'],
+  },
+  'indirect-reexports': {
+    src: './src/indirect-reexports.js',
+    loaderOptions: {},
+    mustInclude: [
+      '@fluentui/react-icons/svg/add',
+      '@fluentui/react-icons/svg/arrow-left',
+      '@fluentui/react-icons/utils',
+    ],
+    mustExclude: ['"@fluentui/react-icons"'],
+  },
+  'aliased-indirect-reexports': {
+    src: './src/aliased-indirect-reexports.js',
+    loaderOptions: {},
+    mustInclude: ['@fluentui/react-icons/svg/add', '@fluentui/react-icons/svg/arrow-left'],
+    mustExclude: ['"@fluentui/react-icons"'],
+  },
+  'renamed-indirect-reexports': {
+    src: './src/renamed-indirect-reexports.js',
+    loaderOptions: {},
+    mustInclude: ['@fluentui/react-icons/svg/add', '@fluentui/react-icons/svg/arrow-left'],
+    mustExclude: ['"@fluentui/react-icons"'],
+  },
+  'mixed-reexports': {
+    src: './src/mixed-reexports.js',
+    loaderOptions: {},
+    mustInclude: [
+      '@fluentui/react-icons/svg/add',
+      '@fluentui/react-icons/svg/arrow-left',
+      '@fluentui/react-icons/utils',
+    ],
+    mustExclude: ['"@fluentui/react-icons"'],
+  },
+  'fonts-imports': {
+    src: './src/fonts-imports.js',
+    loaderOptions: { iconVariant: 'fonts' },
+    mustInclude: [
+      '@fluentui/react-icons/fonts/add',
+      '@fluentui/react-icons/fonts/arrow-left',
+      '@fluentui/react-icons/utils',
+    ],
+    mustExclude: ['"@fluentui/react-icons"', '@fluentui/react-icons/svg/'],
+  },
+  'color-fonts-imports': {
+    src: './src/color-fonts-imports.js',
+    // Color icons are SVG-only; under 'fonts' they reroute to svg while their
+    // non-color siblings stay on the font build.
+    loaderOptions: { iconVariant: 'fonts' },
+    mustInclude: ['@fluentui/react-icons/fonts/add', '@fluentui/react-icons/svg/add-circle'],
+    mustExclude: ['"@fluentui/react-icons"', '@fluentui/react-icons/fonts/add-circle'],
+  },
+  'svg-sprite-imports': {
+    src: './src/svg-sprite-imports.js',
+    loaderOptions: { iconVariant: 'svg-sprite' },
+    mustInclude: [
+      '@fluentui/react-icons/svg-sprite/add',
+      '@fluentui/react-icons/svg-sprite/arrow-left',
+      '@fluentui/react-icons/utils',
+    ],
+    mustExclude: ['"@fluentui/react-icons"', '@fluentui/react-icons/svg/', '@fluentui/react-icons/fonts/'],
+  },
+
+  'headless-imports': {
+    src: './src/headless-imports.js',
+    loaderOptions: { headless: true },
+    mustInclude: [
+      '@fluentui/react-icons/headless/svg/add',
+      '@fluentui/react-icons/headless/svg/arrow-left',
+      '@fluentui/react-icons/headless/svg/arrow-circle-down',
+      '@fluentui/react-icons/headless/svg/people',
+      // context stays on the shared (non-headless) providers entry
+      '@fluentui/react-icons/providers',
+      '@fluentui/react-icons/headless/utils',
+    ],
+    // no standard (non-headless) svg/utils paths should leak through
+    mustExclude: ['"@fluentui/react-icons"', '@fluentui/react-icons/svg/', '@fluentui/react-icons/utils'],
+  },
+
+  'color-headless-fonts-imports': {
+    src: './src/color-headless-fonts-imports.js',
+    // Under headless fonts, color icons reroute to the headless svg build while
+    // their non-color siblings stay on the headless font build.
+    loaderOptions: { iconVariant: 'fonts', headless: true },
+    mustInclude: ['@fluentui/react-icons/headless/fonts/add', '@fluentui/react-icons/headless/svg/add-circle'],
+    mustExclude: ['"@fluentui/react-icons"', '@fluentui/react-icons/headless/fonts/add-circle'],
+  },
+
+  'brand-icons-imports': {
+    src: './src/brand-icons-imports.js',
+    loaderOptions: {},
+    mustInclude: [
+      '@fluentui/react-brand-icons/svg/calendar-taskbar',
+      '@fluentui/react-brand-icons/svg/project',
+      '@fluentui/react-brand-icons/utils',
+    ],
+    mustExclude: ['"@fluentui/react-brand-icons"'],
+  },
+
+  'mixed-modules-fonts': {
+    src: './src/mixed-modules-fonts.js',
+    // react-icons honors 'fonts'; react-brand-icons only ships 'svg', so it
+    // falls back via the explicit fallbackVariant without erroring.
+    loaderOptions: { iconVariant: 'fonts', fallbackVariant: 'svg' },
+    mustInclude: ['@fluentui/react-icons/fonts/add', '@fluentui/react-brand-icons/svg/project'],
+    mustExclude: ['"@fluentui/react-icons"', '"@fluentui/react-brand-icons"', '@fluentui/react-brand-icons/fonts/'],
+  },
+
+  'jsx-component': {
+    src: './src/jsx-component.jsx',
+    loaderOptions: {},
+    mustInclude: ['@fluentui/react-icons/svg/add', '@fluentui/react-icons/svg/arrow-left'],
+    mustExclude: ['"@fluentui/react-icons"'],
+  },
+  'tsx-component': {
+    src: './src/tsx-component.tsx',
+    loaderOptions: {},
+    mustInclude: ['@fluentui/react-icons/svg/add', '@fluentui/react-icons/svg/arrow-left'],
+    mustExclude: ['"@fluentui/react-icons"'],
+  },
+
+  'dynamic-barrel-imports': {
+    src: './src/dynamic-barrel-imports.js',
+    loaderOptions: {},
+    // Dynamic imports are code-split into separate async chunks and left
+    // untouched by the loader, so there is nothing to assert on the main bundle
+    // content — the point of this fixture is the emitted warnings below.
+    mustInclude: [],
+    mustExclude: [],
+    // Each barrel dynamic import must surface a warning; the atomic one must not.
+    mustWarn: [
+      'dynamic import of the "@fluentui/react-icons" barrel cannot be atomized',
+      'dynamic import of the "@fluentui/react-brand-icons" barrel cannot be atomized',
+    ],
+  },
+
+  'dynamic-atomize': {
+    src: './src/dynamic-atomize.js',
+    loaderOptions: { allowDynamicImports: true },
+    // With allowDynamicImports the barrel dynamic import is rewritten to atomic
+    // dynamic imports; the bare barrel specifier must be gone.
+    mustInclude: ['@fluentui/react-icons/svg/add', '@fluentui/react-icons/svg/arrow-left'],
+    mustExclude: ['"@fluentui/react-icons"'],
+  },
+};
+
+/**
+ * @typedef {object} BundlerAdapter
+ * @property {'webpack' | 'rspack'} name
+ * @property {(dirname: string) => any} typescriptRule Rule compiling the `.tsx`/`.ts` fixtures.
+ */
+
+/**
+ * @param {BundlerAdapter} adapter
+ * @returns {import('webpack').Configuration[]}
+ */
+function makeConfigs(adapter) {
+  return Object.entries(entries).map(([name, entry]) => createConfig(name, entry, adapter));
+}
+
+// ====================================
+
+/**
+ * @param {string} name
+ * @param {EntryConfig} entry
+ * @param {BundlerAdapter} adapter
+ * @returns {import('webpack').Configuration}
+ */
+function createConfig(name, entry, adapter) {
+  return {
+    name,
+    context: __dirname,
+    mode: 'production',
+    optimization: { minimize: false },
+    entry: { [name]: entry.src },
+    experiments: { outputModule: true },
+    output: {
+      path: resolve(__dirname, 'dist', adapter.name, name),
+      filename: '[name].js',
+      library: { type: 'module' },
+    },
+    resolve: {
+      extensions: ['.tsx', '.ts', '.jsx', '.js'],
+    },
+    externals: [/^@fluentui\/react-icons/, /^@fluentui\/react-brand-icons/, /^react$/],
+    module: {
+      rules: [
+        {
+          test: /\.(jsx?|tsx?)$/,
+          enforce: 'pre',
+          use: [
+            {
+              loader: resolve(__dirname, '../lib/index.js'),
+              options: entry.loaderOptions,
+            },
+          ],
+        },
+        adapter.typescriptRule(__dirname),
+      ],
+    },
+    plugins: [createAssertionPlugin(name, entry, adapter)],
+  };
+}
+
+/**
+ * Reads every emitted chunk from disk and asserts the loader rewrote imports as expected.
+ *
+ * @param {string} name
+ * @param {EntryConfig} entry
+ * @param {BundlerAdapter} adapter
+ */
+function createAssertionPlugin(name, entry, adapter) {
+  const { mustInclude, mustExclude, mustWarn } = resolveAssertions(entry, adapter.name);
+  const label = `${adapter.name}/${name}`;
+
+  return {
+    apply(/** @type {import('webpack').Compiler} */ compiler) {
+      compiler.hooks.afterEmit.tap('verify-transforms', (compilation) => {
+        // Read every emitted JS chunk from disk (entry chunk + async chunks)
+        // so assertions also cover code split behind a dynamic import().
+        // afterEmit sources are size-only, hence reading the written files.
+        const outDir = resolve(__dirname, 'dist', adapter.name, name);
+        const output = readdirSync(outDir)
+          .filter((file) => file.endsWith('.js'))
+          .map((file) => readFileSync(resolve(outDir, file), 'utf8'))
+          .join('\n');
+
+        for (const pattern of mustInclude) {
+          if (!output.includes(pattern)) {
+            throw new Error(`[${label}] Expected output to contain "${pattern}" but it was not found.`);
+          }
+        }
+
+        for (const pattern of mustExclude) {
+          if (output.includes(pattern)) {
+            throw new Error(`[${label}] Expected output NOT to contain "${pattern}" but it was found.`);
+          }
+        }
+
+        if (mustWarn.length > 0) {
+          // rspack surfaces RspackError objects rather than Error instances, so read `message` directly.
+          const warnings = compilation.warnings.map((w) => (w && w.message) || String(w));
+
+          for (const warning of warnings) {
+            console.log(`  ⚠ ${label}: ${warning}`);
+          }
+
+          for (const expected of mustWarn) {
+            if (!warnings.some((w) => w.includes(expected))) {
+              throw new Error(`[${label}] Expected a build warning containing "${expected}" but none was emitted.`);
+            }
+          }
+        }
+
+        console.log(`  ✓ ${label}: all assertions passed`);
+      });
+    },
+  };
+}
+
+/**
+ * @param {EntryConfig} entry
+ * @param {string} bundler
+ * @returns {{ mustInclude: string[], mustExclude: string[], mustWarn: string[] }}
+ */
+function resolveAssertions(entry, bundler) {
+  const override = entry.overrides?.[bundler] ?? {};
+
+  return {
+    mustInclude: override.mustInclude ?? entry.mustInclude,
+    mustExclude: override.mustExclude ?? entry.mustExclude,
+    mustWarn: override.mustWarn ?? entry.mustWarn ?? [],
+  };
+}
+
+module.exports = { makeConfigs, entries };

--- a/packages/react-icons-atomic-webpack-loader/test/rspack.config.js
+++ b/packages/react-icons-atomic-webpack-loader/test/rspack.config.js
@@ -1,8 +1,11 @@
 // @ts-check
 const { makeConfigs } = require('./make-configs');
 
+// Intentionally the same ts-loader setup as webpack: the fixtures are only compiled so the atomic
+// transform has something to run against, and keeping the pipelines identical means any difference
+// in the emitted output comes from the bundler rather than from the TypeScript toolchain.
 module.exports = makeConfigs({
-  name: 'webpack',
+  name: 'rspack',
   typescriptRule: (dirname) => ({
     test: /\.[jt]sx?$/,
     exclude: /\.js$/,
@@ -11,8 +14,6 @@ module.exports = makeConfigs({
         loader: 'ts-loader',
         options: {
           transpileOnly: true,
-          // These fixtures live outside the package `rootDir`, and
-          // ts-loader picks up the package tsconfig.json for them.
           compilerOptions: { jsx: 'react', module: 'es2020', allowJs: true, rootDir: dirname },
         },
       },

--- a/packages/react-icons-atomic-webpack-loader/test/run.js
+++ b/packages/react-icons-atomic-webpack-loader/test/run.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * Runs the atomic import loader fixture builds against webpack and/or rspack.
+ *
+ * Each bundler compiles the same fixture entries; the assertion plugin in `make-configs.js`
+ * throws when the loader did not rewrite imports as expected.
+ *
+ * Usage: node test/run.js [options]
+ *
+ * Options:
+ *   -b, --bundler   Which bundler to run: webpack | rspack | all (default: all)
+ *   -h, --help      Show this message
+ */
+const { parseArgs } = require('node:util');
+
+const BUNDLERS = /** @type {const} */ (['webpack', 'rspack']);
+
+main();
+
+async function main() {
+  const options = processArgs();
+  const selected = options.bundler === 'all' ? BUNDLERS : [options.bundler];
+
+  for (const bundler of selected) {
+    console.log(`\n=== Running atomic loader fixtures with ${bundler} ===\n`);
+    await runBundler(/** @type {'webpack' | 'rspack'} */ (bundler));
+    console.log(`\n✓ ${bundler} passed\n`);
+  }
+}
+
+// ====================================
+
+/**
+ * @param {'webpack' | 'rspack'} bundler
+ * @returns {Promise<void>}
+ */
+function runBundler(bundler) {
+  const compilerFactory = bundler === 'webpack' ? require('webpack') : require('@rspack/core').rspack;
+  const configs = require(`./${bundler}.config.js`);
+
+  return new Promise((resolvePromise, rejectPromise) => {
+    compilerFactory(configs, (err, stats) => {
+      if (err) {
+        rejectPromise(err);
+        return;
+      }
+
+      if (stats.hasErrors()) {
+        console.error(stats.toString({ colors: true, preset: 'errors-only' }));
+        rejectPromise(new Error(`${bundler} build failed`));
+        return;
+      }
+
+      resolvePromise();
+    });
+  });
+}
+
+function processArgs() {
+  try {
+    const { values } = parseArgs({
+      options: {
+        bundler: { type: 'string', short: 'b', default: 'all' },
+        help: { type: 'boolean', short: 'h' },
+      },
+    });
+
+    if (values.help) {
+      printUsage();
+      process.exit(0);
+    }
+
+    if (!['all', ...BUNDLERS].includes(/** @type {string} */ (values.bundler))) {
+      throw new Error(`invalid --bundler "${values.bundler}", expected one of: all, ${BUNDLERS.join(', ')}`);
+    }
+
+    return { bundler: /** @type {'all' | 'webpack' | 'rspack'} */ (values.bundler) };
+  } catch (err) {
+    console.error(`Error parsing arguments: ${/** @type {Error} */ (err).message}`);
+    printUsage();
+    process.exit(1);
+  }
+}
+
+function printUsage() {
+  console.error(`
+Usage: node test/run.js [options]
+
+Options:
+  -b, --bundler   Which bundler to run: webpack | rspack | all (default: all)
+  -h, --help      Show this message
+`);
+}

--- a/packages/react-icons-atomic-webpack-loader/test/tsconfig.conformance.json
+++ b/packages/react-icons-atomic-webpack-loader/test/tsconfig.conformance.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "target": "es2020",
+    "module": "esnext",
+    // rspack ships its types behind an `exports` map, which node10 resolution cannot read.
+    "moduleResolution": "bundler",
+    "types": ["node"]
+  },
+  "include": ["types.conformance.ts", "../src/**/*.ts"]
+}

--- a/packages/react-icons-atomic-webpack-loader/test/types.conformance.ts
+++ b/packages/react-icons-atomic-webpack-loader/test/types.conformance.ts
@@ -1,0 +1,25 @@
+// Type-level conformance test — no runtime behaviour, checked by `tsc` only.
+//
+// Asserts that the hand-maintained `AtomicLoaderContext` remains a supertype of the real webpack
+// and rspack loader contexts. If either bundler changes a member the loader uses, this fails to
+// compile, which is the drift protection that justifies maintaining the interface by hand.
+import type * as webpack from 'webpack';
+import type * as rspack from '@rspack/core';
+
+import type { AtomicLoaderContext, FluentIconsAtomicImportLoaderOptions } from '../src/index';
+
+/** Fails to compile unless `Actual` is assignable to `Expected`. */
+type AssertAssignable<Expected, Actual extends Expected> = Actual;
+
+// The loader is invoked by the bundler with its own context as `this`, so every real loader
+// context must satisfy the maintained interface.
+type WebpackContextConforms = AssertAssignable<
+  AtomicLoaderContext,
+  webpack.LoaderContext<FluentIconsAtomicImportLoaderOptions>
+>;
+type RspackContextConforms = AssertAssignable<
+  AtomicLoaderContext,
+  rspack.LoaderContext<FluentIconsAtomicImportLoaderOptions>
+>;
+
+export type { WebpackContextConforms, RspackContextConforms };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3904,7 +3904,7 @@ __metadata:
     magic-string: "npm:^0.30.0"
     oxc-parser: "npm:^0.125.0"
   peerDependencies:
-    "@rspack/core": ">=1.0.0"
+    "@rspack/core": ">=2.1.0"
     webpack: ">=5.0.0"
   peerDependenciesMeta:
     "@rspack/core":

--- a/yarn.lock
+++ b/yarn.lock
@@ -3904,7 +3904,13 @@ __metadata:
     magic-string: "npm:^0.30.0"
     oxc-parser: "npm:^0.125.0"
   peerDependencies:
+    "@rspack/core": ">=1.0.0"
     webpack: ">=5.0.0"
+  peerDependenciesMeta:
+    "@rspack/core":
+      optional: true
+    webpack:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Why

`@fluentui/react-icons-atomic-webpack-loader` was only ever exercised against webpack. Since #1219
established rspack support for the font subsetting plugin, that claim should be tested here too
rather than assumed.

## Change

The fixture entries and their assertions move into a shared `test/make-configs.js`, and
`test/run.js` (`--bundler webpack|rspack|all`) drives **both** bundlers over the same 17 entries.
`test/webpack.config.js` becomes a thin wrapper, so the existing webpack behaviour is unchanged.

The rspack config deliberately keeps the **same `ts-loader` setup** as webpack rather than switching
to `builtin:swc-loader`, so that any difference in emitted output comes from the bundler rather than
from a different TypeScript toolchain.

## Result: no per-bundler overrides were needed

All 17 entries pass under rspack unmodified, including the three things I expected to be risky:

| Expected risk | Outcome |
| --- | --- |
| `ts-loader` under rspack (`.jsx` / `.tsx` fixtures) | works |
| `experiments.outputModule` + `library: { type: 'module' }` | works; every `mustInclude`/`mustExclude` string assertion holds |
| Emitted-warning assertions (`dynamic-barrel-imports`) | works after the fix below |

`make-configs.js` still supports `overrides.<bundler>` so a future divergence has somewhere to go,
but nothing uses it today.

## One real bug found

The assertion plugin read warnings as:

```js
compilation.warnings.map((w) => (w instanceof Error ? w.message : String(w)))
```

rspack surfaces `RspackError` objects rather than `Error` instances, so this would have fallen into
the `String(w)` branch and produced `[object Object]` — the `mustWarn` assertions would have failed
confusingly rather than reporting the real warning. Now reads `message` directly, which is correct
for both bundlers.

## Type leak fixed

`lib/index.d.ts` carried `import type { LoaderContext } from 'webpack'`. With both bundlers now
declared as **optional** peers, an rspack-only consumer would hit `Cannot find module 'webpack'`
while type-checking — the same defect fixed in #1219 for the font plugin.

Replaced with a hand-maintained `AtomicLoaderContext` covering the four members the loader actually
uses (`resourcePath`, `getOptions`, `callback`, `emitWarning`), plus
`test/types.conformance.ts` asserting that **both** bundlers' real `LoaderContext` still satisfies
it. Verified the check is not vacuous: adding a member no bundler has fails compilation for both.

## Peer range

`@rspack/core` is declared as `>=2.1.0`, matching the font plugin. The loader itself only touches the
loader context, which has been stable since rspack 1.x, so a lower floor would technically work — but
2.1.0 is the only version this suite exercises, and advertising untested versions is what produced
the incorrect range caught in review on #1219.

## Verification

- `nx run …:test` — vitest + type conformance + webpack 17/17 + rspack 17/17
- **Negative test**: a deliberately unsatisfiable `mustInclude` fails under rspack with
  `[rspack/svg-imports] Expected output to contain "THIS-SHOULD-NOT-EXIST"`, proving the rspack path
  actually evaluates assertions rather than passing vacuously
- **Conformance negative test**: adding a bogus required member fails for both bundlers
- Warnings confirmed genuinely captured under both bundlers (2 each on `dynamic-barrel-imports`)
- `nx run …:lint`, `yarn deps:check`, and `yarn install --immutable` all pass
