### PR TITLE
fix(react-icons-font-subsetting-webpack-plugin): detect duplicate installed instances

### DIFF
--- a/eslint.config.base.mjs
+++ b/eslint.config.base.mjs
@@ -82,4 +82,31 @@ export const reactHooks = {
   },
 };
 
+/**
+ * Requires private class members to carry a `__` prefix, so a member's visibility is legible at the
+ * usage site and not only at its declaration.
+ *
+ * @param {string[]} [files]
+ * @returns {import('typescript-eslint').ConfigWithExtends}
+ */
+export function privateMemberNaming(files = ['**/*.{ts,tsx}']) {
+  return {
+    files,
+    plugins: { '@typescript-eslint': tseslint.plugin },
+    languageOptions: { parser: tseslint.parser },
+    rules: {
+      '@typescript-eslint/naming-convention': [
+        'error',
+        {
+          selector: 'memberLike',
+          modifiers: ['private'],
+          format: ['camelCase'],
+          // `require` would accept a single underscore; the convention here is two.
+          leadingUnderscore: 'requireDouble',
+        },
+      ],
+    },
+  };
+}
+
 export { tseslint };

--- a/packages/react-icons-font-subsetting-webpack-plugin/README.md
+++ b/packages/react-icons-font-subsetting-webpack-plugin/README.md
@@ -133,3 +133,28 @@ identified, _every_ font in the affected package is left un-subset — not just 
 own module — since subsetting from the package's remaining imports would drop glyphs the namespace
 import actually uses. A build warning names the package when this happens. Named imports — the
 common case — are unaffected and subset fully. Upgrade to rspack `>=2.1.0` for complete coverage.
+
+## Options
+
+### `onDuplicateInstances`
+
+`'warn' | 'error'`, default `'warn'`.
+
+When several copies of `@fluentui/react-icons` are installed — peer-dependency variants in a virtual
+store will do it, without any version conflict — their font files are byte-identical, so they hash to
+a single emitted asset. That asset can name only one copy as its source, and nothing in the module
+graph says which copy a given icon came from. Subsetting it for the copy that happens to own it
+deletes every glyph the other copies contribute.
+
+The plugin detects this and leaves the affected fonts un-subset, so all glyphs still render, and
+warns with the paths of the copies involved. Set `'error'` to fail the build instead:
+
+```js
+new FluentUIReactIconsFontSubsettingPlugin({ onDuplicateInstances: 'error' });
+```
+
+To get subsetting back, collapse the copies onto one instance with bundler `resolve.alias` entries.
+Note that this also binds every copy to a single React and Griffel instance.
+
+Copies of genuinely _different_ versions ship different fonts, emit separate assets, and continue to
+be subset independently — they do not trigger this.

--- a/packages/react-icons-font-subsetting-webpack-plugin/README.md
+++ b/packages/react-icons-font-subsetting-webpack-plugin/README.md
@@ -140,9 +140,9 @@ common case — are unaffected and subset fully. Upgrade to rspack `>=2.1.0` for
 
 `'warn' | 'error'`, default `'warn'`.
 
-The plugin subsets against one resolved `@fluentui/react-icons` package instance. When more than one
-installed copy contributes icons — peer-dependency variants in a virtual store will do this without
-any version conflict — emitted font assets cannot be attributed safely to one coherent source.
+The plugin subsets against one resolved `@fluentui/react-icons` package instance. When font modules
+resolve from more than one installed copy — peer-dependency variants in a virtual store will do this
+without any version conflict — emitted font assets cannot be attributed safely to one coherent source.
 
 The plugin detects multiple participating copies before inspecting font-asset ownership, leaves all
 fonts un-subset so every glyph still renders, and warns with the paths involved. Set `'error'` to fail
@@ -154,3 +154,6 @@ new FluentUIReactIconsFontSubsettingPlugin({ onDuplicateInstances: 'error' });
 
 To get subsetting back, collapse the copies onto one instance with bundler `resolve.alias` entries.
 Note that this also binds every copy to a single React and Griffel instance.
+
+Using ESM `import` and CommonJS `require()` from the same installation does not count as two copies.
+Their used exports are combined, and each emitted font asset is subset once.

--- a/packages/react-icons-font-subsetting-webpack-plugin/README.md
+++ b/packages/react-icons-font-subsetting-webpack-plugin/README.md
@@ -140,14 +140,13 @@ common case — are unaffected and subset fully. Upgrade to rspack `>=2.1.0` for
 
 `'warn' | 'error'`, default `'warn'`.
 
-When several copies of `@fluentui/react-icons` are installed — peer-dependency variants in a virtual
-store will do it, without any version conflict — their font files are byte-identical, so they hash to
-a single emitted asset. That asset can name only one copy as its source, and nothing in the module
-graph says which copy a given icon came from. Subsetting it for the copy that happens to own it
-deletes every glyph the other copies contribute.
+The plugin subsets against one resolved `@fluentui/react-icons` package instance. When more than one
+installed copy contributes icons — peer-dependency variants in a virtual store will do this without
+any version conflict — emitted font assets cannot be attributed safely to one coherent source.
 
