### PR TITLE
fix(react-icons): emit valid font-display descriptor

### DIFF
--- a/packages/react-icons/build-verify.test.js
+++ b/packages/react-icons/build-verify.test.js
@@ -321,7 +321,7 @@ describe('Build Verification', () => {
           [3 /* Light */]: 'FluentSystemIconsLight'
         };
         export const useStaticStyles = __staticStyles({
-          d: [\`@font-face{font-family:FluentSystemIconsFilled;font-display:"block";src:url(\${_asset}) format("woff2"),url(\${_asset2}) format("woff"),url(\${_asset3}) format("truetype");}\`, \`@font-face{font-family:FluentSystemIconsRegular;font-display:"block";src:url(\${_asset4}) format("woff2"),url(\${_asset5}) format("woff"),url(\${_asset6}) format("truetype");}\`, \`@font-face{font-family:FluentSystemIconsLight;font-display:"block";src:url(\${_asset7}) format("woff2"),url(\${_asset8}) format("woff"),url(\${_asset9}) format("truetype");}\`, \`@font-face{font-family:FluentSystemIcons;font-display:"block";src:url(\${_asset0}) format("woff2"),url(\${_asset1}) format("woff"),url(\${_asset10}) format("truetype");}\`]
+          d: [\`@font-face{font-family:FluentSystemIconsFilled;font-display:block;src:url(\${_asset}) format("woff2"),url(\${_asset2}) format("woff"),url(\${_asset3}) format("truetype");}\`, \`@font-face{font-family:FluentSystemIconsRegular;font-display:block;src:url(\${_asset4}) format("woff2"),url(\${_asset5}) format("woff"),url(\${_asset6}) format("truetype");}\`, \`@font-face{font-family:FluentSystemIconsLight;font-display:block;src:url(\${_asset7}) format("woff2"),url(\${_asset8}) format("woff"),url(\${_asset9}) format("truetype");}\`, \`@font-face{font-family:FluentSystemIcons;font-display:block;src:url(\${_asset0}) format("woff2"),url(\${_asset1}) format("woff"),url(\${_asset10}) format("truetype");}\`]
         });
         export const useRootStyles = __styles({
           "0": {
@@ -377,14 +377,14 @@ describe('Build Verification', () => {
         export const useStaticStyles = makeStaticStyles(\`
         @font-face {
             font-family: \${FONT_FAMILY_MAP[0 /* Filled */]};
-            font-display: "block";
+          font-display: block;
             src: url(\${JSON.stringify(fontFilledWoff2)}) format("woff2"),
             url(\${JSON.stringify(fontFilledWoff)}) format("woff"),
             url(\${JSON.stringify(fontFilledTtf)}) format("truetype");
         }
         @font-face {
             font-family: \${FONT_FAMILY_MAP[1 /* Regular */]};
-            font-display: "block";
+          font-display: block;
             src: url(\${JSON.stringify(fontRegularWoff2)}) format("woff2"),
             url(\${JSON.stringify(fontRegularWoff)}) format("woff"),
             url(\${JSON.stringify(fontRegularTtf)}) format("truetype");
@@ -392,7 +392,7 @@ describe('Build Verification', () => {
 
         @font-face {
             font-family: \${FONT_FAMILY_MAP[3 /* Light */]};
-            font-display: "block";
+          font-display: block;
             src: url(\${JSON.stringify(fontLightWoff2)}) format("woff2"),
             url(\${JSON.stringify(fontLightWoff)}) format("woff"),
             url(\${JSON.stringify(fontLightTtf)}) format("truetype");
@@ -400,7 +400,7 @@ describe('Build Verification', () => {
 
         @font-face {
             font-family: \${FONT_FAMILY_MAP[2 /* Resizable */]};
-            font-display: "block";
+          font-display: block;
             src: url(\${JSON.stringify(fontOneSizeWoff2)}) format("woff2"),
             url(\${JSON.stringify(fontOneSizeWoff)}) format("woff"),
             url(\${JSON.stringify(fontOneSizeTtf)}) format("truetype");

--- a/packages/react-icons/src/utils/fonts/createFluentFontIcon.styles.ts
+++ b/packages/react-icons/src/utils/fonts/createFluentFontIcon.styles.ts
@@ -27,14 +27,14 @@ const FONT_FAMILY_MAP = {
 export const useStaticStyles = makeStaticStyles(`
 @font-face {
     font-family: ${FONT_FAMILY_MAP[FontFile.Filled]};
-    font-display: "block";
+  font-display: block;
     src: url(${JSON.stringify(fontFilledWoff2)}) format("woff2"),
     url(${JSON.stringify(fontFilledWoff)}) format("woff"),
     url(${JSON.stringify(fontFilledTtf)}) format("truetype");
 }
 @font-face {
     font-family: ${FONT_FAMILY_MAP[FontFile.Regular]};
-    font-display: "block";
+  font-display: block;
     src: url(${JSON.stringify(fontRegularWoff2)}) format("woff2"),
     url(${JSON.stringify(fontRegularWoff)}) format("woff"),
     url(${JSON.stringify(fontRegularTtf)}) format("truetype");
@@ -42,7 +42,7 @@ export const useStaticStyles = makeStaticStyles(`
 
 @font-face {
     font-family: ${FONT_FAMILY_MAP[FontFile.Light]};
-    font-display: "block";
+  font-display: block;
     src: url(${JSON.stringify(fontLightWoff2)}) format("woff2"),
     url(${JSON.stringify(fontLightWoff)}) format("woff"),
     url(${JSON.stringify(fontLightTtf)}) format("truetype");
@@ -50,7 +50,7 @@ export const useStaticStyles = makeStaticStyles(`
 
 @font-face {
     font-family: ${FONT_FAMILY_MAP[FontFile.Resizable]};
-    font-display: "block";
+  font-display: block;
     src: url(${JSON.stringify(fontOneSizeWoff2)}) format("woff2"),
     url(${JSON.stringify(fontOneSizeWoff)}) format("woff"),
     url(${JSON.stringify(fontOneSizeTtf)}) format("truetype");


### PR DESCRIPTION
## Summary

- emit the `font-display: block` keyword without quotes in Griffel font-face styles
- update build verification snapshots to guard the processed and raw outputs

Quoted `"block"` is invalid for the `font-display` descriptor, so browsers discarded it and used `auto`. This could expose a fallback missing-glyph rectangle while an icon font loaded. Headless CSS already emitted the valid unquoted keyword.

## Validation

- `yarn nx run react-icons:build`
- `yarn nx run react-icons:lint`
- `yarn nx run react-icons:build-verify -- -t "should produce griffel processed .styles.js and unprocessed .styles.raw.js having makeStaticStyles calls [lib]"`
- verified in Chrome that all four Fluent icon font faces report `FontFace.display === "block"`