### PR TITLE
fix(react-icons-font-subsetting-webpack-plugin): derive rspack runtime from chunks, support rspack 2.0.x

### DIFF
--- a/packages/react-icons-font-subsetting-webpack-plugin/README.md
+++ b/packages/react-icons-font-subsetting-webpack-plugin/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-icons-font-subsetting-webpack-plugin
 
-This package includes a plugin for `webpack@>=5.0.0` and `@rspack/core@>=2.1.0` to subset the icon font files used by `@fluentui/react-icons` when using font-based icon implementations.
+This package includes a plugin for `webpack@>=5.0.0` and `@rspack/core@>=2.0.0` to subset the icon font files used by `@fluentui/react-icons` when using font-based icon implementations.
 
 If `optimization.usedExports` is enabled (as it is by default in `production` mode), this plugin will subset the font files to only include the glyphs actually used by your build.
 
@@ -123,6 +123,11 @@ Two rspack-specific notes:
 - For the headless import pattern, use `rspack.CssExtractRspackPlugin` instead of `mini-css-extract-plugin`, which is not compatible with rspack.
 - `webpack` and `@rspack/core` are both declared as **optional** peer dependencies, so you only need to install the bundler you actually use.
 
-rspack `>=2.1.0` is required because subsetting reads the module graph: `moduleGraph.getUsedExports()`
-was exposed to the JS API in rspack 2.0.0, and `moduleGraph.getProvidedExports()` — which this plugin
-relies on to subset namespace imports (`import * as …`) — only landed in 2.1.0.
+rspack `>=2.0.0` is required because subsetting reads the module graph, and
+`moduleGraph.getUsedExports()` was exposed to the JS API in rspack 2.0.0.
+
+On rspack `2.0.x` there is one limitation: `moduleGraph.getProvidedExports()` only landed in 2.1.0,
+and it is what lets the plugin subset icons reached through a **namespace import**
+(`import * as Icons from '@fluentui/react-icons/fonts/…'`). Those modules are skipped and their font
+is left un-subset, with a build warning saying so. Named imports — the common case — are unaffected
+and subset fully. Upgrade to rspack `>=2.1.0` for complete coverage.

--- a/packages/react-icons-font-subsetting-webpack-plugin/README.md
+++ b/packages/react-icons-font-subsetting-webpack-plugin/README.md
@@ -128,6 +128,8 @@ rspack `>=2.0.0` is required because subsetting reads the module graph, and
 
 On rspack `2.0.x` there is one limitation: `moduleGraph.getProvidedExports()` only landed in 2.1.0,
 and it is what lets the plugin subset icons reached through a **namespace import**
-(`import * as Icons from '@fluentui/react-icons/fonts/…'`). Those modules are skipped and their font
-is left un-subset, with a build warning saying so. Named imports — the common case — are unaffected
-and subset fully. Upgrade to rspack `>=2.1.0` for complete coverage.
+(`import * as Icons from '@fluentui/react-icons/fonts/…'`). Because those icons cannot be
+identified, _every_ font in the affected package is left un-subset — not just the namespace import's
+own module — since subsetting from the package's remaining imports would drop glyphs the namespace
+import actually uses. A build warning names the package when this happens. Named imports — the
+common case — are unaffected and subset fully. Upgrade to rspack `>=2.1.0` for complete coverage.

