### PR TITLE
chore(deps): ban nx packages from dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,14 @@ updates:
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
+      # Nx is upgraded exclusively via `yarn nx migrate`, which keeps the whole `nx`/`@nx/*` set
+      # version-locked and applies config codemods (nx.json, project.json, migrations.json).
+      # A Dependabot bump only touches package.json/yarn.lock, so it silently skips the codemods
+      # and can desync plugin versions from the Nx runtime. Banned outright, security updates
+      # included — those must go through `nx migrate` too.
+      - dependency-name: 'nx'
+      - dependency-name: '@nx/*'
+      - dependency-name: '@nrwl/*'
     groups:
       production-dependencies:
         dependency-type: 'production'


### PR DESCRIPTION
## Why

Dependabot's grouped updates are working well, but the `development-dependencies` group keeps
sweeping Nx along with everything else — see #1223, which bundles `nx`, `@nx/js` and
`@nx/eslint-plugin` in with 19 unrelated bumps.

Nx can't be upgraded that way. `yarn nx migrate` is what keeps the `nx` runtime and every `@nx/*`
plugin version-locked to each other, and it's also what applies the config codemods
(`nx.json`, `project.json`, `migrations.json`). Dependabot only rewrites `package.json` and
`yarn.lock`, so it silently skips the codemods and can leave plugins desynced from the runtime.

## Change

Adds an ignore rule for `nx`, `@nx/*` and `@nrwl/*` to the npm ecosystem in
`.github/dependabot.yml`.

Deliberately **no `update-types` filter**, unlike the existing major-version rule above it. That
makes the ban total — security updates included — because those need to go through `nx migrate`
just the same. `@nrwl/*` is listed pre-emptively; nothing in the repo depends on the legacy scope
today.

Ignore rules are evaluated before grouping, so these drop out of `development-dependencies` rather
than forming a group of their own.

## Verification

Parsed the config with `js-yaml` to confirm it's valid and the rules land on the npm entry:

```json
[
  { "dependency-name": "*", "update-types": ["version-update:semver-major"] },
  { "dependency-name": "nx" },
  { "dependency-name": "@nx/*" },
  { "dependency-name": "@nrwl/*" }
]
```

## Follow-up

#1223 won't self-correct — it needs `@dependabot recreate` (or a close/reopen) once this lands so
the group is rebuilt without the Nx bumps.
