### PR TITLE
fix(react-icons-atomic-webpack-loader): lower rspack peer floor to >=2.0.0

### DIFF
--- a/packages/react-icons-atomic-webpack-loader/README.md
+++ b/packages/react-icons-atomic-webpack-loader/README.md
@@ -27,7 +27,7 @@ Add the loader to your webpack config as an [`enforce: 'pre'`](https://webpack.j
 
 NOTE: Unlike most loaders, this one should NOT exclude `node_modules`. It needs to process files inside `node_modules` as well to transform barrel imports from `@fluentui/react-icons` and `@fluentui/react-brand-icons` in your third-party dependencies. Files that don't reference a supported module are skipped via a fast pre-check, so there is no meaningful overhead.
 
-The loader also works unchanged with [rspack](https://rspack.rs) (`>=2.1.0`) — the same rule shape applies, and every fixture in this package's test suite is verified against both bundlers. `webpack` and `@rspack/core` are declared as **optional** peer dependencies, so you only need to install the one you use.
+The loader also works unchanged with [rspack](https://rspack.rs) (`>=2.0.0`) — the same rule shape applies, and every fixture in this package's test suite is verified against both bundlers. `webpack` and `@rspack/core` are declared as **optional** peer dependencies, so you only need to install the one you use.
 
 ```js
 // webpack.config.js

--- a/packages/react-icons-atomic-webpack-loader/package.json
+++ b/packages/react-icons-atomic-webpack-loader/package.json
@@ -31,7 +31,7 @@
     "@fluentui/react-icons": "*"
   },
   "peerDependencies": {
-    "@rspack/core": ">=2.1.0",
+    "@rspack/core": ">=2.0.0",
     "webpack": ">=5.0.0"
   },
   "peerDependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3904,7 +3904,7 @@ __metadata:
     magic-string: "npm:^0.30.0"
     oxc-parser: "npm:^0.125.0"
   peerDependencies:
-    "@rspack/core": ">=2.1.0"
+    "@rspack/core": ">=2.0.0"
     webpack: ">=5.0.0"
   peerDependenciesMeta:
     "@rspack/core":


### PR DESCRIPTION
## Summary

Aligns `@fluentui/react-icons-atomic-webpack-loader`'s rspack peer range with [#1230](https://github.com/microsoft/fluentui-system-icons/pull/1230), which lowers the font subsetting plugin to `>=2.0.0`. Having the two packages disagree would force anyone on rspack 2.0.x into a peer warning for the loader alone, even though it runs fine there.

`>=2.1.0` → `>=2.0.0`.

## Why this is safe

The 2.1 floor was inherited from the plugin, not derived from this package's own needs. The loader's entire bundler-facing surface is the four members declared in `AtomicLoaderContext`:

- `resourcePath`
- `getOptions()`
- `callback()`
- `emitWarning()`

All are loader-context members that long predate rspack 2.0. Grepping `src/` for `moduleGraph`, `compilation`, `compiler.`, `getUsedExports` and `getProvidedExports` returns nothing — the loader never touches the compilation object, which is where every version-sensitive API in the plugin lived.

So unlike #1230, there is no capability to feature-detect and no guard to add here; the declared range was simply narrower than the code requires.

## Validation

- loader fixtures 17/17 webpack, 17/17 rspack
- type conformance, lint, `yarn deps:check`, `yarn install --immutable` all pass

## Caveat

CI still installs rspack 2.1.10, so `>=2.0.0` is a claim about the API surface rather than something exercised by a real 2.0.x build — the same caveat noted on #1230. The risk is materially lower here though, since there is no version-gated API involved at all.
