### PR TITLE
fix(react-icons): export package metadata

### DIFF
--- a/packages/react-icons/build-verify.test.js
+++ b/packages/react-icons/build-verify.test.js
@@ -172,6 +172,13 @@ describe('Build Verification', () => {
   });
 
   describe('Package.json Exports', () => {
+    it('should export package.json', async () => {
+      const packageJsonPath = path.join(__dirname, 'package.json');
+      const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
+
+      expect(packageJson.exports['./package.json']).toBe('./package.json');
+    });
+
     it('should have all exported files exist', async () => {
       const packageJsonPath = path.join(__dirname, 'package.json');
       /** @type {{main:string;module:string;typings:string;exports:Record<string,string>}} */

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -226,6 +226,7 @@
         "types": "./lib-cjs/headless/utils.d.cts",
         "default": "./lib-cjs/headless/utils.cjs"
       }
-    }
+    },
+    "./package.json": "./package.json"
   }
 }

--- a/packages/react-icons/verify-esm-exports.mjs
+++ b/packages/react-icons/verify-esm-exports.mjs
@@ -17,10 +17,10 @@
  * - **loaded**: SVG/utility/provider/headless(non-font) entries are actually
  *   `import()`-ed and asserted to expose named exports. This is the true bare-Node
  *   ESM proof for the surface the ESM-first change targets.
- * - **resolve-only**: font entries and `.css` entries are only *resolved* (not
+ * - **resolve-only**: font entries, `.css` entries, and `.json` entries are only *resolved* (not
  *   imported). Font modules transitively `import './*.ttf'|'*.woff'` (binary assets
- *   that only a bundler can load), and `.css` is not JavaScript — neither is meant
- *   to load in bare Node. We still assert their export-map target is a real,
+ *   that only a bundler can load), while CSS and JSON are not JavaScript modules.
+ *   We still assert their export-map target is a real,
  *   fully-specified file on disk.
  *
  * Pass `--font` (together with `node --conditions=fluentIconFont`) to verify the
@@ -63,8 +63,8 @@ for (const { key, spec, isCss } of deriveEntries()) {
       throw new Error(`export map resolved to a missing file: ${resolvedPath}`);
     }
 
-    if (isCss) {
-      console.log(`  ✓ resolve-only  ${key}  ->  ${spec}  (css asset)`);
+    if (isCss || resolvedPath.endsWith('.json')) {
+      console.log(`  ✓ resolve-only  ${key}  ->  ${spec}  (non-JavaScript asset)`);
     } else if (isFontTarget(resolvedPath)) {
       console.log(`  ✓ resolve-only  ${key}  ->  ${spec}  (font/binary-asset graph)`);
     } else {


### PR DESCRIPTION
## Summary

- expose `@fluentui/react-icons/package.json` through the package export map
- add regression coverage for the package metadata subpath

## Validation

- `corepack yarn nx run react-icons:build-verify -- --testNamePattern='should export package.json'`
- `corepack yarn nx run-many -t lint check:types-packaging -p react-icons`