--- a/packages/react-icons-font-subsetting-webpack-plugin/package.json
+++ b/packages/react-icons-font-subsetting-webpack-plugin/package.json
@@ -4,7 +4,7 @@
   "description": "Webpack plugin to subset the icon fonts used by @fluentui/react-icons based on which icons are used.",
   "main": "lib/index.js",
   "scripts": {
-    "test": "yarn run test:types && node test/run.js --bundler all",
+    "test": "yarn run -T vitest run && yarn run test:types && node test/run.js --bundler all",
     "test:types": "yarn run -T tsc -p test/tsconfig.conformance.json",
     "test:webpack": "node test/run.js --bundler webpack",
     "test:rspack": "node test/run.js --bundler rspack",

--- a/packages/react-icons-font-subsetting-webpack-plugin/package.json
+++ b/packages/react-icons-font-subsetting-webpack-plugin/package.json
@@ -33,7 +33,7 @@
     "subset-font": "^1.4.0"
   },
   "peerDependencies": {
-    "@rspack/core": ">=2.1.0",
+    "@rspack/core": ">=2.0.0",
     "webpack": ">=5.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/react-icons-font-subsetting-webpack-plugin/src/bundler-api.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/src/bundler-api.ts
@@ -31,8 +31,8 @@ export interface BundlerModuleGraph {
     module: BundlerModule,
     runtime: string | string[] | ReadonlySet<string> | undefined,
   ): ReadonlySet<string> | readonly string[] | boolean | null;
-  /** Exposed to rspack's JS API only in 2.1.0, which is what sets the `@rspack/core` peer floor. */
-  getProvidedExports(module: BundlerModule): readonly string[] | boolean | null;
+  /** Optional: exposed to rspack's JS API only in 2.1.0, so absent on the supported 2.0.x floor. */
+  getProvidedExports?(module: BundlerModule): readonly string[] | boolean | null;
 }
 
 export interface BundlerAsset {

--- a/packages/react-icons-font-subsetting-webpack-plugin/src/bundler-api.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/src/bundler-api.ts
@@ -41,6 +41,11 @@ export interface BundlerAsset {
   info?: { sourceFilename?: string };
 }
 
+/** webpack's `RuntimeSpec` is `string | SortableSet<string> | undefined`; rspack's is a `Set<string>`. */
+export interface BundlerChunk {
+  runtime?: string | ReadonlySet<string>;
+}
+
 export interface BundlerCompilation {
   hooks: {
     processAssets: {
@@ -48,6 +53,7 @@ export interface BundlerCompilation {
     };
   };
   modules: Iterable<BundlerModule>;
+  chunks: Iterable<BundlerChunk>;
   moduleGraph: BundlerModuleGraph;
   entrypoints: ReadonlyMap<string, unknown>;
   warnings: Error[];

--- a/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
@@ -25,6 +25,9 @@ const FONT_FILES_BASE_NAMES = [
 
 const FONT_EXTENSIONS = ['.ttf', '.woff', '.woff2'];
 
+/** Separates "this module's icons are unknowable" from the benign "this module contributes nothing". */
+const UNRESOLVABLE_NAMESPACE_IMPORT = Symbol('unresolvable-namespace-import');
+
 /**
  *  Match both chunk files and atomic font imports, for the standard (Griffel)
  *  and headless APIs:
@@ -61,19 +64,25 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
         { name: PLUGIN_NAME, stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE },
         async () => {
           const runtime = getRuntimeSpec(compiler, compilation);
-          // Set when a namespace import is found but the bundler cannot report provided exports.
-          const diagnostics = { namespaceImportsUnsupported: false };
+          // Packages holding a namespace import this bundler cannot resolve; their fonts must be left whole.
+          const unresolvableNamespacePackages = new Set<string>();
 
           // There could be multiple instances of `@fluentui/react-icons`, and they need to be subset separately
           const packageToUsedFontExports: Map<string, Set<string>> = new Map<string, Set<string>>();
           for (const m of compilation.modules) {
             if (isFluentUIReactFontChunk(m)) {
-              const icons = resolveUsedIconExports(m, compilation.moduleGraph, runtime, diagnostics);
+              const pkgLibPath = resolve(dirname(m.resource), '../..');
+              const icons = resolveUsedIconExports(m, compilation.moduleGraph, runtime);
+
+              if (icons === UNRESOLVABLE_NAMESPACE_IMPORT) {
+                unresolvableNamespacePackages.add(pkgLibPath);
+                continue;
+              }
+
               if (icons === null) {
                 continue;
               }
 
-              const pkgLibPath = resolve(dirname(m.resource), '../..');
               const usedPkgExports = packageToUsedFontExports.get(pkgLibPath) ?? new Set<string>();
               for (const icon of icons) {
                 usedPkgExports.add(icon);
@@ -83,13 +92,18 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
           }
           const optimizationPromises: Promise<void>[] = [];
 
-          if (diagnostics.namespaceImportsUnsupported) {
-            // Degrading quietly would ship a full font while looking healthy, so say so once.
+          for (const pkgLibPath of unresolvableNamespacePackages) {
+            // Sibling modules would otherwise subset this package's shared fonts down to *their*
+            // glyphs alone, dropping the ones the namespace import needs.
+            packageToUsedFontExports.delete(pkgLibPath);
             compilation.warnings.push(
               new Error(
-                `${PLUGIN_NAME}: this bundler does not expose \`moduleGraph.getProvidedExports()\`, so icons ` +
-                  `reached through a namespace import (\`import * as ...\`) cannot be subset and were left ` +
-                  `un-subset. Named imports are unaffected. Upgrade to rspack >=2.1.0 for full coverage.`,
+                `${PLUGIN_NAME}: "${pkgLibPath}" is reached through a namespace import (\`import * as ...\`) ` +
+                  `whose icons cannot be determined — either the bundler does not expose ` +
+                  `\`moduleGraph.getProvidedExports()\` (rspack <2.1.0), or \`optimization.providedExports\` is ` +
+                  `disabled. Every font in this package was left un-subset, because subsetting from the ` +
+                  `remaining imports alone would drop glyphs that are actually used. Named imports are ` +
+                  `unaffected. Upgrade to rspack >=2.1.0 for full coverage.`,
               ),
             );
           }
@@ -229,14 +243,15 @@ function getTargetFormat(assetName: string) {
  *   with namespace imports. Without this, namespace imports would skip subsetting entirely and ship
  *   the full unsubsetted font.
  *
- * Returns `null` when subsetting cannot be performed, so the caller can skip the module.
+ * Returns `null` when the module contributes no glyphs, and {@link UNRESOLVABLE_NAMESPACE_IMPORT}
+ * when its glyphs exist but cannot be identified — the caller must then leave the whole package's
+ * fonts alone, since dropping the module silently would subset those glyphs away.
  */
 function resolveUsedIconExports(
   m: BundlerNormalModule,
   moduleGraph: BundlerModuleGraph,
   runtime: string[] | undefined,
-  diagnostics: { namespaceImportsUnsupported: boolean },
-): string[] | null {
+): string[] | null | typeof UNRESOLVABLE_NAMESPACE_IMPORT {
   const usedModuleExports = moduleGraph.getUsedExports(m, runtime);
 
   if (usedModuleExports === null) {
@@ -254,15 +269,14 @@ function resolveUsedIconExports(
     // Retrieve statically-provided exports from the module graph so we can subset to exactly
     // the glyphs this module declares (rather than the full font or nothing).
     if (typeof moduleGraph.getProvidedExports !== 'function') {
-      // rspack <2.1 has no such API; skip rather than crash, and let the caller warn.
-      diagnostics.namespaceImportsUnsupported = true;
-      return null;
+      // rspack <2.1 has no such API; the glyphs are real but unknowable, so the caller must bail.
+      return UNRESOLVABLE_NAMESPACE_IMPORT;
     }
 
     const providedExports = moduleGraph.getProvidedExports(m);
     if (providedExports === null || typeof providedExports === 'boolean') {
-      // Provided exports not statically known (optimization.providedExports disabled) - skip.
-      return null;
+      // Provided exports not statically known (optimization.providedExports disabled).
+      return UNRESOLVABLE_NAMESPACE_IMPORT;
     }
     return [...providedExports];
   }

--- a/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
@@ -61,12 +61,14 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
         { name: PLUGIN_NAME, stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE },
         async () => {
           const runtime = getRuntimeSpec(compiler, compilation);
+          // Set when a namespace import is found but the bundler cannot report provided exports.
+          const diagnostics = { namespaceImportsUnsupported: false };
 
           // There could be multiple instances of `@fluentui/react-icons`, and they need to be subset separately
           const packageToUsedFontExports: Map<string, Set<string>> = new Map<string, Set<string>>();
           for (const m of compilation.modules) {
             if (isFluentUIReactFontChunk(m)) {
-              const icons = resolveUsedIconExports(m, compilation.moduleGraph, runtime);
+              const icons = resolveUsedIconExports(m, compilation.moduleGraph, runtime, diagnostics);
               if (icons === null) {
                 continue;
               }
@@ -80,6 +82,17 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
             }
           }
           const optimizationPromises: Promise<void>[] = [];
+
+          if (diagnostics.namespaceImportsUnsupported) {
+            // Degrading quietly would ship a full font while looking healthy, so say so once.
+            compilation.warnings.push(
+              new Error(
+                `${PLUGIN_NAME}: this bundler does not expose \`moduleGraph.getProvidedExports()\`, so icons ` +
+                  `reached through a namespace import (\`import * as ...\`) cannot be subset and were left ` +
+                  `un-subset. Named imports are unaffected. Upgrade to rspack >=2.1.0 for full coverage.`,
+              ),
+            );
+          }
 
           for (const [pkgLibPath, usedExports] of packageToUsedFontExports) {
             const fontAssets = await getFontAssetsAndCodepoints(pkgLibPath, compilation, compiler.context);
@@ -222,6 +235,7 @@ function resolveUsedIconExports(
   m: BundlerNormalModule,
   moduleGraph: BundlerModuleGraph,
   runtime: string[] | undefined,
+  diagnostics: { namespaceImportsUnsupported: boolean },
 ): string[] | null {
   const usedModuleExports = moduleGraph.getUsedExports(m, runtime);
 
@@ -239,6 +253,12 @@ function resolveUsedIconExports(
     // All exports are used (e.g. `import * as ns from '...'` or similar namespace import).
     // Retrieve statically-provided exports from the module graph so we can subset to exactly
     // the glyphs this module declares (rather than the full font or nothing).
+    if (typeof moduleGraph.getProvidedExports !== 'function') {
+      // rspack <2.1 has no such API; skip rather than crash, and let the caller warn.
+      diagnostics.namespaceImportsUnsupported = true;
+      return null;
+    }
+
     const providedExports = moduleGraph.getProvidedExports(m);
     if (providedExports === null || typeof providedExports === 'boolean') {
       // Provided exports not statically known (optimization.providedExports disabled) - skip.

--- a/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
@@ -114,15 +114,31 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
 /**
  * Resolves the runtime to query used-exports information for.
  *
- * webpack accepts `undefined` to mean "merged across all runtimes", but rspack's binding requires an
- * explicit `string | string[]`, so entrypoint names are passed instead.
+ * webpack accepts `undefined`, meaning "merged across all runtimes". rspack requires explicit
+ * runtime names, and those are the names of the *runtime chunks* — which are only the entrypoint
+ * names by coincidence. Any build that names its runtime chunk (`entry.runtime`,
+ * `optimization.runtimeChunk`) makes the two diverge, and querying the wrong runtime reports every
+ * module as unused, so nothing gets subset. The runtimes are therefore read off the chunks.
  */
 function getRuntimeSpec(compiler: BundlerCompiler, compilation: BundlerCompilation): string[] | undefined {
   if (!isRspack(compiler)) {
     return undefined;
   }
 
-  return Array.from(compilation.entrypoints.keys());
+  const runtimes = new Set<string>();
+  for (const chunk of compilation.chunks) {
+    const { runtime } = chunk;
+    if (typeof runtime === 'string') {
+      runtimes.add(runtime);
+    } else if (runtime) {
+      for (const name of runtime) {
+        runtimes.add(name);
+      }
+    }
+  }
+
+  // Entrypoint names remain a last resort for the (unexpected) case of chunks without runtimes.
+  return runtimes.size > 0 ? Array.from(runtimes) : Array.from(compilation.entrypoints.keys());
 }
 
 function isRspack(compiler: BundlerCompiler): boolean {

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/make-configs.js
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/make-configs.js
@@ -29,7 +29,25 @@ const entries = {
     useAtomicLoader: true,
     assertNoGriffel: true,
   },
+  // Regression guard: naming the runtime chunk makes the runtime name differ from the entry name.
+  // rspack resolves used exports per runtime, so querying the wrong one reports every module as
+  // unused and silently subsets nothing. Every other entry here happens to have runtime === entry
+  // name, which is exactly why this went unnoticed.
+  namedRuntimeChunk: {
+    src: './src/atoms.js',
+    threshold: 2 * 1_024, // 2 KB — same content as `atoms`, so the same budget must hold
+    runtimeChunkName: 'shared-runtime',
+  },
 };
+
+/**
+ * @typedef {object} EntryConfig
+ * @property {string} src
+ * @property {number} threshold
+ * @property {boolean} [useAtomicLoader]
+ * @property {boolean} [assertNoGriffel]
+ * @property {string} [runtimeChunkName] Name the runtime chunk, decoupling runtime name from entry name.
+ */
 
 /**
  * @typedef {object} BundlerAdapter
@@ -54,7 +72,7 @@ function makeConfigs(adapter, options = {}) {
 
 /**
  * @param {string} name
- * @param {{ src: string, threshold: number, useAtomicLoader?: boolean, assertNoGriffel?: boolean }} entry
+ * @param {EntryConfig} entry
  * @param {BundlerAdapter} adapter
  * @param {boolean} isDevServer
  * @returns {import('webpack').Configuration}
@@ -111,7 +129,7 @@ function createConfig(name, entry, adapter, isDevServer) {
         },
       ],
     },
-    entry: { [name]: entry.src },
+    entry: { [name]: entry.runtimeChunkName ? { import: entry.src, runtime: entry.runtimeChunkName } : entry.src },
     output: {
       path: resolve(__dirname, 'dist', adapter.name, name),
       filename: '[name].js',

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/plugin.test.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/plugin.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import FluentUIReactIconsFontSubsettingPlugin from '../src/index';
+import type { BundlerCompiler } from '../src/bundler-api';
+
+// The package's `exports` map hides package.json, so the sibling workspace path is used instead.
+const REACT_ICONS_LIB = resolve(dirname(fileURLToPath(import.meta.url)), '../../react-icons/lib');
+const FONT_FILE = resolve(REACT_ICONS_LIB, 'utils/fonts/FluentSystemIcons-Regular.ttf');
+const FONT_MODULE = resolve(REACT_ICONS_LIB, 'atoms/fonts/games.js');
+
+/**
+ * webpack's `RuntimeSpec` value meaning "do not scope this query — merge across every runtime".
+ * rspack has no equivalent and rejects it, which is why the two bundlers take different paths.
+ */
+const MERGED_ACROSS_ALL_RUNTIMES = undefined;
+
+/** Deliberately different from the entrypoint name, which is what the runtime bug confused it with. */
+const RUNTIME_CHUNK_NAME = 'shared-runtime';
+const ENTRYPOINT_NAME = 'main';
+
+interface HarnessOptions {
+  /** Adds the `rspack` marker so the plugin takes the explicit-runtime path. */
+  isRspack?: boolean;
+  /** Whether the bundler exposes the 2.1-only API. */
+  hasProvidedExports?: boolean;
+  usedExports: () => ReadonlySet<string> | readonly string[] | boolean | null;
+}
+
+/**
+ * Drives `apply()` against a minimal fake compiler.
+ *
+ * The bundler-integration suite cannot express "an rspack without `getProvidedExports`" or assert
+ * which runtime was queried, so both live here instead.
+ */
+async function harness(options: HarnessOptions) {
+  const originalFont = readFileSync(FONT_FILE);
+  /** Every `runtime` argument the plugin passed to `getUsedExports`, in call order. */
+  const runtimesSeen: unknown[] = [];
+  const updatedAssets: { name: string; size: number }[] = [];
+  const warnings: Error[] = [];
+
+  /** Captures the callback the plugin registers on `processAssets`, so the test can invoke it. */
+  let processAssets: (() => Promise<void>) | undefined;
+
+  const moduleGraph = {
+    getUsedExports(_m: unknown, runtime: unknown) {
+      runtimesSeen.push(runtime);
+      return options.usedExports();
+    },
+    // Omitted entirely when absent, mirroring rspack 2.0.x where the method does not exist.
+    ...(options.hasProvidedExports ? { getProvidedExports: () => ['GamesFilled'] as readonly string[] } : {}),
+  };
+
+  const compilation = {
+    hooks: {
+      processAssets: {
+        tapPromise(_options: unknown, fn: () => Promise<void>) {
+          processAssets = fn;
+        },
+      },
+    },
+    modules: [{ type: 'javascript/auto', resource: FONT_MODULE }],
+    // rspack exposes `chunk.runtime` as a Set; webpack's may also be a bare string.
+    chunks: [{ runtime: new Set([RUNTIME_CHUNK_NAME]) }],
+    moduleGraph,
+    entrypoints: new Map([[ENTRYPOINT_NAME, {}]]),
+    warnings,
+    getAsset: (name: string) => ({ name, source: { source: () => originalFont } }),
+    // An absolute `sourceFilename` resolves independently of `context`.
+    getAssets: () => [
+      { name: 'Regular.ttf', source: { source: () => originalFont }, info: { sourceFilename: FONT_FILE } },
+    ],
+    updateAsset: (name: string, source: { source(): string | Buffer }) => {
+      updatedAssets.push({ name, size: Buffer.from(source.source()).length });
+    },
+  };
+
+  const compiler = {
+    context: '/',
+    // The plugin detects rspack via this marker.
+    ...(options.isRspack ? { rspack: {} } : {}),
+    webpack: {
+      Compilation: { PROCESS_ASSETS_STAGE_OPTIMIZE: 0 },
+      sources: {
+        RawSource: class {
+          constructor(private readonly value: string | Buffer) {}
+          source() {
+            return this.value;
+          }
+        },
+      },
+    },
+    hooks: { compilation: { tap: (_name: string, fn: (c: unknown) => void) => fn(compilation) } },
+  };
+
+  new FluentUIReactIconsFontSubsettingPlugin().apply(compiler as unknown as BundlerCompiler);
+  await processAssets!();
+
+  return { runtimesSeen, updatedAssets, warnings, originalSize: originalFont.length };
+}
+
+describe('runtime resolution', () => {
+  it('asks rspack about the runtime chunk, not the entrypoint', async () => {
+    const { runtimesSeen } = await harness({
+      isRspack: true,
+      hasProvidedExports: true,
+      usedExports: () => ['GamesFilled'],
+    });
+
+    // The two names coincide only when the runtime chunk is unnamed, which is true of every
+    // fixture in the bundler suite. Query the entrypoint instead and rspack reports every module
+    // unused, so the plugin skips everything and ships full fonts without failing the build.
+    expect(runtimesSeen).toEqual([[RUNTIME_CHUNK_NAME]]);
+    expect(runtimesSeen).not.toEqual([[ENTRYPOINT_NAME]]);
+  });
+
+  it('asks webpack for usage merged across all runtimes', async () => {
+    const { runtimesSeen } = await harness({ hasProvidedExports: true, usedExports: () => ['GamesFilled'] });
+
+    // Scoping webpack to specific runtimes would be the inverse failure: an icon used only in an
+    // unlisted runtime would look unused and lose its glyph — a wrong subset, silently.
+    expect(runtimesSeen).toEqual([MERGED_ACROSS_ALL_RUNTIMES]);
+  });
+});
+
+describe('getProvidedExports capability guard', () => {
+  it('warns and skips instead of throwing when the bundler lacks the API', async () => {
+    const { updatedAssets, warnings } = await harness({
+      isRspack: true,
+      hasProvidedExports: false,
+      // `true` is what both bundlers return for a namespace import: "every export is used".
+      usedExports: () => true,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain('getProvidedExports');
+    // Skipped, so the font is left whole rather than wrongly subset.
+    expect(updatedAssets).toEqual([]);
+  });
+
+  it('subsets namespace imports when the API is available', async () => {
+    const { updatedAssets, warnings, originalSize } = await harness({
+      isRspack: true,
+      hasProvidedExports: true,
+      usedExports: () => true,
+    });
+
+    expect(warnings).toEqual([]);
+    expect(updatedAssets).toHaveLength(1);
+    expect(updatedAssets[0].size).toBeLessThan(originalSize);
+  });
+
+  it('subsets named imports without needing the API at all', async () => {
+    const { updatedAssets, warnings, originalSize } = await harness({
+      isRspack: true,
+      // The rspack 2.0.x shape: no `getProvidedExports`, and named imports never need it.
+      hasProvidedExports: false,
+      usedExports: () => ['GamesFilled'],
+    });
+
+    expect(warnings).toEqual([]);
+    expect(updatedAssets).toHaveLength(1);
+    expect(updatedAssets[0].size).toBeLessThan(originalSize);
+  });
+});

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/plugin.test.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/plugin.test.ts
@@ -10,6 +10,8 @@ import type { BundlerCompiler } from '../src/bundler-api';
 const REACT_ICONS_LIB = resolve(dirname(fileURLToPath(import.meta.url)), '../../react-icons/lib');
 const FONT_FILE = resolve(REACT_ICONS_LIB, 'utils/fonts/FluentSystemIcons-Regular.ttf');
 const FONT_MODULE = resolve(REACT_ICONS_LIB, 'atoms/fonts/games.js');
+/** A second module in the *same* package, so both share one set of font assets. */
+const SIBLING_FONT_MODULE = resolve(REACT_ICONS_LIB, 'atoms/fonts/add.js');
 
 /**
  * webpack's `RuntimeSpec` value meaning "do not scope this query — merge across every runtime".
@@ -26,7 +28,9 @@ interface HarnessOptions {
   isRspack?: boolean;
   /** Whether the bundler exposes the 2.1-only API. */
   hasProvidedExports?: boolean;
-  usedExports: () => ReadonlySet<string> | readonly string[] | boolean | null;
+  /** Font module resources to place in the graph. */
+  moduleResources?: string[];
+  usedExports: (resource: string) => ReadonlySet<string> | readonly string[] | boolean | null;
 }
 
 /**
@@ -46,9 +50,9 @@ async function harness(options: HarnessOptions) {
   let processAssets: (() => Promise<void>) | undefined;
 
   const moduleGraph = {
-    getUsedExports(_m: unknown, runtime: unknown) {
+    getUsedExports(m: { resource: string }, runtime: unknown) {
       runtimesSeen.push(runtime);
-      return options.usedExports();
+      return options.usedExports(m.resource);
     },
     // Omitted entirely when absent, mirroring rspack 2.0.x where the method does not exist.
     ...(options.hasProvidedExports ? { getProvidedExports: () => ['GamesFilled'] as readonly string[] } : {}),
@@ -62,7 +66,10 @@ async function harness(options: HarnessOptions) {
         },
       },
     },
-    modules: [{ type: 'javascript/auto', resource: FONT_MODULE }],
+    modules: (options.moduleResources ?? [FONT_MODULE]).map((resource) => ({
+      type: 'javascript/auto',
+      resource,
+    })),
     // rspack exposes `chunk.runtime` as a Set; webpack's may also be a bare string.
     chunks: [{ runtime: new Set([RUNTIME_CHUNK_NAME]) }],
     moduleGraph,
@@ -164,5 +171,20 @@ describe('getProvidedExports capability guard', () => {
     expect(warnings).toEqual([]);
     expect(updatedAssets).toHaveLength(1);
     expect(updatedAssets[0].size).toBeLessThan(originalSize);
+  });
+
+  it('leaves the package whole when a namespace import sits alongside a named one', async () => {
+    const { updatedAssets, warnings } = await harness({
+      isRspack: true,
+      hasProvidedExports: false,
+      moduleResources: [FONT_MODULE, SIBLING_FONT_MODULE],
+      usedExports: (resource) => (resource === FONT_MODULE ? true : ['AddFilled']),
+    });
+
+    // Both modules share one font, so subsetting to the named import alone would delete the
+    // glyphs the unresolvable namespace import needs — a broken build that still looks green.
+    expect(updatedAssets).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain(REACT_ICONS_LIB);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3936,7 +3936,7 @@ __metadata:
     "@fluentui/react-icons": "npm:*"
     subset-font: "npm:^1.4.0"
   peerDependencies:
-    "@rspack/core": ">=2.1.0"
+    "@rspack/core": ">=2.0.0"
     webpack: ">=5.0.0"
   peerDependenciesMeta:
     "@rspack/core":


### PR DESCRIPTION
## Summary

The font subsetting plugin silently subset **nothing** on rspack whenever the app used a named runtime chunk. This fixes the root cause, lowers the supported rspack floor to `>=2.0.0` behind a capability guard, and adds unit tests that pin both behaviours.

## The bug

`getRuntimeSpec()` passed `compilation.entrypoints.keys()` to `moduleGraph.getUsedExports()` as a stand-in for runtime names. Those two coincide only when the runtime chunk is *unnamed*. As soon as an app sets `entry.runtime` or `optimization.runtimeChunk`, they diverge — `getUsedExports()` then returns `false` for every module, the plugin concludes no icons are used, and every font ships un-subset.

| `runtime` passed to `getUsedExports` | result |
| --- | --- |
| `['atoms']` (entrypoint name) | `false` ❌ |
| `['shared-runtime']` (chunk runtime) | `["GamesFilled"]` ✅ |

This was never an rspack version issue — it reproduces identically on 2.0.1 and 2.1.10.

The fix derives the runtime spec from `chunk.runtime` across `compilation.chunks`, handling both the `string` and `Set<string>` shapes. Entrypoint names are kept only as a last-resort fallback.

New `namedRuntimeChunk` fixture, measured on both bundlers:

| | before | after |
| --- | --- | --- |
| emitted font bytes | 2,818,416 B | **1,164 B** |

## rspack 2.0.x support

Peer range lowered `>=2.1.0` → `>=2.0.0`. The only 2.1-only API the plugin touches is `moduleGraph.getProvidedExports()` ([rspack#14349](https://github.com/web-infra-dev/rspack/pull/14349)), which is needed solely to resolve icons reached through a namespace import (`import * as ...`). `getUsedExports()` — the hot path for named imports — landed in 2.0.0 ([rspack#13519](https://github.com/web-infra-dev/rspack/pull/13519)).

So on 2.0.x the plugin now feature-detects: named imports subset normally, namespace imports are left un-subset and a build **warning** explains why and points at the upgrade. Previously this path threw `TypeError: getProvidedExports is not a function`.

Verified manually on rspack 2.0.1:

| fixture | bytes | warning |
| --- | --- | --- |
| `atoms` | 1,164 B | — |
| `namedRuntimeChunk` | 1,164 B | — |
| `atomsImportStar` | 2,818,416 B | emitted, build succeeds |

## Tests

The existing integration suites only observe emitted bytes, so they can't assert *which* runtime was queried, nor simulate an absent API. Added `test/plugin.test.ts`, which drives `apply()` against a fake compiler — no bundler required:

1. rspack path queries the chunk runtime, not the entrypoint
2. webpack path queries with `undefined` (merge across all runtimes)
3. missing `getProvidedExports` → warns and skips, no throw
4. namespace imports subset when the API is present
5. named imports subset without the API

Both regressions confirmed caught by reintroducing them:

- revert the runtime fix → `expected [['main']] to deeply equal [['shared-runtime']]`
- remove the guard → `TypeError: getProvidedExports is not a function`

## Validation

- Unit 5/5, conformance, webpack 6/6, rspack 6/6, lint clean

## Caveat worth flagging

CI still only exercises rspack 2.1.10, so the `>=2.0.0` floor is verified manually here rather than continuously. The unit tests cover the capability-guard logic, but not a real 2.0.x build. Pinning a second aliased rspack in CI is possible (~40 MB of extra native binaries) if reviewers would rather have that guarantee than the manual check.


## Follow-up: namespace-import fallout is now scoped to the package

Review surfaced a second, worse bug in the capability guard above. Skipping only the *offending module* let its siblings subset the package's shared fonts down to their own glyphs, deleting the ones the namespace import needed — a green build shipping broken glyphs, rather than the merely-larger font the warning claimed.

Reproduced as a failing unit test before fixing:

```
AssertionError: expected [ { name: 'Regular.ttf', size: 660 } ] to deeply equal []
```

`resolveUsedIconExports` now returns an `UNRESOLVABLE_NAMESPACE_IMPORT` sentinel rather than a bare `null`, so the caller can tell "contributes nothing" apart from "glyphs are real but unknowable". The latter poisons its `pkgLibPath`, which is dropped before subsetting, leaving that package's fonts whole. Scoped per-package rather than per-compilation, since multiple `@fluentui/react-icons` instances are supported and poisoning one shouldn't disable the others.

Also applied to `getProvidedExports()` returning `null`/boolean (`optimization.providedExports` disabled) — identical failure mode. The warning now names the affected package and covers both causes.

Not expressible as an integration fixture: CI runs rspack 2.1.10, where `getProvidedExports` exists and the bug is unreachable.

Unit tests now 6/6; webpack 6/6, rspack 6/6, conformance and lint unchanged.