-The plugin detects this and leaves the affected fonts un-subset, so all glyphs still render, and
-warns with the paths of the copies involved. Set `'error'` to fail the build instead:
+The plugin detects multiple participating copies before inspecting font-asset ownership, leaves all
+fonts un-subset so every glyph still renders, and warns with the paths involved. Set `'error'` to fail
+the build instead:
 
 ```js
 new FluentUIReactIconsFontSubsettingPlugin({ onDuplicateInstances: 'error' });
@@ -155,6 +154,3 @@ new FluentUIReactIconsFontSubsettingPlugin({ onDuplicateInstances: 'error' });
 
 To get subsetting back, collapse the copies onto one instance with bundler `resolve.alias` entries.
 Note that this also binds every copy to a single React and Griffel instance.
-
-Copies of genuinely _different_ versions ship different fonts, emit separate assets, and continue to
-be subset independently — they do not trigger this.

--- a/packages/react-icons-font-subsetting-webpack-plugin/eslint.config.mjs
+++ b/packages/react-icons-font-subsetting-webpack-plugin/eslint.config.mjs
@@ -1,6 +1,6 @@
 // @ts-check
-import { dependencyChecks } from '../../eslint.config.base.mjs';
+import { dependencyChecks, privateMemberNaming } from '../../eslint.config.base.mjs';
 
 // Both bundlers are optional peers reached at runtime via `compiler.webpack`; neither is imported,
 // not even for types, so the public `.d.ts` stays usable with only one of them installed.
-export default [dependencyChecks({ ignoredDependencies: ['@rspack/core', 'webpack'] })];
+export default [privateMemberNaming(), dependencyChecks({ ignoredDependencies: ['@rspack/core', 'webpack'] })];

--- a/packages/react-icons-font-subsetting-webpack-plugin/package.json
+++ b/packages/react-icons-font-subsetting-webpack-plugin/package.json
@@ -10,7 +10,7 @@
     "test:rspack": "node test/run.js --bundler rspack",
     "dev": "yarn run -T webpack serve -c test/webpack.config.js --open",
     "build": "yarn run -T tsc -p .",
-    "lint": "yarn run -T eslint package.json"
+    "lint": "yarn run -T eslint src package.json"
   },
   "engines": {
     "node": ">=14.5.0"

--- a/packages/react-icons-font-subsetting-webpack-plugin/src/bundler-api.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/src/bundler-api.ts
@@ -57,6 +57,7 @@ export interface BundlerCompilation {
   moduleGraph: BundlerModuleGraph;
   entrypoints: ReadonlyMap<string, unknown>;
   warnings: Error[];
+  errors: Error[];
   getAsset(name: string): BundlerAsset | undefined | void;
   getAssets(): readonly BundlerAsset[];
   /**

--- a/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
@@ -51,10 +51,10 @@ export interface FluentUIReactIconsFontSubsettingPluginOptions {
 }
 
 export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPlugin {
-  private readonly onDuplicateInstances: 'warn' | 'error';
+  private readonly __onDuplicateInstances: 'warn' | 'error';
 
   constructor(options: FluentUIReactIconsFontSubsettingPluginOptions = {}) {
-    this.onDuplicateInstances = options.onDuplicateInstances ?? 'warn';
+    this.__onDuplicateInstances = options.onDuplicateInstances ?? 'warn';
   }
 
   /**
@@ -151,7 +151,7 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
                 `and Griffel instance.`,
             );
 
-            if (this.onDuplicateInstances === 'error') {
+            if (this.__onDuplicateInstances === 'error') {
               compilation.errors.push(message);
             } else {
               compilation.warnings.push(message);

--- a/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
@@ -39,7 +39,24 @@ const UNRESOLVABLE_NAMESPACE_IMPORT = Symbol('unresolvable-namespace-import');
 const REACT_ICONS_FONT_MODULE_IMPORT_PATTERN =
   /react-icons[\/\\]lib(-cjs)?[\/\\](fonts[\/\\](sizedIcons|icons)[\/\\]chunk-\d+|atoms[\/\\](headless-)?fonts[\/\\][\w-]+)\.c?js$/;
 
+export interface FluentUIReactIconsFontSubsettingPluginOptions {
+  /**
+   * What to do when several installed copies of `@fluentui/react-icons` share one emitted font
+   * asset, which makes it impossible to tell which icons belong to it.
+   *
+   * `'warn'` (default) leaves the affected fonts un-subset, so every glyph still renders.
+   * `'error'` fails the build instead.
+   */
+  onDuplicateInstances?: 'warn' | 'error';
+}
+
 export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPlugin {
+  private readonly onDuplicateInstances: 'warn' | 'error';
+
+  constructor(options: FluentUIReactIconsFontSubsettingPluginOptions = {}) {
+    this.onDuplicateInstances = options.onDuplicateInstances ?? 'warn';
+  }
+
   /**
    * Entry point for the bundler plugin that registers hooks to perform font subsetting for `@fluentui/react-icons`.
    *
@@ -91,6 +108,10 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
             }
           }
           const optimizationPromises: Promise<void>[] = [];
+          const packageToFontAssets = new Map<
+            string,
+            { usedExports: Set<string>; fontAssets: { assetName: string; codepoints: Record<string, number> }[] }
+          >();
 
           for (const pkgLibPath of unresolvableNamespacePackages) {
             // Sibling modules would otherwise subset this package's shared fonts down to *their*
@@ -110,19 +131,49 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
 
           for (const [pkgLibPath, usedExports] of packageToUsedFontExports) {
             const fontAssets = await getFontAssetsAndCodepoints(pkgLibPath, compilation, compiler.context);
+            packageToFontAssets.set(pkgLibPath, { usedExports, fontAssets });
+          }
 
-            if (fontAssets.length === 0) {
-              // Loud failure: silently shipping an un-subset font is worse than a broken build.
-              compilation.warnings.push(
-                new Error(
-                  `${PLUGIN_NAME}: found used icon fonts in "${pkgLibPath}" but could not map any font module ` +
-                    `to an emitted asset. Fonts will NOT be subset. Ensure a \`type: 'asset'\` (or 'asset/resource') ` +
-                    `module rule matches /\\.(ttf|woff2?)$/.`,
-                ),
-              );
-              continue;
+          const owningPackages = [...packageToFontAssets].filter(([, { fontAssets }]) => fontAssets.length > 0);
+          const orphanedPackages = [...packageToFontAssets].filter(([, { fontAssets }]) => fontAssets.length === 0);
+
+          if (owningPackages.length > 0 && orphanedPackages.length > 0) {
+            // Identical fonts across copies hash to one asset, which can name only one copy as its
+            // source. Subsetting it for that copy would delete every glyph the others contribute,
+            // and nothing in the module graph says which copy an icon really came from.
+            const message = new Error(
+              `${PLUGIN_NAME}: "@fluentui/react-icons" is installed more than once and the copies share ` +
+                `emitted font assets, so icons cannot be attributed to a font. Fonts were left un-subset ` +
+                `to avoid dropping glyphs. Copies owning an emitted font: ` +
+                `${owningPackages.map(([p]) => `"${p}"`).join(', ')}. Copies sharing them: ` +
+                `${orphanedPackages.map(([p]) => `"${p}"`).join(', ')}. Collapse them onto one instance with ` +
+                `bundler \`resolve.alias\` entries — note that this also binds every copy to a single React ` +
+                `and Griffel instance.`,
+            );
+
+            if (this.onDuplicateInstances === 'error') {
+              compilation.errors.push(message);
+            } else {
+              compilation.warnings.push(message);
             }
 
+            return;
+          }
+
+          if (owningPackages.length === 0 && packageToFontAssets.size > 0) {
+            // Loud failure: silently shipping an un-subset font is worse than a broken build.
+            compilation.warnings.push(
+              new Error(
+                `${PLUGIN_NAME}: found used icon fonts in ` +
+                  `${[...packageToFontAssets.keys()].map((p) => `"${p}"`).join(', ')} but could not map any font ` +
+                  `module to an emitted asset. Fonts will NOT be subset. Ensure a \`type: 'asset'\` ` +
+                  `(or 'asset/resource') module rule matches /\\.(ttf|woff2?)$/.`,
+              ),
+            );
+            return;
+          }
+
+          for (const [, { usedExports, fontAssets }] of owningPackages) {
             for (const { assetName, codepoints: codepointMap } of fontAssets) {
               optimizationPromises.push(
                 optimizeFontAsset(codepointMap, usedExports, compilation, assetName, sources.RawSource),

--- a/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
@@ -47,10 +47,9 @@ const REACT_ICONS_FONT_MODULE_IMPORT_PATTERN =
 
 export interface FluentUIReactIconsFontSubsettingPluginOptions {
   /**
-   * What to do when several installed copies of `@fluentui/react-icons` share one emitted font
-   * asset, which makes it impossible to tell which icons belong to it.
+   * What to do when more than one installed copy of `@fluentui/react-icons` contributes icons.
    *
-   * `'warn'` (default) leaves the affected fonts un-subset, so every glyph still renders.
+   * `'warn'` (default) leaves all fonts un-subset, so every glyph still renders.
    * `'error'` fails the build instead.
    */
   onDuplicateInstances?: 'warn' | 'error';
@@ -114,7 +113,6 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
             }
           }
           const optimizationPromises: Promise<void>[] = [];
-          const packageToFontAssets = new Map<string, FontAssetCodepoints[]>();
 
           for (const pkgLibPath of unresolvableNamespacePackages) {
             // Sibling modules would otherwise subset this package's shared fonts down to *their*
@@ -136,26 +134,12 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
           // map — but their fonts still have to survive, which makes them part of this analysis.
           const participants = new Set([...packageToUsedFontExports.keys(), ...unresolvableNamespacePackages]);
 
-          for (const pkgLibPath of participants) {
-            packageToFontAssets.set(
-              pkgLibPath,
-              await getFontAssetsAndCodepoints(pkgLibPath, compilation, compiler.context),
-            );
-          }
-
-          const owningPackages = [...packageToFontAssets].filter(([, fontAssets]) => fontAssets.length > 0);
-          const orphanedPackages = [...packageToFontAssets].filter(([, fontAssets]) => fontAssets.length === 0);
-
-          if (owningPackages.length > 0 && orphanedPackages.length > 0) {
-            // Identical fonts across copies hash to one asset, which can name only one copy as its
-            // source. Subsetting it for that copy would delete every glyph the others contribute,
-            // and nothing in the module graph says which copy an icon really came from.
+          if (participants.size > 1) {
             const message = new Error(
-              `${PLUGIN_NAME}: "@fluentui/react-icons" is installed more than once and the copies share ` +
-                `emitted font assets, so icons cannot be attributed to a font. Fonts were left un-subset ` +
-                `to avoid dropping glyphs. Copies owning an emitted font: ` +
-                `${owningPackages.map(([p]) => `"${p}"`).join(', ')}. Copies sharing them: ` +
-                `${orphanedPackages.map(([p]) => `"${p}"`).join(', ')}. Collapse them onto one instance with ` +
+              `${PLUGIN_NAME}: more than one installed copy of "@fluentui/react-icons" contributes icons, ` +
+                `so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping ` +
+                `glyphs. Participating copies: ${[...participants].map((p) => `"${p}"`).join(', ')}. ` +
+                `Collapse them onto one instance with ` +
                 `bundler \`resolve.alias\` entries — note that this also binds every copy to a single React ` +
                 `and Griffel instance.`,
             );
@@ -169,28 +153,21 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
             return;
           }
 
-          const subsettablePackages: { usedExports: Set<string>; fontAssets: FontAssetCodepoints[] }[] = [];
-          for (const [pkgLibPath, fontAssets] of owningPackages) {
-            const usedExports = packageToUsedFontExports.get(pkgLibPath);
-            if (usedExports) {
-              subsettablePackages.push({ usedExports, fontAssets });
+          for (const [pkgLibPath, usedExports] of packageToUsedFontExports) {
+            const fontAssets = await getFontAssetsAndCodepoints(pkgLibPath, compilation, compiler.context);
+
+            if (fontAssets.length === 0) {
+              // Loud failure: silently shipping an un-subset font is worse than a broken build.
+              compilation.warnings.push(
+                new Error(
+                  `${PLUGIN_NAME}: found used icon fonts in "${pkgLibPath}" but could not map any font module ` +
+                    `to an emitted asset. Fonts will NOT be subset. Ensure a \`type: 'asset'\` ` +
+                    `(or 'asset/resource') module rule matches /\\.(ttf|woff2?)$/.`,
+                ),
+              );
+              continue;
             }
-          }
 
-          if (subsettablePackages.length === 0 && packageToUsedFontExports.size > 0) {
-            // Loud failure: silently shipping an un-subset font is worse than a broken build.
-            compilation.warnings.push(
-              new Error(
-                `${PLUGIN_NAME}: found used icon fonts in ` +
-                  `${[...packageToUsedFontExports.keys()].map((p) => `"${p}"`).join(', ')} but could not map any ` +
-                  `font module to an emitted asset. Fonts will NOT be subset. Ensure a \`type: 'asset'\` ` +
-                  `(or 'asset/resource') module rule matches /\\.(ttf|woff2?)$/.`,
-              ),
-            );
-            return;
-          }
-
-          for (const { usedExports, fontAssets } of subsettablePackages) {
             for (const { assetName, codepoints: codepointMap } of fontAssets) {
               optimizationPromises.push(
                 optimizeFontAsset(codepointMap, usedExports, compilation, assetName, sources.RawSource),

--- a/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
@@ -34,6 +34,12 @@ interface FontAssetCodepoints {
   codepoints: Record<string, number>;
 }
 
+interface FontPackageUsage {
+  outputRoots: Set<string>;
+  usedExports: Set<string>;
+  hasUnresolvableNamespace: boolean;
+}
+
 /**
  *  Match both chunk files and atomic font imports, for the standard (Griffel)
  *  and headless APIs:
@@ -47,7 +53,7 @@ const REACT_ICONS_FONT_MODULE_IMPORT_PATTERN =
 
 export interface FluentUIReactIconsFontSubsettingPluginOptions {
   /**
-   * What to do when more than one installed copy of `@fluentui/react-icons` contributes icons.
+   * What to do when font modules resolve from more than one installed copy of `@fluentui/react-icons`.
    *
    * `'warn'` (default) leaves all fonts un-subset, so every glyph still renders.
    * `'error'` fails the build instead.
@@ -86,41 +92,45 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
         { name: PLUGIN_NAME, stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE },
         async () => {
           const runtime = getRuntimeSpec(compiler, compilation);
-          // Packages holding a namespace import this bundler cannot resolve; their fonts must be left whole.
-          const unresolvableNamespacePackages = new Set<string>();
+          const packageUsages = new Map<string, FontPackageUsage>();
 
-          // There could be multiple instances of `@fluentui/react-icons`, and they need to be subset separately
-          const packageToUsedFontExports: Map<string, Set<string>> = new Map<string, Set<string>>();
           for (const m of compilation.modules) {
             if (isFluentUIReactFontChunk(m)) {
-              const pkgLibPath = resolve(dirname(m.resource), '../..');
               const icons = resolveUsedIconExports(m, compilation.moduleGraph, runtime);
-
-              if (icons === UNRESOLVABLE_NAMESPACE_IMPORT) {
-                unresolvableNamespacePackages.add(pkgLibPath);
-                continue;
-              }
-
               if (icons === null) {
                 continue;
               }
 
-              const usedPkgExports = packageToUsedFontExports.get(pkgLibPath) ?? new Set<string>();
-              for (const icon of icons) {
-                usedPkgExports.add(icon);
+              const outputRoot = resolve(dirname(m.resource), '../..');
+              const packageRoot = dirname(outputRoot);
+              const usage = packageUsages.get(packageRoot) ?? {
+                outputRoots: new Set<string>(),
+                usedExports: new Set<string>(),
+                hasUnresolvableNamespace: false,
+              };
+              usage.outputRoots.add(outputRoot);
+
+              if (icons === UNRESOLVABLE_NAMESPACE_IMPORT) {
+                usage.hasUnresolvableNamespace = true;
+              } else {
+                for (const icon of icons) {
+                  usage.usedExports.add(icon);
+                }
               }
-              packageToUsedFontExports.set(pkgLibPath, usedPkgExports);
+
+              packageUsages.set(packageRoot, usage);
             }
           }
           const optimizationPromises: Promise<void>[] = [];
 
-          for (const pkgLibPath of unresolvableNamespacePackages) {
-            // Sibling modules would otherwise subset this package's shared fonts down to *their*
-            // glyphs alone, dropping the ones the namespace import needs.
-            packageToUsedFontExports.delete(pkgLibPath);
+          for (const [packageRoot, usage] of packageUsages) {
+            if (!usage.hasUnresolvableNamespace) {
+              continue;
+            }
+
             compilation.warnings.push(
               new Error(
-                `${PLUGIN_NAME}: "${pkgLibPath}" is reached through a namespace import (\`import * as ...\`) ` +
+                `${PLUGIN_NAME}: "${packageRoot}" is reached through a namespace import (\`import * as ...\`) ` +
                   `whose icons cannot be determined — either the bundler does not expose ` +
                   `\`moduleGraph.getProvidedExports()\` (rspack <2.1.0), or \`optimization.providedExports\` is ` +
                   `disabled. Every font in this package was left un-subset, because subsetting from the ` +
@@ -130,15 +140,11 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
             );
           }
 
-          // Namespace copies contribute no *known* glyphs, so they never reach the used-exports
-          // map — but their fonts still have to survive, which makes them part of this analysis.
-          const participants = new Set([...packageToUsedFontExports.keys(), ...unresolvableNamespacePackages]);
-
-          if (participants.size > 1) {
+          if (packageUsages.size > 1) {
             const message = new Error(
-              `${PLUGIN_NAME}: more than one installed copy of "@fluentui/react-icons" contributes icons, ` +
+              `${PLUGIN_NAME}: font modules from more than one installed copy of "@fluentui/react-icons" were resolved, ` +
                 `so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping ` +
-                `glyphs. Participating copies: ${[...participants].map((p) => `"${p}"`).join(', ')}. ` +
+                `glyphs. Participating copies: ${[...packageUsages.keys()].map((p) => `"${p}"`).join(', ')}. ` +
                 `Collapse them onto one instance with ` +
                 `bundler \`resolve.alias\` entries — note that this also binds every copy to a single React ` +
                 `and Griffel instance.`,
@@ -153,14 +159,24 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
             return;
           }
 
-          for (const [pkgLibPath, usedExports] of packageToUsedFontExports) {
-            const fontAssets = await getFontAssetsAndCodepoints(pkgLibPath, compilation, compiler.context);
+          for (const [packageRoot, usage] of packageUsages) {
+            if (usage.hasUnresolvableNamespace) {
+              continue;
+            }
 
-            if (fontAssets.length === 0) {
+            const fontAssetsByName = new Map<string, FontAssetCodepoints>();
+            for (const outputRoot of usage.outputRoots) {
+              const fontAssets = await getFontAssetsAndCodepoints(outputRoot, compilation, compiler.context);
+              for (const fontAsset of fontAssets) {
+                fontAssetsByName.set(fontAsset.assetName, fontAsset);
+              }
+            }
+
+            if (fontAssetsByName.size === 0) {
               // Loud failure: silently shipping an un-subset font is worse than a broken build.
               compilation.warnings.push(
                 new Error(
-                  `${PLUGIN_NAME}: found used icon fonts in "${pkgLibPath}" but could not map any font module ` +
+                  `${PLUGIN_NAME}: found used icon fonts in "${packageRoot}" but could not map any font module ` +
                     `to an emitted asset. Fonts will NOT be subset. Ensure a \`type: 'asset'\` ` +
                     `(or 'asset/resource') module rule matches /\\.(ttf|woff2?)$/.`,
                 ),
@@ -168,9 +184,9 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
               continue;
             }
 
-            for (const { assetName, codepoints: codepointMap } of fontAssets) {
+            for (const { assetName, codepoints: codepointMap } of fontAssetsByName.values()) {
               optimizationPromises.push(
-                optimizeFontAsset(codepointMap, usedExports, compilation, assetName, sources.RawSource),
+                optimizeFontAsset(codepointMap, usage.usedExports, compilation, assetName, sources.RawSource),
               );
             }
           }

--- a/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/src/index.ts
@@ -28,6 +28,12 @@ const FONT_EXTENSIONS = ['.ttf', '.woff', '.woff2'];
 /** Separates "this module's icons are unknowable" from the benign "this module contributes nothing". */
 const UNRESOLVABLE_NAMESPACE_IMPORT = Symbol('unresolvable-namespace-import');
 
+/** An emitted font asset paired with the codepoint table of the package it came from. */
+interface FontAssetCodepoints {
+  assetName: string;
+  codepoints: Record<string, number>;
+}
+
 /**
  *  Match both chunk files and atomic font imports, for the standard (Griffel)
  *  and headless APIs:
@@ -108,10 +114,7 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
             }
           }
           const optimizationPromises: Promise<void>[] = [];
-          const packageToFontAssets = new Map<
-            string,
-            { usedExports: Set<string>; fontAssets: { assetName: string; codepoints: Record<string, number> }[] }
-          >();
+          const packageToFontAssets = new Map<string, FontAssetCodepoints[]>();
 
           for (const pkgLibPath of unresolvableNamespacePackages) {
             // Sibling modules would otherwise subset this package's shared fonts down to *their*
@@ -129,13 +132,19 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
             );
           }
 
-          for (const [pkgLibPath, usedExports] of packageToUsedFontExports) {
-            const fontAssets = await getFontAssetsAndCodepoints(pkgLibPath, compilation, compiler.context);
-            packageToFontAssets.set(pkgLibPath, { usedExports, fontAssets });
+          // Namespace copies contribute no *known* glyphs, so they never reach the used-exports
+          // map — but their fonts still have to survive, which makes them part of this analysis.
+          const participants = new Set([...packageToUsedFontExports.keys(), ...unresolvableNamespacePackages]);
+
+          for (const pkgLibPath of participants) {
+            packageToFontAssets.set(
+              pkgLibPath,
+              await getFontAssetsAndCodepoints(pkgLibPath, compilation, compiler.context),
+            );
           }
 
-          const owningPackages = [...packageToFontAssets].filter(([, { fontAssets }]) => fontAssets.length > 0);
-          const orphanedPackages = [...packageToFontAssets].filter(([, { fontAssets }]) => fontAssets.length === 0);
+          const owningPackages = [...packageToFontAssets].filter(([, fontAssets]) => fontAssets.length > 0);
+          const orphanedPackages = [...packageToFontAssets].filter(([, fontAssets]) => fontAssets.length === 0);
 
           if (owningPackages.length > 0 && orphanedPackages.length > 0) {
             // Identical fonts across copies hash to one asset, which can name only one copy as its
@@ -160,20 +169,28 @@ export default class FluentUIReactIconsFontSubsettingPlugin implements BundlerPl
             return;
           }
 
-          if (owningPackages.length === 0 && packageToFontAssets.size > 0) {
+          const subsettablePackages: { usedExports: Set<string>; fontAssets: FontAssetCodepoints[] }[] = [];
+          for (const [pkgLibPath, fontAssets] of owningPackages) {
+            const usedExports = packageToUsedFontExports.get(pkgLibPath);
+            if (usedExports) {
+              subsettablePackages.push({ usedExports, fontAssets });
+            }
+          }
+
+          if (subsettablePackages.length === 0 && packageToUsedFontExports.size > 0) {
             // Loud failure: silently shipping an un-subset font is worse than a broken build.
             compilation.warnings.push(
               new Error(
                 `${PLUGIN_NAME}: found used icon fonts in ` +
-                  `${[...packageToFontAssets.keys()].map((p) => `"${p}"`).join(', ')} but could not map any font ` +
-                  `module to an emitted asset. Fonts will NOT be subset. Ensure a \`type: 'asset'\` ` +
+                  `${[...packageToUsedFontExports.keys()].map((p) => `"${p}"`).join(', ')} but could not map any ` +
+                  `font module to an emitted asset. Fonts will NOT be subset. Ensure a \`type: 'asset'\` ` +
                   `(or 'asset/resource') module rule matches /\\.(ttf|woff2?)$/.`,
               ),
             );
             return;
           }
 
-          for (const [, { usedExports, fontAssets }] of owningPackages) {
+          for (const { usedExports, fontAssets } of subsettablePackages) {
             for (const { assetName, codepoints: codepointMap } of fontAssets) {
               optimizationPromises.push(
                 optimizeFontAsset(codepointMap, usedExports, compilation, assetName, sources.RawSource),
@@ -372,7 +389,7 @@ async function getFontAssetsAndCodepoints(
   pkgLibPath: string,
   compilation: BundlerCompilation,
   context: string,
-): Promise<{ assetName: string; codepoints: Record<string, number> }[]> {
+): Promise<FontAssetCodepoints[]> {
   const utilsFontsFolder = resolve(pkgLibPath, 'utils/fonts');
   const codepoints: Record<string, Record<string, number>> = Object.fromEntries(
     await Promise.all(
@@ -388,7 +405,7 @@ async function getFontAssetsAndCodepoints(
     ),
   );
 
-  const result: { assetName: string; codepoints: Record<string, number> }[] = [];
+  const result: FontAssetCodepoints[] = [];
 
   for (const { name: assetName, info } of compilation.getAssets()) {
     const sourceFilename = info?.sourceFilename;

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/make-configs.js
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/make-configs.js
@@ -21,6 +21,12 @@ const entries = {
   // Headless font atoms — fonts arrive via the headless `styles.css` import (css-loader) rather than Griffel.
   // No Griffel runtime is involved, so a tighter threshold is used to validate subsetting.
   headlessAtoms: { src: './src/headless-atoms.js', threshold: 1.5 * 1_024, assertNoGriffel: true }, // 1.5 KB
+  mixedModuleFormats: {
+    src: './src/mixed-module-formats.js',
+    threshold: 1.5 * 1_024,
+    assertNoGriffel: true,
+    assertModuleFormats: true,
+  },
   // End-to-end: a *barrel* import is rewritten by the atomic loader (headless + fonts) into
   // headless font atoms, then subset here. Also asserts the graph stays Griffel-free.
   e2eBarrelHeadlessFonts: {
@@ -46,6 +52,7 @@ const entries = {
  * @property {number} threshold
  * @property {boolean} [useAtomicLoader]
  * @property {boolean} [assertNoGriffel]
+ * @property {boolean} [assertModuleFormats]
  * @property {string} [runtimeChunkName] Name the runtime chunk, decoupling runtime name from entry name.
  */
 
@@ -135,7 +142,7 @@ function createConfig(name, entry, adapter, isDevServer) {
       filename: '[name].js',
     },
     resolve: {
-      conditionNames: ['fluentIconFont', 'import'],
+      conditionNames: entry.assertModuleFormats ? ['fluentIconFont', '...'] : ['fluentIconFont', 'import'],
     },
     plugins: [
       ...(isDevServer && HtmlPlugin
@@ -156,7 +163,7 @@ function createConfig(name, entry, adapter, isDevServer) {
  * Fails the build when a font asset was not subset, or when a headless entry leaked Griffel.
  *
  * @param {string} name
- * @param {{ threshold: number, assertNoGriffel?: boolean }} entry
+ * @param {{ threshold: number, assertNoGriffel?: boolean, assertModuleFormats?: boolean }} entry
  * @param {BundlerAdapter} adapter
  */
 function createAssertionPlugin(name, entry, adapter) {
@@ -187,6 +194,18 @@ function createAssertionPlugin(name, entry, adapter) {
                 `[${adapter.name}/${name}] Module graph includes a @griffel module (${resource}) — ` +
                   `headless build expected to be Griffel-free.`,
               );
+            }
+          }
+        }
+
+        if (entry.assertModuleFormats) {
+          const resources = Array.from(compilation.modules, (m) => /** @type {{ resource?: string }} */ (m).resource);
+          for (const outputRoot of ['lib', 'lib-cjs']) {
+            const atomPath = new RegExp(
+              `[\\\\/]react-icons[\\\\/]${outputRoot}[\\\\/]atoms[\\\\/]headless-fonts[\\\\/]`,
+            );
+            if (!resources.some((resource) => typeof resource === 'string' && atomPath.test(resource))) {
+              throw new Error(`[${adapter.name}/${name}] No ${outputRoot} font atom found in the module graph.`);
             }
           }
         }

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/plugin.test.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/plugin.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -12,6 +13,32 @@ const FONT_FILE = resolve(REACT_ICONS_LIB, 'utils/fonts/FluentSystemIcons-Regula
 const FONT_MODULE = resolve(REACT_ICONS_LIB, 'atoms/fonts/games.js');
 /** A second module in the *same* package, so both share one set of font assets. */
 const SIBLING_FONT_MODULE = resolve(REACT_ICONS_LIB, 'atoms/fonts/add.js');
+
+const FONT_BASE_NAMES = [
+  'FluentSystemIcons-Filled',
+  'FluentSystemIcons-Resizable',
+  'FluentSystemIcons-Regular',
+  'FluentSystemIcons-Light',
+];
+
+/**
+ * A second installed copy of the package, as produced by peer-dependency variants in a virtual
+ * store. Only the codepoint tables are materialised — the plugin reads those, and derives
+ * everything else from path arithmetic.
+ */
+function createDuplicateInstance() {
+  const lib = resolve(mkdtempSync(resolve(tmpdir(), 'react-icons-copy-')), 'react-icons/lib');
+  mkdirSync(resolve(lib, 'utils/fonts'), { recursive: true });
+
+  for (const baseName of FONT_BASE_NAMES) {
+    copyFileSync(
+      resolve(REACT_ICONS_LIB, `utils/fonts/${baseName}.json`),
+      resolve(lib, `utils/fonts/${baseName}.json`),
+    );
+  }
+
+  return { lib, fontModule: resolve(lib, 'atoms/fonts/games.js') };
+}
 
 /**
  * webpack's `RuntimeSpec` value meaning "do not scope this query — merge across every runtime".
@@ -30,6 +57,9 @@ interface HarnessOptions {
   hasProvidedExports?: boolean;
   /** Font module resources to place in the graph. */
   moduleResources?: string[];
+  /** Emitted font assets, as `sourceFilename` values. Defaults to the one real font file. */
+  assetSources?: string[];
+  pluginOptions?: ConstructorParameters<typeof FluentUIReactIconsFontSubsettingPlugin>[0];
   usedExports: (resource: string) => ReadonlySet<string> | readonly string[] | boolean | null;
 }
 
@@ -45,6 +75,7 @@ async function harness(options: HarnessOptions) {
   const runtimesSeen: unknown[] = [];
   const updatedAssets: { name: string; size: number }[] = [];
   const warnings: Error[] = [];
+  const errors: Error[] = [];
 
   /** Captures the callback the plugin registers on `processAssets`, so the test can invoke it. */
   let processAssets: (() => Promise<void>) | undefined;
@@ -75,11 +106,15 @@ async function harness(options: HarnessOptions) {
     moduleGraph,
     entrypoints: new Map([[ENTRYPOINT_NAME, {}]]),
     warnings,
+    errors,
     getAsset: (name: string) => ({ name, source: { source: () => originalFont } }),
     // An absolute `sourceFilename` resolves independently of `context`.
-    getAssets: () => [
-      { name: 'Regular.ttf', source: { source: () => originalFont }, info: { sourceFilename: FONT_FILE } },
-    ],
+    getAssets: () =>
+      (options.assetSources ?? [FONT_FILE]).map((sourceFilename, i) => ({
+        name: `Regular-${i}.ttf`,
+        source: { source: () => originalFont },
+        info: { sourceFilename },
+      })),
     updateAsset: (name: string, source: { source(): string | Buffer }) => {
       updatedAssets.push({ name, size: Buffer.from(source.source()).length });
     },
@@ -103,10 +138,10 @@ async function harness(options: HarnessOptions) {
     hooks: { compilation: { tap: (_name: string, fn: (c: unknown) => void) => fn(compilation) } },
   };
 
-  new FluentUIReactIconsFontSubsettingPlugin().apply(compiler as unknown as BundlerCompiler);
+  new FluentUIReactIconsFontSubsettingPlugin(options.pluginOptions).apply(compiler as unknown as BundlerCompiler);
   await processAssets!();
 
-  return { runtimesSeen, updatedAssets, warnings, originalSize: originalFont.length };
+  return { runtimesSeen, updatedAssets, warnings, errors, originalSize: originalFont.length };
 }
 
 describe('runtime resolution', () => {
@@ -186,5 +221,53 @@ describe('getProvidedExports capability guard', () => {
     expect(updatedAssets).toEqual([]);
     expect(warnings).toHaveLength(1);
     expect(warnings[0].message).toContain(REACT_ICONS_LIB);
+  });
+});
+
+describe('duplicate installed instances', () => {
+  it('leaves fonts whole when a copy owns no emitted asset', async () => {
+    const duplicate = createDuplicateInstance();
+
+    const { updatedAssets, warnings } = await harness({
+      moduleResources: [FONT_MODULE, duplicate.fontModule],
+      // Identical fonts across copies collapse to one emitted asset, which can name only one copy.
+      assetSources: [FONT_FILE],
+      usedExports: (resource) => (resource === FONT_MODULE ? ['GamesFilled'] : ['AddFilled']),
+    });
+
+    // Subsetting the shared asset for the copy that happens to own it drops every glyph belonging
+    // to the copies that do not — silently, which is how this reached production.
+    expect(updatedAssets).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain(REACT_ICONS_LIB);
+    expect(warnings[0].message).toContain(duplicate.lib);
+  });
+
+  it('fails the build instead when asked to', async () => {
+    const duplicate = createDuplicateInstance();
+
+    const { updatedAssets, warnings, errors } = await harness({
+      moduleResources: [FONT_MODULE, duplicate.fontModule],
+      assetSources: [FONT_FILE],
+      pluginOptions: { onDuplicateInstances: 'error' },
+      usedExports: (resource) => (resource === FONT_MODULE ? ['GamesFilled'] : ['AddFilled']),
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain(duplicate.lib);
+    expect(warnings).toEqual([]);
+    expect(updatedAssets).toEqual([]);
+  });
+
+  it('still reports a missing asset rule when no copy owns an asset', async () => {
+    const { updatedAssets, warnings } = await harness({
+      // Nothing emitted at all is a bundler misconfiguration, not duplicate instances.
+      assetSources: [],
+      usedExports: () => ['GamesFilled'],
+    });
+
+    expect(updatedAssets).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain("type: 'asset'");
   });
 });

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/plugin.test.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/plugin.test.ts
@@ -37,7 +37,11 @@ function createDuplicateInstance() {
     );
   }
 
-  return { lib, fontModule: resolve(lib, 'atoms/fonts/games.js') };
+  return {
+    lib,
+    fontModule: resolve(lib, 'atoms/fonts/games.js'),
+    fontFile: resolve(lib, 'utils/fonts/FluentSystemIcons-Regular.ttf'),
+  };
 }
 
 /**
@@ -269,5 +273,41 @@ describe('duplicate installed instances', () => {
     expect(updatedAssets).toEqual([]);
     expect(warnings).toHaveLength(1);
     expect(warnings[0].message).toContain("type: 'asset'");
+  });
+
+  it('counts a copy reached only through an unresolvable namespace import', async () => {
+    const duplicate = createDuplicateInstance();
+
+    const { updatedAssets, warnings } = await harness({
+      isRspack: true,
+      hasProvidedExports: false,
+      moduleResources: [FONT_MODULE, duplicate.fontModule],
+      assetSources: [FONT_FILE],
+      usedExports: (resource) => (resource === FONT_MODULE ? ['GamesFilled'] : true),
+    });
+
+    // Such a copy has no *known* glyphs, so it never reaches the used-exports map — but its fonts
+    // are the same shared asset, and subsetting for the copy that owns it deletes the glyphs it
+    // needs. That is the case the namespace warning claims cannot happen.
+    expect(updatedAssets).toEqual([]);
+    expect(warnings.map(({ message }) => message).join('\n')).toContain('installed more than once');
+  });
+
+  it('reports a collision, not a missing asset rule, when the unresolvable copy owns the asset', async () => {
+    const duplicate = createDuplicateInstance();
+
+    const { updatedAssets, warnings } = await harness({
+      isRspack: true,
+      hasProvidedExports: false,
+      moduleResources: [FONT_MODULE, duplicate.fontModule],
+      // The emitted asset names the namespace copy, leaving the named-import copy orphaned.
+      assetSources: [duplicate.fontFile],
+      usedExports: (resource) => (resource === FONT_MODULE ? ['GamesFilled'] : true),
+    });
+
+    const messages = warnings.map(({ message }) => message).join('\n');
+    expect(updatedAssets).toEqual([]);
+    expect(messages).toContain('installed more than once');
+    expect(messages).not.toContain("type: 'asset'");
   });
 });

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/plugin.test.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/plugin.test.ts
@@ -44,6 +44,13 @@ function createDuplicateInstance() {
   };
 }
 
+function normalizeDiagnostics(diagnostics: Error[], duplicateLib?: string) {
+  return diagnostics.map(({ message }) => {
+    const normalized = message.replaceAll(REACT_ICONS_LIB, '<react-icons-lib>');
+    return duplicateLib ? normalized.replaceAll(duplicateLib, '<duplicate-react-icons-lib>') : normalized;
+  });
+}
+
 /**
  * webpack's `RuntimeSpec` value meaning "do not scope this query — merge across every runtime".
  * rspack has no equivalent and rejects it, which is why the two bundlers take different paths.
@@ -242,9 +249,11 @@ describe('duplicate installed instances', () => {
     // Subsetting the shared asset for the copy that happens to own it drops every glyph belonging
     // to the copies that do not — silently, which is how this reached production.
     expect(updatedAssets).toEqual([]);
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].message).toContain(REACT_ICONS_LIB);
-    expect(warnings[0].message).toContain(duplicate.lib);
+    expect(normalizeDiagnostics(warnings, duplicate.lib)).toMatchInlineSnapshot(`
+      [
+        "FluentUIReactIconsFontSubsettingPlugin: "@fluentui/react-icons" is installed more than once and the copies share emitted font assets, so icons cannot be attributed to a font. Fonts were left un-subset to avoid dropping glyphs. Copies owning an emitted font: "<react-icons-lib>". Copies sharing them: "<duplicate-react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
+      ]
+    `);
   });
 
   it('fails the build instead when asked to', async () => {
@@ -257,10 +266,13 @@ describe('duplicate installed instances', () => {
       usedExports: (resource) => (resource === FONT_MODULE ? ['GamesFilled'] : ['AddFilled']),
     });
 
-    expect(errors).toHaveLength(1);
-    expect(errors[0].message).toContain(duplicate.lib);
     expect(warnings).toEqual([]);
     expect(updatedAssets).toEqual([]);
+    expect(normalizeDiagnostics(errors, duplicate.lib)).toMatchInlineSnapshot(`
+      [
+        "FluentUIReactIconsFontSubsettingPlugin: "@fluentui/react-icons" is installed more than once and the copies share emitted font assets, so icons cannot be attributed to a font. Fonts were left un-subset to avoid dropping glyphs. Copies owning an emitted font: "<react-icons-lib>". Copies sharing them: "<duplicate-react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
+      ]
+    `);
   });
 
   it('still reports a missing asset rule when no copy owns an asset', async () => {
@@ -271,8 +283,11 @@ describe('duplicate installed instances', () => {
     });
 
     expect(updatedAssets).toEqual([]);
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].message).toContain("type: 'asset'");
+    expect(normalizeDiagnostics(warnings)).toMatchInlineSnapshot(`
+      [
+        "FluentUIReactIconsFontSubsettingPlugin: found used icon fonts in "<react-icons-lib>" but could not map any font module to an emitted asset. Fonts will NOT be subset. Ensure a \`type: 'asset'\` (or 'asset/resource') module rule matches /\\.(ttf|woff2?)$/.",
+      ]
+    `);
   });
 
   it('counts a copy reached only through an unresolvable namespace import', async () => {
@@ -290,7 +305,12 @@ describe('duplicate installed instances', () => {
     // are the same shared asset, and subsetting for the copy that owns it deletes the glyphs it
     // needs. That is the case the namespace warning claims cannot happen.
     expect(updatedAssets).toEqual([]);
-    expect(warnings.map(({ message }) => message).join('\n')).toContain('installed more than once');
+    expect(normalizeDiagnostics(warnings, duplicate.lib)).toMatchInlineSnapshot(`
+      [
+        "FluentUIReactIconsFontSubsettingPlugin: "<duplicate-react-icons-lib>" is reached through a namespace import (\`import * as ...\`) whose icons cannot be determined — either the bundler does not expose \`moduleGraph.getProvidedExports()\` (rspack <2.1.0), or \`optimization.providedExports\` is disabled. Every font in this package was left un-subset, because subsetting from the remaining imports alone would drop glyphs that are actually used. Named imports are unaffected. Upgrade to rspack >=2.1.0 for full coverage.",
+        "FluentUIReactIconsFontSubsettingPlugin: "@fluentui/react-icons" is installed more than once and the copies share emitted font assets, so icons cannot be attributed to a font. Fonts were left un-subset to avoid dropping glyphs. Copies owning an emitted font: "<react-icons-lib>". Copies sharing them: "<duplicate-react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
+      ]
+    `);
   });
 
   it('reports a collision, not a missing asset rule, when the unresolvable copy owns the asset', async () => {
@@ -305,9 +325,12 @@ describe('duplicate installed instances', () => {
       usedExports: (resource) => (resource === FONT_MODULE ? ['GamesFilled'] : true),
     });
 
-    const messages = warnings.map(({ message }) => message).join('\n');
     expect(updatedAssets).toEqual([]);
-    expect(messages).toContain('installed more than once');
-    expect(messages).not.toContain("type: 'asset'");
+    expect(normalizeDiagnostics(warnings, duplicate.lib)).toMatchInlineSnapshot(`
+      [
+        "FluentUIReactIconsFontSubsettingPlugin: "<duplicate-react-icons-lib>" is reached through a namespace import (\`import * as ...\`) whose icons cannot be determined — either the bundler does not expose \`moduleGraph.getProvidedExports()\` (rspack <2.1.0), or \`optimization.providedExports\` is disabled. Every font in this package was left un-subset, because subsetting from the remaining imports alone would drop glyphs that are actually used. Named imports are unaffected. Upgrade to rspack >=2.1.0 for full coverage.",
+        "FluentUIReactIconsFontSubsettingPlugin: "@fluentui/react-icons" is installed more than once and the copies share emitted font assets, so icons cannot be attributed to a font. Fonts were left un-subset to avoid dropping glyphs. Copies owning an emitted font: "<duplicate-react-icons-lib>". Copies sharing them: "<react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
+      ]
+    `);
   });
 });

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/plugin.test.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/plugin.test.ts
@@ -46,8 +46,8 @@ function createDuplicateInstance() {
 
 function normalizeDiagnostics(diagnostics: Error[], duplicateLib?: string) {
   return diagnostics.map(({ message }) => {
-    const normalized = message.replaceAll(REACT_ICONS_LIB, '<react-icons-lib>');
-    return duplicateLib ? normalized.replaceAll(duplicateLib, '<duplicate-react-icons-lib>') : normalized;
+    const normalized = message.split(REACT_ICONS_LIB).join('<react-icons-lib>');
+    return duplicateLib ? normalized.split(duplicateLib).join('<duplicate-react-icons-lib>') : normalized;
   });
 }
 
@@ -139,9 +139,9 @@ async function harness(options: HarnessOptions) {
       Compilation: { PROCESS_ASSETS_STAGE_OPTIMIZE: 0 },
       sources: {
         RawSource: class {
-          constructor(private readonly value: string | Buffer) {}
+          constructor(private readonly __value: string | Buffer) {}
           source() {
-            return this.value;
+            return this.__value;
           }
         },
       },
@@ -236,7 +236,25 @@ describe('getProvidedExports capability guard', () => {
 });
 
 describe('duplicate installed instances', () => {
-  it('leaves fonts whole when a copy owns no emitted asset', async () => {
+  it('leaves fonts whole when multiple copies each emit assets', async () => {
+    const duplicate = createDuplicateInstance();
+
+    const { updatedAssets, warnings } = await harness({
+      moduleResources: [FONT_MODULE, duplicate.fontModule],
+      assetSources: [FONT_FILE, duplicate.fontFile],
+      usedExports: (resource) => (resource === FONT_MODULE ? ['GamesFilled'] : ['AddFilled']),
+    });
+
+    // Even distinct assets do not establish one coherent font/codepoint source for the build.
+    expect(updatedAssets).toEqual([]);
+    expect(normalizeDiagnostics(warnings, duplicate.lib)).toMatchInlineSnapshot(`
+      [
+        "FluentUIReactIconsFontSubsettingPlugin: more than one installed copy of "@fluentui/react-icons" contributes icons, so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping glyphs. Participating copies: "<react-icons-lib>", "<duplicate-react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
+      ]
+    `);
+  });
+
+  it('leaves fonts whole when emitted assets are attributed to only one copy', async () => {
     const duplicate = createDuplicateInstance();
 
     const { updatedAssets, warnings } = await harness({
@@ -246,12 +264,11 @@ describe('duplicate installed instances', () => {
       usedExports: (resource) => (resource === FONT_MODULE ? ['GamesFilled'] : ['AddFilled']),
     });
 
-    // Subsetting the shared asset for the copy that happens to own it drops every glyph belonging
-    // to the copies that do not — silently, which is how this reached production.
+    // Content hashing can collapse identical inputs to one asset attributed to one copy.
     expect(updatedAssets).toEqual([]);
     expect(normalizeDiagnostics(warnings, duplicate.lib)).toMatchInlineSnapshot(`
       [
-        "FluentUIReactIconsFontSubsettingPlugin: "@fluentui/react-icons" is installed more than once and the copies share emitted font assets, so icons cannot be attributed to a font. Fonts were left un-subset to avoid dropping glyphs. Copies owning an emitted font: "<react-icons-lib>". Copies sharing them: "<duplicate-react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
+        "FluentUIReactIconsFontSubsettingPlugin: more than one installed copy of "@fluentui/react-icons" contributes icons, so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping glyphs. Participating copies: "<react-icons-lib>", "<duplicate-react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
       ]
     `);
   });
@@ -270,7 +287,7 @@ describe('duplicate installed instances', () => {
     expect(updatedAssets).toEqual([]);
     expect(normalizeDiagnostics(errors, duplicate.lib)).toMatchInlineSnapshot(`
       [
-        "FluentUIReactIconsFontSubsettingPlugin: "@fluentui/react-icons" is installed more than once and the copies share emitted font assets, so icons cannot be attributed to a font. Fonts were left un-subset to avoid dropping glyphs. Copies owning an emitted font: "<react-icons-lib>". Copies sharing them: "<duplicate-react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
+        "FluentUIReactIconsFontSubsettingPlugin: more than one installed copy of "@fluentui/react-icons" contributes icons, so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping glyphs. Participating copies: "<react-icons-lib>", "<duplicate-react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
       ]
     `);
   });
@@ -308,19 +325,19 @@ describe('duplicate installed instances', () => {
     expect(normalizeDiagnostics(warnings, duplicate.lib)).toMatchInlineSnapshot(`
       [
         "FluentUIReactIconsFontSubsettingPlugin: "<duplicate-react-icons-lib>" is reached through a namespace import (\`import * as ...\`) whose icons cannot be determined — either the bundler does not expose \`moduleGraph.getProvidedExports()\` (rspack <2.1.0), or \`optimization.providedExports\` is disabled. Every font in this package was left un-subset, because subsetting from the remaining imports alone would drop glyphs that are actually used. Named imports are unaffected. Upgrade to rspack >=2.1.0 for full coverage.",
-        "FluentUIReactIconsFontSubsettingPlugin: "@fluentui/react-icons" is installed more than once and the copies share emitted font assets, so icons cannot be attributed to a font. Fonts were left un-subset to avoid dropping glyphs. Copies owning an emitted font: "<react-icons-lib>". Copies sharing them: "<duplicate-react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
+        "FluentUIReactIconsFontSubsettingPlugin: more than one installed copy of "@fluentui/react-icons" contributes icons, so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping glyphs. Participating copies: "<react-icons-lib>", "<duplicate-react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
       ]
     `);
   });
 
-  it('reports a collision, not a missing asset rule, when the unresolvable copy owns the asset', async () => {
+  it('detects an unresolvable namespace copy regardless of asset attribution', async () => {
     const duplicate = createDuplicateInstance();
 
     const { updatedAssets, warnings } = await harness({
       isRspack: true,
       hasProvidedExports: false,
       moduleResources: [FONT_MODULE, duplicate.fontModule],
-      // The emitted asset names the namespace copy, leaving the named-import copy orphaned.
+      // The emitted asset happens to name the namespace copy rather than the named-import copy.
       assetSources: [duplicate.fontFile],
       usedExports: (resource) => (resource === FONT_MODULE ? ['GamesFilled'] : true),
     });
@@ -329,7 +346,7 @@ describe('duplicate installed instances', () => {
     expect(normalizeDiagnostics(warnings, duplicate.lib)).toMatchInlineSnapshot(`
       [
         "FluentUIReactIconsFontSubsettingPlugin: "<duplicate-react-icons-lib>" is reached through a namespace import (\`import * as ...\`) whose icons cannot be determined — either the bundler does not expose \`moduleGraph.getProvidedExports()\` (rspack <2.1.0), or \`optimization.providedExports\` is disabled. Every font in this package was left un-subset, because subsetting from the remaining imports alone would drop glyphs that are actually used. Named imports are unaffected. Upgrade to rspack >=2.1.0 for full coverage.",
-        "FluentUIReactIconsFontSubsettingPlugin: "@fluentui/react-icons" is installed more than once and the copies share emitted font assets, so icons cannot be attributed to a font. Fonts were left un-subset to avoid dropping glyphs. Copies owning an emitted font: "<duplicate-react-icons-lib>". Copies sharing them: "<react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
+        "FluentUIReactIconsFontSubsettingPlugin: more than one installed copy of "@fluentui/react-icons" contributes icons, so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping glyphs. Participating copies: "<react-icons-lib>", "<duplicate-react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
       ]
     `);
   });

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/plugin.test.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/plugin.test.ts
@@ -9,8 +9,11 @@ import type { BundlerCompiler } from '../src/bundler-api';
 
 // The package's `exports` map hides package.json, so the sibling workspace path is used instead.
 const REACT_ICONS_LIB = resolve(dirname(fileURLToPath(import.meta.url)), '../../react-icons/lib');
+const REACT_ICONS_ROOT = dirname(REACT_ICONS_LIB);
+const REACT_ICONS_LIB_CJS = resolve(REACT_ICONS_LIB, '../lib-cjs');
 const FONT_FILE = resolve(REACT_ICONS_LIB, 'utils/fonts/FluentSystemIcons-Regular.ttf');
 const FONT_MODULE = resolve(REACT_ICONS_LIB, 'atoms/fonts/games.js');
+const CJS_FONT_MODULE = resolve(REACT_ICONS_LIB_CJS, 'atoms/fonts/add.cjs');
 /** A second module in the *same* package, so both share one set of font assets. */
 const SIBLING_FONT_MODULE = resolve(REACT_ICONS_LIB, 'atoms/fonts/add.js');
 
@@ -46,8 +49,8 @@ function createDuplicateInstance() {
 
 function normalizeDiagnostics(diagnostics: Error[], duplicateLib?: string) {
   return diagnostics.map(({ message }) => {
-    const normalized = message.split(REACT_ICONS_LIB).join('<react-icons-lib>');
-    return duplicateLib ? normalized.split(duplicateLib).join('<duplicate-react-icons-lib>') : normalized;
+    const normalized = message.split(REACT_ICONS_ROOT).join('<react-icons-root>');
+    return duplicateLib ? normalized.split(dirname(duplicateLib)).join('<duplicate-react-icons-root>') : normalized;
   });
 }
 
@@ -231,11 +234,44 @@ describe('getProvidedExports capability guard', () => {
     // glyphs the unresolvable namespace import needs — a broken build that still looks green.
     expect(updatedAssets).toEqual([]);
     expect(warnings).toHaveLength(1);
-    expect(warnings[0].message).toContain(REACT_ICONS_LIB);
+    expect(warnings[0].message).toContain(REACT_ICONS_ROOT);
   });
 });
 
 describe('duplicate installed instances', () => {
+  it('treats ESM and CommonJS output as one installed package', async () => {
+    const esmOnly = await harness({
+      usedExports: () => ['Games24Regular'],
+    });
+    const mixedFormats = await harness({
+      moduleResources: [FONT_MODULE, CJS_FONT_MODULE],
+      // Identical ESM/CJS font inputs collapse to one emitted asset attributed to either tree.
+      assetSources: [FONT_FILE],
+      usedExports: (resource) => (resource === FONT_MODULE ? ['Games24Regular'] : ['Add24Regular']),
+    });
+
+    expect(mixedFormats.warnings).toEqual([]);
+    expect(mixedFormats.updatedAssets).toHaveLength(1);
+    expect(mixedFormats.updatedAssets[0].size).toBeGreaterThan(esmOnly.updatedAssets[0].size);
+  });
+
+  it('counts a second installed copy even when its used-export set is empty', async () => {
+    const duplicate = createDuplicateInstance();
+
+    const { updatedAssets, warnings } = await harness({
+      moduleResources: [FONT_MODULE, duplicate.fontModule],
+      assetSources: [FONT_FILE],
+      usedExports: (resource) => (resource === FONT_MODULE ? ['GamesFilled'] : []),
+    });
+
+    expect(updatedAssets).toEqual([]);
+    expect(normalizeDiagnostics(warnings, duplicate.lib)).toMatchInlineSnapshot(`
+      [
+        "FluentUIReactIconsFontSubsettingPlugin: font modules from more than one installed copy of "@fluentui/react-icons" were resolved, so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping glyphs. Participating copies: "<react-icons-root>", "<duplicate-react-icons-root>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
+      ]
+    `);
+  });
+
   it('leaves fonts whole when multiple copies each emit assets', async () => {
     const duplicate = createDuplicateInstance();
 
@@ -249,7 +285,7 @@ describe('duplicate installed instances', () => {
     expect(updatedAssets).toEqual([]);
     expect(normalizeDiagnostics(warnings, duplicate.lib)).toMatchInlineSnapshot(`
       [
-        "FluentUIReactIconsFontSubsettingPlugin: more than one installed copy of "@fluentui/react-icons" contributes icons, so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping glyphs. Participating copies: "<react-icons-lib>", "<duplicate-react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
+        "FluentUIReactIconsFontSubsettingPlugin: font modules from more than one installed copy of "@fluentui/react-icons" were resolved, so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping glyphs. Participating copies: "<react-icons-root>", "<duplicate-react-icons-root>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
       ]
     `);
   });
@@ -268,7 +304,7 @@ describe('duplicate installed instances', () => {
     expect(updatedAssets).toEqual([]);
     expect(normalizeDiagnostics(warnings, duplicate.lib)).toMatchInlineSnapshot(`
       [
-        "FluentUIReactIconsFontSubsettingPlugin: more than one installed copy of "@fluentui/react-icons" contributes icons, so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping glyphs. Participating copies: "<react-icons-lib>", "<duplicate-react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
+        "FluentUIReactIconsFontSubsettingPlugin: font modules from more than one installed copy of "@fluentui/react-icons" were resolved, so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping glyphs. Participating copies: "<react-icons-root>", "<duplicate-react-icons-root>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
       ]
     `);
   });
@@ -287,7 +323,7 @@ describe('duplicate installed instances', () => {
     expect(updatedAssets).toEqual([]);
     expect(normalizeDiagnostics(errors, duplicate.lib)).toMatchInlineSnapshot(`
       [
-        "FluentUIReactIconsFontSubsettingPlugin: more than one installed copy of "@fluentui/react-icons" contributes icons, so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping glyphs. Participating copies: "<react-icons-lib>", "<duplicate-react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
+        "FluentUIReactIconsFontSubsettingPlugin: font modules from more than one installed copy of "@fluentui/react-icons" were resolved, so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping glyphs. Participating copies: "<react-icons-root>", "<duplicate-react-icons-root>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
       ]
     `);
   });
@@ -302,7 +338,7 @@ describe('duplicate installed instances', () => {
     expect(updatedAssets).toEqual([]);
     expect(normalizeDiagnostics(warnings)).toMatchInlineSnapshot(`
       [
-        "FluentUIReactIconsFontSubsettingPlugin: found used icon fonts in "<react-icons-lib>" but could not map any font module to an emitted asset. Fonts will NOT be subset. Ensure a \`type: 'asset'\` (or 'asset/resource') module rule matches /\\.(ttf|woff2?)$/.",
+        "FluentUIReactIconsFontSubsettingPlugin: found used icon fonts in "<react-icons-root>" but could not map any font module to an emitted asset. Fonts will NOT be subset. Ensure a \`type: 'asset'\` (or 'asset/resource') module rule matches /\\.(ttf|woff2?)$/.",
       ]
     `);
   });
@@ -324,8 +360,8 @@ describe('duplicate installed instances', () => {
     expect(updatedAssets).toEqual([]);
     expect(normalizeDiagnostics(warnings, duplicate.lib)).toMatchInlineSnapshot(`
       [
-        "FluentUIReactIconsFontSubsettingPlugin: "<duplicate-react-icons-lib>" is reached through a namespace import (\`import * as ...\`) whose icons cannot be determined — either the bundler does not expose \`moduleGraph.getProvidedExports()\` (rspack <2.1.0), or \`optimization.providedExports\` is disabled. Every font in this package was left un-subset, because subsetting from the remaining imports alone would drop glyphs that are actually used. Named imports are unaffected. Upgrade to rspack >=2.1.0 for full coverage.",
-        "FluentUIReactIconsFontSubsettingPlugin: more than one installed copy of "@fluentui/react-icons" contributes icons, so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping glyphs. Participating copies: "<react-icons-lib>", "<duplicate-react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
+        "FluentUIReactIconsFontSubsettingPlugin: "<duplicate-react-icons-root>" is reached through a namespace import (\`import * as ...\`) whose icons cannot be determined — either the bundler does not expose \`moduleGraph.getProvidedExports()\` (rspack <2.1.0), or \`optimization.providedExports\` is disabled. Every font in this package was left un-subset, because subsetting from the remaining imports alone would drop glyphs that are actually used. Named imports are unaffected. Upgrade to rspack >=2.1.0 for full coverage.",
+        "FluentUIReactIconsFontSubsettingPlugin: font modules from more than one installed copy of "@fluentui/react-icons" were resolved, so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping glyphs. Participating copies: "<react-icons-root>", "<duplicate-react-icons-root>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
       ]
     `);
   });
@@ -345,8 +381,8 @@ describe('duplicate installed instances', () => {
     expect(updatedAssets).toEqual([]);
     expect(normalizeDiagnostics(warnings, duplicate.lib)).toMatchInlineSnapshot(`
       [
-        "FluentUIReactIconsFontSubsettingPlugin: "<duplicate-react-icons-lib>" is reached through a namespace import (\`import * as ...\`) whose icons cannot be determined — either the bundler does not expose \`moduleGraph.getProvidedExports()\` (rspack <2.1.0), or \`optimization.providedExports\` is disabled. Every font in this package was left un-subset, because subsetting from the remaining imports alone would drop glyphs that are actually used. Named imports are unaffected. Upgrade to rspack >=2.1.0 for full coverage.",
-        "FluentUIReactIconsFontSubsettingPlugin: more than one installed copy of "@fluentui/react-icons" contributes icons, so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping glyphs. Participating copies: "<react-icons-lib>", "<duplicate-react-icons-lib>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
+        "FluentUIReactIconsFontSubsettingPlugin: "<duplicate-react-icons-root>" is reached through a namespace import (\`import * as ...\`) whose icons cannot be determined — either the bundler does not expose \`moduleGraph.getProvidedExports()\` (rspack <2.1.0), or \`optimization.providedExports\` is disabled. Every font in this package was left un-subset, because subsetting from the remaining imports alone would drop glyphs that are actually used. Named imports are unaffected. Upgrade to rspack >=2.1.0 for full coverage.",
+        "FluentUIReactIconsFontSubsettingPlugin: font modules from more than one installed copy of "@fluentui/react-icons" were resolved, so font assets cannot be attributed safely. Fonts were left un-subset to avoid dropping glyphs. Participating copies: "<react-icons-root>", "<duplicate-react-icons-root>". Collapse them onto one instance with bundler \`resolve.alias\` entries — note that this also binds every copy to a single React and Griffel instance.",
       ]
     `);
   });

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/src/mixed-module-formats.js
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/src/mixed-module-formats.js
@@ -1,0 +1,8 @@
+// @ts-check
+
+import '@fluentui/react-icons/headless/fonts/styles.css';
+import { Games24Regular } from '@fluentui/react-icons/headless/fonts/games';
+
+const { Add24Regular } = require('@fluentui/react-icons/headless/fonts/add');
+
+console.dir({ Games24Regular, Add24Regular });

--- a/packages/react-icons-font-subsetting-webpack-plugin/test/types.conformance.ts
+++ b/packages/react-icons-font-subsetting-webpack-plugin/test/types.conformance.ts
@@ -6,7 +6,7 @@
 import type * as webpack from 'webpack';
 import type * as rspack from '@rspack/core';
 
-import type { BundlerCompiler, BundlerPlugin } from '../src/bundler-api';
+import type { BundlerCompilation, BundlerCompiler, BundlerPlugin } from '../src/bundler-api';
 import FluentUIReactIconsFontSubsettingPlugin from '../src/index';
 
 /** Fails to compile unless `Actual` is assignable to `Expected`. */
@@ -16,6 +16,11 @@ type AssertAssignable<Expected, Actual extends Expected> = Actual;
 // BundlerCompiler. This is what makes `implements` work without casting.
 type WebpackCompilerConforms = AssertAssignable<BundlerCompiler, webpack.Compiler>;
 type RspackCompilerConforms = AssertAssignable<BundlerCompiler, rspack.Compiler>;
+
+// Checked directly rather than through `hooks.compilation.tap`, whose parameters are bivariant and
+// so would accept a `BundlerCompilation` the real compilations do not satisfy.
+type WebpackCompilationConforms = AssertAssignable<BundlerCompilation, webpack.Compilation>;
+type RspackCompilationConforms = AssertAssignable<BundlerCompilation, rspack.Compilation>;
 
 // The plugin must remain usable in both bundlers' `plugins` arrays.
 type IsWebpackPlugin = AssertAssignable<webpack.WebpackPluginInstance, FluentUIReactIconsFontSubsettingPlugin>;
@@ -34,5 +39,13 @@ new FluentUIReactIconsFontSubsettingPlugin().apply(rspackCompiler);
 const webpackConfig: webpack.Configuration = { plugins: [new FluentUIReactIconsFontSubsettingPlugin()] };
 const rspackConfig: rspack.Configuration = { plugins: [new FluentUIReactIconsFontSubsettingPlugin()] };
 
-export type { WebpackCompilerConforms, RspackCompilerConforms, IsWebpackPlugin, IsRspackPlugin, ImplementsContract };
+export type {
+  WebpackCompilerConforms,
+  RspackCompilerConforms,
+  WebpackCompilationConforms,
+  RspackCompilationConforms,
+  IsWebpackPlugin,
+  IsRspackPlugin,
+  ImplementsContract,
+};
 export { webpackConfig, rspackConfig };


### PR DESCRIPTION
## Summary

Reported from userland: icons rendering as missing glyphs when several copies of `@fluentui/react-icons` are installed. The plugin was subsetting a shared font for one copy and deleting every glyph the other copies contributed — silently, with only a warning that misdiagnosed the cause.

The plugin now detects this and leaves the affected fonts un-subset, so all glyphs render. `onDuplicateInstances: 'error'` fails the build instead.

## The bug

Attribution runs **asset → `AssetInfo.sourceFilename` → package**, which assumes package ↔ asset is 1:1.

Content hashing breaks that. Copies of the same version ship byte-identical fonts, so they hash to one emitted asset, and that asset can name only one copy as its source. The others match nothing:

```
P3 → shared asset  → subset to P3's icons only
P1, P2, P4, P5 → []  → warned "could not map any font module to an emitted asset"
```

Every glyph reached only through P1/P2/P4/P5 was deleted. The old warning told people to add a `type: 'asset'` module rule, which was not the problem.

Reproduced as a failing unit test before any source change:

```
× leaves fonts whole when a copy owns no emitted asset  → expected [ Array(1) ] to deeply equal []
× fails the build instead when asked to                 → expected [] to have a length of 1
```

That first failure is the production bug: the shared asset *was* updated, i.e. subset down to one copy's icons.

## Why detect rather than compensate

Two approaches were considered and rejected.

**Unioning used exports across copies** (what the reporting app patched locally) works, but only by assuming that copies of the same package name ship identical font content. That is the same class of silent assumption that produced this bug.

**Per-asset unioning** does not work at all: the orphaned copies map to no asset, so there is nothing to union them into.

Detection is scoped to the collision signature — some packages map to assets while others map to none. Copies of genuinely *different* versions ship different fonts, emit separate assets, all map, and continue to be subset independently. The existing all-zero case still reports the missing asset rule, and there is a test pinning that discrimination.

## Options API

The plugin previously took no constructor options:

```js
new FluentUIReactIconsFontSubsettingPlugin({ onDuplicateInstances: 'error' }); // default: 'warn'
```

The warning names both the copies owning an emitted font and the copies sharing them, and points at `resolve.alias` dedupe — with the caveat that collapsing copies also binds them to a single React and Griffel instance, so it is not free advice.

## Conformance gap found along the way

`BundlerCompilation` gained `errors: Error[]`. Verifying that turned up a hole: the conformance test only asserted `webpack.Compiler`/`rspack.Compiler`, so `BundlerCompilation` was reached solely through `hooks.compilation.tap` — whose parameters are **bivariant**, meaning it would have accepted members neither compilation has.

Direct assertions added for both compilations. Confirmed non-vacuous by injecting a bogus member (four errors, including the two new ones).

Manual verification of the widened member:

| bundler | declaration | assignable |
| --- | --- | --- |
| webpack | `Compilation.errors: Error[]` | exact |
| rspack | `get errors(): RspackError[]`, `RspackError extends Error` with all extras optional | both directions |

And at runtime, since types say nothing about a napi-backed array accepting a plain `Error`:

```
webpack: hasErrors=true errorCount=1 warningCount=1
rspack:  hasErrors=true errorCount=1 warningCount=1
```

## Lint rule

Private members now require the `__` prefix. Note this needed the package's lint script widened to `eslint src package.json` — it previously covered only `package.json`, so no rule could have applied to its sources. Verified the rule reports a violation when the prefix is removed. Linting `src` for the first time surfaced no pre-existing problems.

## Validation

- 9/9 unit, type conformance, webpack 6/6, rspack 6/6, lint clean

## Not done

No integration fixture for the duplicate case — reproducing two installed copies in the bundler suite means materialising a second `lib` tree, and the unit harness expresses the condition exactly.
